### PR TITLE
feat: Sim 9 engine hardening — rule scoping, convergence gate, efficiency metric

### DIFF
--- a/src/gradata/_core.py
+++ b/src/gradata/_core.py
@@ -782,26 +782,103 @@ def brain_export_skills(brain: Brain, *, output_dir: str | None = None,
 
 # ── convergence() ─────────────────────────────────────────────────────
 
+def _mann_kendall(data: "list[int] | list[float]") -> tuple[str, float]:
+    """Mann-Kendall trend test (pure Python, no scipy needed).
+
+    Returns (trend, p_value) where trend is "decreasing", "increasing", or "no_trend".
+    Uses normal approximation for n >= 3.
+    """
+    import math
+
+    n = len(data)
+    if n < 3:
+        return "no_trend", 1.0
+
+    # Compute S statistic
+    s = 0
+    for i in range(n - 1):
+        for j in range(i + 1, n):
+            diff = data[j] - data[i]
+            if diff > 0:
+                s += 1
+            elif diff < 0:
+                s -= 1
+
+    # Handle ties
+    from collections import Counter
+    tie_counts = [c for c in Counter(data).values() if c > 1]
+    tie_correction = sum(t * (t - 1) * (2 * t + 5) for t in tie_counts)
+
+    # Variance of S
+    var_s = (n * (n - 1) * (2 * n + 5) - tie_correction) / 18.0
+    if var_s == 0:
+        return "no_trend", 1.0
+
+    # Z statistic (continuity correction)
+    if s > 0:
+        z = (s - 1) / math.sqrt(var_s)
+    elif s < 0:
+        z = (s + 1) / math.sqrt(var_s)
+    else:
+        z = 0.0
+
+    # Two-tailed p-value using normal CDF approximation
+    p_value = 2.0 * (1.0 - _normal_cdf(abs(z)))
+
+    if p_value < 0.05:
+        trend = "decreasing" if s < 0 else "increasing"
+    else:
+        trend = "no_trend"
+
+    return trend, round(p_value, 4)
+
+
+def _normal_cdf(x: float) -> float:
+    """Standard normal CDF approximation (Abramowitz & Stegun)."""
+    import math
+    t = 1.0 / (1.0 + 0.2316419 * abs(x))
+    d = 0.3989422804014327  # 1/sqrt(2*pi)
+    p = d * math.exp(-x * x / 2.0) * (
+        t * (0.319381530 + t * (-0.356563782 + t * (1.781477937 +
+        t * (-1.821255978 + t * 1.330274429))))
+    )
+    return 1.0 - p if x >= 0 else p
+
+
 def brain_convergence(brain: "Brain") -> dict:
     """Compute corrections-per-session convergence data.
+
+    Uses Mann-Kendall trend test for statistical rigor.
+    Includes per-category breakdown.
 
     Returns dict with:
         sessions: list of session numbers
         corrections_per_session: list of correction counts per session
         trend: "converging" | "converged" | "diverging" | "insufficient_data"
+        p_value: float (Mann-Kendall p-value, lower = stronger trend)
+        by_category: dict of category -> {corrections_per_session, trend}
         total_corrections: int
         total_sessions: int
     """
     empty = {"sessions": [], "corrections_per_session": [], "trend": "insufficient_data",
-             "total_corrections": 0, "total_sessions": 0}
+             "p_value": 1.0, "by_category": {}, "total_corrections": 0, "total_sessions": 0}
 
     try:
         from gradata._db import get_connection
+        import json as _json
         with get_connection(brain.db_path) as conn:
+            # Aggregate corrections per session
             rows = conn.execute(
                 "SELECT session, COUNT(*) as cnt FROM events "
                 "WHERE type = 'CORRECTION' AND session IS NOT NULL AND session > 0 "
                 "GROUP BY session ORDER BY session"
+            ).fetchall()
+
+            # Per-category breakdown
+            cat_rows = conn.execute(
+                "SELECT session, data_json FROM events "
+                "WHERE type = 'CORRECTION' AND session IS NOT NULL AND session > 0 "
+                "ORDER BY session"
             ).fetchall()
     except Exception:
         return empty
@@ -812,25 +889,47 @@ def brain_convergence(brain: "Brain") -> dict:
     sessions = [r[0] for r in rows]
     counts = [r[1] for r in rows]
 
-    # Determine trend
-    trend = "insufficient_data"
-    if len(counts) >= 3:
-        first_half = counts[:len(counts) // 2]
-        second_half = counts[len(counts) // 2:]
-        avg_first = sum(first_half) / len(first_half)
-        avg_second = sum(second_half) / len(second_half)
+    # Mann-Kendall trend test
+    mk_trend, p_value = _mann_kendall(counts)
+    if mk_trend == "decreasing":
+        trend = "converging"
+    elif mk_trend == "increasing":
+        trend = "diverging"
+    elif len(counts) >= 3:
+        trend = "converged"
+    else:
+        trend = "insufficient_data"
 
-        if avg_second < avg_first * 0.7:
-            trend = "converging"
-        elif abs(avg_second - avg_first) <= max(1, avg_first * 0.15):
-            trend = "converged"
-        else:
-            trend = "diverging"
+    # Per-category convergence
+    cat_by_session: dict[str, dict[int, int]] = {}
+    for session, data_json in cat_rows:
+        try:
+            data = _json.loads(data_json) if isinstance(data_json, str) else {}
+            cat = data.get("category", "UNKNOWN")
+        except (_json.JSONDecodeError, TypeError):
+            cat = "UNKNOWN"
+        if cat not in cat_by_session:
+            cat_by_session[cat] = {}
+        cat_by_session[cat][session] = cat_by_session[cat].get(session, 0) + 1
+
+    by_category: dict[str, dict] = {}
+    for cat, session_counts in cat_by_session.items():
+        cat_counts = [session_counts.get(s, 0) for s in sessions]
+        cat_mk, cat_p = _mann_kendall(cat_counts)
+        cat_trend = "converging" if cat_mk == "decreasing" else (
+            "diverging" if cat_mk == "increasing" else "converged")
+        by_category[cat] = {
+            "corrections_per_session": cat_counts,
+            "trend": cat_trend,
+            "p_value": cat_p,
+        }
 
     return {
         "sessions": sessions,
         "corrections_per_session": counts,
         "trend": trend,
+        "p_value": p_value,
+        "by_category": by_category,
         "total_corrections": sum(counts),
         "total_sessions": len(sessions),
     }

--- a/src/gradata/_core.py
+++ b/src/gradata/_core.py
@@ -179,21 +179,30 @@ def brain_correct(
                 if classifications:
                     primary = next((c for c in classifications if c.category.upper() == cat),
                                    classifications[0])
-                    # Try behavioral extraction (LLM + cache + templates)
-                    try:
-                        from gradata.enhancements.edit_classifier import extract_behavioral_instruction
-                        from gradata.enhancements.instruction_cache import InstructionCache
-                        if not isinstance(brain._instruction_cache, InstructionCache):
-                            brain._instruction_cache = InstructionCache(
-                                lessons_path.parent / "instruction_cache.json"
-                            )
-                        behavioral_desc = extract_behavioral_instruction(
-                            diff, primary, cache=brain._instruction_cache,  # type: ignore[arg-type]
-                        )
-                        desc = behavioral_desc or primary.description
-                    except Exception as e:
-                        _log.debug("Behavioral extraction failed: %s", e)
+                    # Check convergence gate — skip extraction if category is settled
+                    convergence_data = brain._get_convergence()
+                    cat_convergence = convergence_data.get("by_category", {}).get(cat, {})
+                    category_converged = cat_convergence.get("trend") == "converged"
+
+                    if category_converged:
+                        _log.debug("Skipping extraction for converged category: %s", cat)
                         desc = primary.description
+                    else:
+                        # Try behavioral extraction (LLM + cache + templates)
+                        try:
+                            from gradata.enhancements.edit_classifier import extract_behavioral_instruction
+                            from gradata.enhancements.instruction_cache import InstructionCache
+                            if not isinstance(brain._instruction_cache, InstructionCache):
+                                brain._instruction_cache = InstructionCache(
+                                    lessons_path.parent / "instruction_cache.json"
+                                )
+                            behavioral_desc = extract_behavioral_instruction(
+                                diff, primary, cache=brain._instruction_cache,  # type: ignore[arg-type]
+                            )
+                            desc = behavioral_desc or primary.description
+                        except Exception as e:
+                            _log.debug("Behavioral extraction failed: %s", e)
+                            desc = primary.description
                 elif summary:
                     desc = summary
                 else:

--- a/src/gradata/_core.py
+++ b/src/gradata/_core.py
@@ -980,3 +980,61 @@ def brain_convergence(brain: "Brain") -> dict:
         "total_corrections": sum(counts),
         "total_sessions": len(sessions),
     }
+
+
+# ── Efficiency ────────────────────────────────────────────────────────
+
+_SEVERITY_SECONDS = {
+    "trivial": 5,
+    "minor": 15,
+    "moderate": 45,
+    "major": 120,
+    "rewrite": 300,
+}
+
+
+def brain_efficiency(brain: "Brain", *, estimate_time: bool = False) -> dict:
+    """Quantify effort saved by brain learning.
+
+    Returns effort_ratio (current vs initial correction rate).
+    Optional estimate_time adds severity-weighted time estimates (approximate).
+    """
+    convergence = brain._get_convergence()
+    counts = convergence.get("corrections_per_session", [])
+
+    if len(counts) < 3:
+        result: dict = {
+            "effort_ratio": 1.0,
+            "corrections_initial": 0,
+            "corrections_recent": 0,
+            "total_corrections": convergence.get("total_corrections", 0),
+            "total_sessions": convergence.get("total_sessions", 0),
+        }
+        if estimate_time:
+            result["estimated_seconds_saved"] = 0
+            result["time_breakdown"] = {}
+        return result
+
+    initial = sum(counts[:3]) / 3.0
+    recent = sum(counts[-3:]) / 3.0
+    effort_ratio = round(recent / initial, 2) if initial > 0 else 1.0
+
+    result = {
+        "effort_ratio": effort_ratio,
+        "corrections_initial": round(initial, 1),
+        "corrections_recent": round(recent, 1),
+        "total_corrections": convergence.get("total_corrections", 0),
+        "total_sessions": convergence.get("total_sessions", 0),
+    }
+
+    if estimate_time:
+        corrections_avoided = max(0, (initial - recent) * len(counts))
+        avg_severity_weight = _SEVERITY_SECONDS.get("moderate", 45)
+        estimated_seconds = int(corrections_avoided * avg_severity_weight)
+        result["estimated_seconds_saved"] = estimated_seconds
+        result["time_breakdown"] = {
+            "corrections_avoided": round(corrections_avoided, 1),
+            "avg_seconds_per_correction": avg_severity_weight,
+        }
+
+    return result

--- a/src/gradata/_core.py
+++ b/src/gradata/_core.py
@@ -40,6 +40,32 @@ def _filter_lessons_by_state(lessons, min_state: str = "PATTERN"):
 
 # ── correct() ──────────────────────────────────────────────────────────
 
+
+def _attribute_domain_fires(
+    brain: "Brain",
+    correction_category: str,
+    correction_desc: str,
+) -> None:
+    """Attribute fires and misfires to rules active in this session.
+
+    For each fired rule, increment fires for the correction's category.
+    If the correction contradicts the rule, also increment misfires.
+    """
+    from gradata.enhancements.self_improvement import _classify_correction_direction
+
+    for rule in brain._fired_rules:
+        if not hasattr(rule, "domain_scores"):
+            continue
+        domain = correction_category.upper()
+        if domain not in rule.domain_scores:
+            rule.domain_scores[domain] = {"fires": 0, "misfires": 0}
+        rule.domain_scores[domain]["fires"] += 1
+
+        direction = _classify_correction_direction(correction_desc, rule.description)
+        if direction == "CONTRADICTING":
+            rule.domain_scores[domain]["misfires"] += 1
+
+
 def brain_correct(
     brain: Brain, draft: str, final: str, *,
     category: str | None = None, context: dict | None = None,
@@ -275,6 +301,18 @@ def brain_correct(
 
     except Exception as e:
         _log.warning("Lesson creation failed: %s", e)
+
+    # Domain-scoped misfire attribution
+    try:
+        if brain._fired_rules and (category or classifications):
+            correction_desc = ""
+            if 'desc' in locals():
+                correction_desc = desc
+            elif summary:
+                correction_desc = summary
+            _attribute_domain_fires(brain, category or "UNKNOWN", correction_desc)
+    except Exception as e:
+        _log.debug("Domain fire attribution failed: %s", e)
 
     # Index into FTS5
     try:

--- a/src/gradata/_types.py
+++ b/src/gradata/_types.py
@@ -122,6 +122,7 @@ class Lesson:
     pending_approval: bool = False  # True = awaiting human review before graduation
     parent_meta_rule_id: str | None = None  # Meta-rule this lesson contributed to
     memory_ids: list[str] = field(default_factory=list)  # Linked memory IDs
+    domain_scores: dict[str, dict[str, int]] = field(default_factory=dict)  # Per-domain fire/misfire tracking
 
     def __post_init__(self) -> None:
         self.confidence = round(max(0.0, min(1.0, self.confidence)), 2)

--- a/src/gradata/brain.py
+++ b/src/gradata/brain.py
@@ -350,6 +350,15 @@ class Brain:
         self._convergence_session = self.session
         return self._convergence_cache
 
+    def efficiency(self, *, estimate_time: bool = False) -> dict:
+        """Quantify effort saved by brain learning.
+
+        Returns effort_ratio (ratio of current vs initial correction rate).
+        Pass estimate_time=True for approximate time-saved estimates.
+        """
+        from gradata._core import brain_efficiency
+        return brain_efficiency(self, estimate_time=estimate_time)
+
     # ── Output Logging ─────────────────────────────────────────────────
 
     def log_output(self, text: str, output_type: str = "general",

--- a/src/gradata/brain.py
+++ b/src/gradata/brain.py
@@ -67,6 +67,7 @@ class Brain:
                 open_encrypted_db(self.dir, self._encryption_key)
 
         self._instruction_cache: object | None = None  # lazy: InstructionCache
+        self._fired_rules: list = []  # Rules injected this session (for misfire attribution)
 
         logger.debug("Brain init: %s (db=%s)", self.dir, self.db_path)
 

--- a/src/gradata/brain.py
+++ b/src/gradata/brain.py
@@ -68,6 +68,8 @@ class Brain:
 
         self._instruction_cache: object | None = None  # lazy: InstructionCache
         self._fired_rules: list = []  # Rules injected this session (for misfire attribution)
+        self._convergence_cache: dict | None = None
+        self._convergence_session: int | None = None
 
         logger.debug("Brain init: %s (db=%s)", self.dir, self.db_path)
 
@@ -338,6 +340,15 @@ class Brain:
         """Get corrections-per-session convergence data."""
         from gradata._core import brain_convergence
         return brain_convergence(self)
+
+    def _get_convergence(self) -> dict:
+        """Get cached convergence data (one DB query per session)."""
+        if self._convergence_cache is not None and self._convergence_session == self.session:
+            return self._convergence_cache
+        from gradata._core import brain_convergence
+        self._convergence_cache = brain_convergence(self)
+        self._convergence_session = self.session
+        return self._convergence_cache
 
     # ── Output Logging ─────────────────────────────────────────────────
 

--- a/src/gradata/enhancements/self_improvement.py
+++ b/src/gradata/enhancements/self_improvement.py
@@ -283,6 +283,7 @@ def parse_lessons(text: str) -> list[Lesson]:
         pending_approval = False
         parent_meta_rule_id: str | None = None
         memory_ids: list[str] = []
+        domain_scores: dict = {}
         j = i + 1
         while j < len(lines) and lines[j].startswith("  "):
             meta_line = lines[j].strip()
@@ -301,6 +302,12 @@ def parse_lessons(text: str) -> list[Lesson]:
                 parent_meta_rule_id = meta_line[len("Parent meta-rule:"):].strip() or None
             elif meta_line.startswith("Memory links:"):
                 memory_ids = [x.strip() for x in meta_line[len("Memory links:"):].strip().split(",") if x.strip()]
+            elif meta_line.startswith("Domain scores:"):
+                import json as _json
+                try:
+                    domain_scores = _json.loads(meta_line[len("Domain scores:"):].strip())
+                except _json.JSONDecodeError:
+                    domain_scores = {}
             meta_m = _META_RE.search(meta_line)
             if meta_m:
                 fire_count = int(meta_m.group(1))
@@ -324,6 +331,7 @@ def parse_lessons(text: str) -> list[Lesson]:
             pending_approval=pending_approval,
             parent_meta_rule_id=parent_meta_rule_id,
             memory_ids=memory_ids,
+            domain_scores=domain_scores,
         ))
         i = j if j > i + 1 else i + 1
 
@@ -889,6 +897,10 @@ def format_lessons(lessons: list[Lesson]) -> str:
 
         if lesson.memory_ids:
             lines.append(f"  Memory links: {','.join(lesson.memory_ids)}")
+
+        if lesson.domain_scores:
+            import json as _json
+            lines.append(f"  Domain scores: {_json.dumps(lesson.domain_scores)}")
 
         lines.append("")  # blank line between lessons
 

--- a/src/gradata/rules/rule_engine.py
+++ b/src/gradata/rules/rule_engine.py
@@ -412,6 +412,20 @@ def filter_by_scope(
     return results
 
 
+def is_rule_disabled_for_domain(lesson: Lesson, domain: str) -> bool:
+    """Check if a rule should be suppressed in a specific domain.
+
+    A rule is disabled when its misfire rate exceeds 30% with at least
+    3 fires in that domain — enough data to be meaningful.
+    """
+    scores = lesson.domain_scores.get(domain, {})
+    fires = scores.get("fires", 0)
+    misfires = scores.get("misfires", 0)
+    if fires < 3:
+        return False
+    return misfires / fires > 0.3
+
+
 def apply_rules(
     lessons: list[Lesson],
     scope: RuleScope,
@@ -466,6 +480,14 @@ def apply_rules(
 
     # Step 1 — eligibility gate
     eligible = [lesson for lesson in lessons if lesson.state in _ELIGIBLE_STATES]
+
+    # Step 1.5 — domain scoping: filter out rules disabled for current domain
+    current_domain = scope.domain.upper() if scope.domain else ""
+    if current_domain:
+        eligible = [
+            lesson for lesson in eligible
+            if not is_rule_disabled_for_domain(lesson, current_domain)
+        ]
 
     # Step 2 & 3 — score with weighted scope matching and threshold
     scored: list[tuple[Lesson, float]] = []

--- a/src/gradata/rules/rule_engine.py
+++ b/src/gradata/rules/rule_engine.py
@@ -28,6 +28,10 @@ import json
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from gradata.events_bus import EventBus
 
 from gradata._scope import RuleScope, scope_matches
 from gradata._types import ELIGIBLE_STATES, CorrectionType, Lesson, LessonState, RuleTransferScope
@@ -433,6 +437,7 @@ def apply_rules(
     events: list[dict[str, str]] | None = None,
     user_message: str = "",
     _context: str = "",
+    bus: "EventBus | None" = None,
 ) -> list[AppliedRule]:
     """Select and rank lessons relevant to the given scope.
 
@@ -484,10 +489,20 @@ def apply_rules(
     # Step 1.5 — domain scoping: filter out rules disabled for current domain
     current_domain = scope.domain.upper() if scope.domain else ""
     if current_domain:
-        eligible = [
-            lesson for lesson in eligible
-            if not is_rule_disabled_for_domain(lesson, current_domain)
-        ]
+        filtered = []
+        for lesson in eligible:
+            if is_rule_disabled_for_domain(lesson, current_domain):
+                if bus:
+                    scores = lesson.domain_scores.get(current_domain, {})
+                    bus.emit("rule_scoped_out", {
+                        "lesson_category": lesson.category,
+                        "lesson_description": lesson.description[:80],
+                        "domain": current_domain,
+                        "misfire_rate": scores.get("misfires", 0) / max(1, scores.get("fires", 1)),
+                    })
+            else:
+                filtered.append(lesson)
+        eligible = filtered
 
     # Step 2 & 3 — score with weighted scope matching and threshold
     scored: list[tuple[Lesson, float]] = []

--- a/tests/test_convergence.py
+++ b/tests/test_convergence.py
@@ -7,22 +7,27 @@ from pathlib import Path
 from gradata.brain import Brain
 
 
-def _make_brain_with_corrections(num_sessions: int, corrections_per: list[int]) -> Brain:
+def _make_brain_with_corrections(num_sessions: int, corrections_per: list[int],
+                                  categories: list[str] | None = None) -> Brain:
     """Create a brain with simulated correction events across sessions."""
     d = tempfile.mkdtemp()
     (Path(d) / "lessons.md").write_text("", encoding="utf-8")
     brain = Brain(d)
     for session_num, count in enumerate(corrections_per, start=1):
+        cat = (categories[session_num - 1] if categories and session_num <= len(categories)
+               else "TEST")
         for _ in range(count):
             try:
                 brain.emit("CORRECTION", "test", {
-                    "category": "TEST", "severity": "minor",
+                    "category": cat, "severity": "minor",
                     "edit_distance": 0.1, "summary": "test correction",
-                }, ["category:TEST"], session_num)
+                }, [f"category:{cat}"], session_num)
             except Exception:
                 pass
     return brain
 
+
+# --- Basic structure tests ---
 
 def test_convergence_returns_dict():
     brain = _make_brain_with_corrections(3, [5, 3, 1])
@@ -46,14 +51,82 @@ def test_convergence_empty_brain():
     assert result["corrections_per_session"] == []
 
 
-def test_convergence_includes_trend():
-    brain = _make_brain_with_corrections(5, [10, 8, 6, 4, 2])
+# --- Mann-Kendall trend tests ---
+
+def test_convergence_monotonic_decline_is_converging():
+    """Strong monotonic decline should be detected by Mann-Kendall."""
+    brain = _make_brain_with_corrections(7, [10, 9, 7, 5, 4, 2, 1])
     result = brain.convergence()
-    assert "trend" in result
-    assert result["trend"] == "converging"  # declining corrections
+    assert result["trend"] == "converging"
+
+
+def test_convergence_monotonic_increase_is_diverging():
+    """Increasing corrections = diverging."""
+    brain = _make_brain_with_corrections(7, [1, 2, 4, 5, 7, 9, 10])
+    result = brain.convergence()
+    assert result["trend"] == "diverging"
 
 
 def test_convergence_flat_is_converged():
-    brain = _make_brain_with_corrections(5, [2, 2, 2, 2, 2])
+    """No trend = converged (already stable)."""
+    brain = _make_brain_with_corrections(7, [3, 3, 3, 3, 3, 3, 3])
     result = brain.convergence()
     assert result["trend"] == "converged"
+
+
+def test_convergence_noisy_decline_still_converging():
+    """Noisy but overall declining should still detect trend."""
+    brain = _make_brain_with_corrections(8, [10, 8, 9, 6, 7, 4, 3, 2])
+    result = brain.convergence()
+    assert result["trend"] == "converging"
+
+
+def test_convergence_insufficient_data():
+    """Need at least 3 sessions for trend detection."""
+    brain = _make_brain_with_corrections(2, [5, 3])
+    result = brain.convergence()
+    assert result["trend"] == "insufficient_data"
+
+
+# --- Mann-Kendall p-value ---
+
+def test_convergence_includes_p_value():
+    """Mann-Kendall should return a p-value for the trend."""
+    brain = _make_brain_with_corrections(7, [10, 9, 7, 5, 4, 2, 1])
+    result = brain.convergence()
+    assert "p_value" in result
+    assert result["p_value"] < 0.05  # strong monotonic trend
+
+
+def test_convergence_flat_high_p_value():
+    """Flat data should have high p-value (no significant trend)."""
+    brain = _make_brain_with_corrections(7, [3, 3, 3, 3, 3, 3, 3])
+    result = brain.convergence()
+    assert result["p_value"] > 0.05
+
+
+# --- Per-category convergence ---
+
+def test_convergence_per_category():
+    """Should return per-category breakdown."""
+    d = tempfile.mkdtemp()
+    (Path(d) / "lessons.md").write_text("", encoding="utf-8")
+    brain = Brain(d)
+    # Session 1: 3 TONE, 2 CODE corrections
+    for _ in range(3):
+        brain.emit("CORRECTION", "test", {"category": "TONE", "severity": "minor"}, ["category:TONE"], 1)
+    for _ in range(2):
+        brain.emit("CORRECTION", "test", {"category": "CODE", "severity": "minor"}, ["category:CODE"], 1)
+    # Session 2: 1 TONE, 2 CODE
+    brain.emit("CORRECTION", "test", {"category": "TONE", "severity": "minor"}, ["category:TONE"], 2)
+    for _ in range(2):
+        brain.emit("CORRECTION", "test", {"category": "CODE", "severity": "minor"}, ["category:CODE"], 2)
+    # Session 3: 0 TONE, 1 CODE
+    brain.emit("CORRECTION", "test", {"category": "CODE", "severity": "minor"}, ["category:CODE"], 3)
+
+    result = brain.convergence()
+    assert "by_category" in result
+    assert "TONE" in result["by_category"]
+    assert "CODE" in result["by_category"]
+    # TONE went 3→1→0 = converging
+    assert result["by_category"]["TONE"]["corrections_per_session"] == [3, 1, 0]

--- a/tests/test_convergence_gate.py
+++ b/tests/test_convergence_gate.py
@@ -1,0 +1,70 @@
+"""Tests for convergence-gated extraction — skip LLM when category converged."""
+from unittest.mock import patch, MagicMock
+from gradata.brain import Brain
+
+
+def test_extraction_skipped_when_converged(tmp_path):
+    """Behavioral extraction is skipped when category trend is converged."""
+    brain = Brain.init(str(tmp_path / "test-brain"), domain="test", interactive=False)
+
+    converged_result = {
+        "sessions": [1, 2, 3, 4, 5],
+        "corrections_per_session": [10, 8, 5, 5, 5],
+        "trend": "converged",
+        "p_value": 0.8,
+        "by_category": {
+            "DRAFTING": {"corrections_per_session": [5, 4, 2, 2, 2], "trend": "converged", "p_value": 0.9},
+        },
+        "total_corrections": 33,
+        "total_sessions": 5,
+    }
+
+    with patch.object(brain, "_get_convergence", return_value=converged_result):
+        with patch("gradata.enhancements.edit_classifier.extract_behavioral_instruction") as mock_extract:
+            brain.correct(
+                "The system is working good",
+                "The system is working well",
+                category="DRAFTING",
+            )
+            mock_extract.assert_not_called()
+
+
+def test_extraction_runs_when_diverging(tmp_path):
+    """Behavioral extraction runs when category trend is diverging."""
+    brain = Brain.init(str(tmp_path / "test-brain"), domain="test", interactive=False)
+
+    diverging_result = {
+        "sessions": [1, 2, 3],
+        "corrections_per_session": [2, 5, 10],
+        "trend": "diverging",
+        "p_value": 0.02,
+        "by_category": {
+            "DRAFTING": {"corrections_per_session": [1, 3, 8], "trend": "diverging", "p_value": 0.01},
+        },
+        "total_corrections": 17,
+        "total_sessions": 3,
+    }
+
+    with patch.object(brain, "_get_convergence", return_value=diverging_result):
+        with patch("gradata.enhancements.edit_classifier.extract_behavioral_instruction", return_value=None) as mock_extract:
+            brain.correct(
+                "The system is working good",
+                "The system is working well",
+                category="DRAFTING",
+            )
+            mock_extract.assert_called_once()
+
+
+def test_convergence_cache_per_session(tmp_path):
+    """Convergence result is cached within a session, refreshed across sessions."""
+    brain = Brain.init(str(tmp_path / "test-brain"), domain="test", interactive=False)
+
+    with patch("gradata._core.brain_convergence", return_value={"trend": "converging", "by_category": {}}) as mock_conv:
+        brain._get_convergence()
+        brain._get_convergence()
+        assert mock_conv.call_count == 1  # Cached
+
+        # Simulate session change by invalidating the cache session
+        brain._convergence_session = -1
+        brain._get_convergence()
+        assert mock_conv.call_count == 2  # New session

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -1,0 +1,71 @@
+"""Tests for brain.efficiency() — effort-saved metric."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from gradata.brain import Brain
+
+
+def _make_brain(tmp_path: Path) -> Brain:
+    (tmp_path / "lessons.md").write_text("", encoding="utf-8")
+    return Brain(str(tmp_path))
+
+
+def _mock_convergence(corrections_per_session):
+    return {
+        "sessions": list(range(1, len(corrections_per_session) + 1)),
+        "corrections_per_session": corrections_per_session,
+        "trend": "converging",
+        "p_value": 0.01,
+        "by_category": {},
+        "total_corrections": sum(corrections_per_session),
+        "total_sessions": len(corrections_per_session),
+    }
+
+
+def test_efficiency_ratio_declining(tmp_path):
+    brain = _make_brain(tmp_path)
+    conv = _mock_convergence([10, 12, 8, 5, 4, 3])
+    with patch.object(brain, "_get_convergence", return_value=conv):
+        result = brain.efficiency()
+    assert "effort_ratio" in result
+    assert result["effort_ratio"] < 1.0
+    assert result["corrections_initial"] == 10.0  # avg(10,12,8)
+    assert result["corrections_recent"] == 4.0    # avg(5,4,3)
+
+
+def test_efficiency_ratio_no_improvement(tmp_path):
+    brain = _make_brain(tmp_path)
+    conv = _mock_convergence([5, 5, 5, 5, 5, 5])
+    with patch.object(brain, "_get_convergence", return_value=conv):
+        result = brain.efficiency()
+    assert result["effort_ratio"] == 1.0
+
+
+def test_efficiency_insufficient_data(tmp_path):
+    brain = _make_brain(tmp_path)
+    conv = _mock_convergence([5, 3])
+    with patch.object(brain, "_get_convergence", return_value=conv):
+        result = brain.efficiency()
+    assert result["effort_ratio"] == 1.0
+    assert result["corrections_initial"] == 0
+    assert result["corrections_recent"] == 0
+
+
+def test_efficiency_no_time_fields_by_default(tmp_path):
+    brain = _make_brain(tmp_path)
+    conv = _mock_convergence([10, 12, 8, 5, 4, 3])
+    with patch.object(brain, "_get_convergence", return_value=conv):
+        result = brain.efficiency()
+    assert "estimated_seconds_saved" not in result
+
+
+def test_efficiency_with_time_estimate(tmp_path):
+    brain = _make_brain(tmp_path)
+    conv = _mock_convergence([10, 12, 8, 5, 4, 3])
+    with patch.object(brain, "_get_convergence", return_value=conv):
+        result = brain.efficiency(estimate_time=True)
+    assert "estimated_seconds_saved" in result
+    assert isinstance(result["estimated_seconds_saved"], (int, float))
+    assert result["estimated_seconds_saved"] > 0

--- a/tests/test_rule_scoping.py
+++ b/tests/test_rule_scoping.py
@@ -25,3 +25,86 @@ def test_domain_scores_round_trip():
     parsed = parse_lessons(text)
     assert len(parsed) == 1
     assert parsed[0].domain_scores == {"CODE": {"fires": 8, "misfires": 1}, "DRAFTING": {"fires": 2, "misfires": 0}}
+
+
+from gradata.rules.rule_engine import is_rule_disabled_for_domain
+
+
+def test_rule_disabled_high_misfire_rate():
+    """Rule disabled when misfire rate >30% in a domain with 3+ fires."""
+    lesson = Lesson(
+        date="2026-04-06", state=LessonState.RULE,
+        confidence=0.95, category="DRAFTING",
+        description="Use active voice",
+        domain_scores={"CODE": {"fires": 10, "misfires": 4}},
+    )
+    assert is_rule_disabled_for_domain(lesson, "CODE") is True
+
+
+def test_rule_not_disabled_low_misfire_rate():
+    lesson = Lesson(
+        date="2026-04-06", state=LessonState.RULE,
+        confidence=0.95, category="DRAFTING",
+        description="Use active voice",
+        domain_scores={"CODE": {"fires": 10, "misfires": 2}},
+    )
+    assert is_rule_disabled_for_domain(lesson, "CODE") is False
+
+
+def test_rule_not_disabled_insufficient_data():
+    lesson = Lesson(
+        date="2026-04-06", state=LessonState.RULE,
+        confidence=0.95, category="DRAFTING",
+        description="Use active voice",
+        domain_scores={"CODE": {"fires": 2, "misfires": 2}},
+    )
+    assert is_rule_disabled_for_domain(lesson, "CODE") is False
+
+
+def test_rule_disabled_one_domain_active_another():
+    lesson = Lesson(
+        date="2026-04-06", state=LessonState.RULE,
+        confidence=0.95, category="DRAFTING",
+        description="Use active voice",
+        domain_scores={
+            "CODE": {"fires": 10, "misfires": 5},
+            "DRAFTING": {"fires": 20, "misfires": 1},
+        },
+    )
+    assert is_rule_disabled_for_domain(lesson, "CODE") is True
+    assert is_rule_disabled_for_domain(lesson, "DRAFTING") is False
+
+
+def test_rule_not_disabled_unknown_domain():
+    lesson = Lesson(
+        date="2026-04-06", state=LessonState.RULE,
+        confidence=0.95, category="DRAFTING",
+        description="Use active voice",
+        domain_scores={"CODE": {"fires": 10, "misfires": 5}},
+    )
+    assert is_rule_disabled_for_domain(lesson, "EMAIL") is False
+
+
+from gradata.rules.rule_engine import apply_rules
+from gradata._scope import RuleScope
+
+
+def test_apply_rules_filters_domain_disabled():
+    """apply_rules excludes rules disabled for the current domain."""
+    good_rule = Lesson(
+        date="2026-04-06", state=LessonState.RULE,
+        confidence=0.95, category="DRAFTING",
+        description="Use active voice",
+        domain_scores={"CODE": {"fires": 20, "misfires": 1}},
+    )
+    bad_rule = Lesson(
+        date="2026-04-06", state=LessonState.RULE,
+        confidence=0.95, category="TONE",
+        description="Be concise",
+        domain_scores={"CODE": {"fires": 10, "misfires": 5}},
+    )
+    scope = RuleScope(domain="CODE")
+    results = apply_rules([good_rule, bad_rule], scope)
+    descriptions = [r.lesson.description for r in results]
+    assert "Use active voice" in descriptions
+    assert "Be concise" not in descriptions

--- a/tests/test_rule_scoping.py
+++ b/tests/test_rule_scoping.py
@@ -108,3 +108,44 @@ def test_apply_rules_filters_domain_disabled():
     descriptions = [r.lesson.description for r in results]
     assert "Use active voice" in descriptions
     assert "Be concise" not in descriptions
+
+
+def test_rule_scoped_out_event_emitted():
+    """rule_scoped_out event fires when a rule is filtered by domain."""
+    from gradata.events_bus import EventBus
+
+    bus = EventBus()
+    events_received = []
+    bus.on("rule_scoped_out", lambda payload: events_received.append(payload))
+
+    bad_rule = Lesson(
+        date="2026-04-06", state=LessonState.RULE,
+        confidence=0.95, category="TONE",
+        description="Be concise in all output",
+        domain_scores={"CODE": {"fires": 10, "misfires": 5}},
+    )
+    scope = RuleScope(domain="CODE")
+    apply_rules([bad_rule], scope, bus=bus)
+
+    assert len(events_received) == 1
+    assert events_received[0]["domain"] == "CODE"
+    assert events_received[0]["lesson_category"] == "TONE"
+
+
+def test_attribute_domain_fires_increments():
+    """_attribute_domain_fires increments fires for correction category."""
+    from gradata._core import _attribute_domain_fires
+    from unittest.mock import MagicMock
+
+    brain = MagicMock()
+    rule = Lesson(
+        date="2026-04-06", state=LessonState.RULE,
+        confidence=0.95, category="DRAFTING",
+        description="Use active voice",
+        domain_scores={"DRAFTING": {"fires": 5, "misfires": 0}},
+    )
+    brain._fired_rules = [rule]
+
+    _attribute_domain_fires(brain, "DRAFTING", "some correction")
+
+    assert rule.domain_scores["DRAFTING"]["fires"] == 6

--- a/tests/test_rule_scoping.py
+++ b/tests/test_rule_scoping.py
@@ -1,0 +1,27 @@
+"""Tests for rule domain scoping — per-domain misfire tracking and auto-disable."""
+from gradata._types import Lesson, LessonState
+
+
+def test_lesson_has_domain_scores_field():
+    lesson = Lesson(
+        date="2026-04-06", state=LessonState.RULE,
+        confidence=0.95, category="DRAFTING",
+        description="Use active voice",
+    )
+    assert hasattr(lesson, "domain_scores")
+    assert lesson.domain_scores == {}
+
+
+def test_domain_scores_round_trip():
+    from gradata.enhancements.self_improvement import parse_lessons, format_lessons
+    lesson = Lesson(
+        date="2026-04-06", state=LessonState.RULE,
+        confidence=0.95, category="DRAFTING",
+        description="Use active voice",
+        fire_count=10,
+        domain_scores={"CODE": {"fires": 8, "misfires": 1}, "DRAFTING": {"fires": 2, "misfires": 0}},
+    )
+    text = format_lessons([lesson])
+    parsed = parse_lessons(text)
+    assert len(parsed) == 1
+    assert parsed[0].domain_scores == {"CODE": {"fires": 8, "misfires": 1}, "DRAFTING": {"fires": 2, "misfires": 0}}


### PR DESCRIPTION
## Summary
- Cherry-picks Mann-Kendall convergence upgrade (per-category tracking, p-values)
- **Rule domain scoping**: per-domain misfire tracking on lessons, auto-disables rules with >30% misfire rate in a domain
- **Convergence gate**: skips LLM extraction when a category is converged (Mann-Kendall flat)
- **brain.efficiency()**: effort-ratio metric with optional time estimates (Kenoodl reframe: "reduced toil" not "AI learned")
- New events: `rule_scoped_out` emitted when a rule is suppressed by domain

## Source
Sim 9 consensus (2000 posts, 200 agents) + Kenoodl synthesis. See `docs/superpowers/specs/2026-04-06-sim9-engine-hardening-design.md`.

## Test plan
- [ ] `pytest tests/test_rule_scoping.py -v` — 8 domain scoping tests
- [ ] `pytest tests/test_convergence_gate.py -v` — 3 gate tests
- [ ] `pytest tests/test_efficiency.py -v` — 5 efficiency metric tests
- [ ] `pytest tests/test_convergence.py -v` — 11 Mann-Kendall tests
- [ ] `pytest tests/ -q` — full regression suite (1374 pass)
- [ ] `pyright src/gradata/` — 0 errors

Generated with Gradata

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the Sim 9 engine with three new capabilities: per-domain rule scoping (auto-disables rules with >30% misfire rate in a given domain), a convergence gate (skips LLM extraction when a category's correction rate has statistically stabilized via Mann-Kendall), and a `brain.efficiency()` metric that computes an effort-ratio from correction trends with an optional time-saved estimate.

- **Rule domain scoping**: `domain_scores` added to `Lesson`, `is_rule_disabled_for_domain()` added to `rule_engine`, and `_attribute_domain_fires()` added to `_core.py`; a new `rule_scoped_out` EventBus event is emitted when a rule is suppressed per domain.
- **Convergence gate**: `_get_convergence()` caches the Mann-Kendall result per-session; per-category trend is checked before calling `extract_behavioral_instruction`, saving LLM calls when a category is already stable.
- **Efficiency metric**: `brain.efficiency()` computes `recent / initial` correction-rate ratio; optional `estimate_time=True` adds a severity-weighted seconds-saved estimate.
- **Two issues require attention**: the per-category convergence branch lacks an `insufficient_data` guard (sparse-data categories can be falsely labeled `converged`, silently suppressing extraction), and the `bus.emit("rule_scoped_out", ...)` call inside the filtering loop is not wrapped in try-except, meaning a misbehaving subscriber can abort the loop and truncate the applied rule set.

<h3>Confidence Score: 3/5</h3>

Two P1 logic bugs found that should be fixed before merge: sparse-category convergence mislabeling and an unguarded EventBus emit inside the rule-filtering loop.

The overall architecture is clean, test coverage is solid, and the three new features are well-reasoned. However, the per-category convergence gap is a production-quality bug — a category with sparse history will be silently marked converged and skip extraction, degrading lesson quality over time. The unguarded bus.emit in apply_rules violates Rule 4 and can cause silent rule-set truncation. Both are targeted fixes (a few lines each). P2s are minor style concerns. Score of 3 reflects two genuine logic bugs on the critical path that warrant a fix before merge.

src/gradata/_core.py (brain_convergence per-category mapping, lines 962–967; locals() pattern, lines 317–319) and src/gradata/rules/rule_engine.py (unguarded bus.emit in apply_rules loop, lines 494–502)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/gradata/_core.py | Convergence gate + domain fire attribution added; per-category convergence lacks insufficient_data guard and uses fragile locals() check |
| src/gradata/rules/rule_engine.py | Domain-scoping filter added to apply_rules; bus.emit(rule_scoped_out) inside loop is not try-except protected |
| src/gradata/brain.py | Adds efficiency() and _get_convergence() with correct per-session caching; clean delegation pattern |
| src/gradata/enhancements/self_improvement.py | domain_scores parse/format round-trip implemented cleanly; backward-compatible |
| src/gradata/_types.py | domain_scores field added to Lesson with correct default_factory; no issues |
| tests/test_rule_scoping.py | 8 scoping tests covering disable thresholds, event emission, and attribution; missing from __future__ import annotations |
| tests/test_convergence_gate.py | 3 gate tests covering skip, run, and cache behaviour; missing from __future__ import annotations |
| tests/test_efficiency.py | 5 efficiency tests including edge cases (insufficient data, flat rate, time estimates); well-structured |
| tests/test_convergence.py | 11 Mann-Kendall tests covering monotone, noisy, flat, and per-category scenarios; comprehensive |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[brain.correct called] --> B[compute_diff + classify_edits]
    B --> C{_get_convergence\ncached this session?}
    C -->|yes| D[use cached result]
    C -->|no| E[brain_convergence — DB query]
    E --> F[Mann-Kendall overall + per-category]
    F --> D
    D --> G{cat_convergence.trend\n== 'converged'?}
    G -->|yes| H[use primary.description\nskip LLM extraction]
    G -->|no| I[extract_behavioral_instruction\nLLM + cache + templates]
    H --> J[find / create / update Lesson]
    I --> J
    J --> K[update_confidence + write lessons.md]
    K --> L{_fired_rules present?}
    L -->|yes| M[_attribute_domain_fires\nincrement domain fires/misfires]
    M --> N[bus.emit correction.created]
    L -->|no| N

    subgraph apply_rules [apply_rules — rule selection]
        O[filter PATTERN + RULE] --> P{scope.domain set?}
        P -->|yes| Q{is_rule_disabled_for_domain?}
        Q -->|yes| R[bus.emit rule_scoped_out\ndrop rule]
        Q -->|no| S[keep rule]
        P -->|no| S
        S --> T[score + rank → AppliedRule list]
    end
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Asrc%2Fgradata%2F_core.py%3A962-967%0A**Per-category%20convergence%20has%20no%20%60insufficient_data%60%20guard**%0A%0AAt%20the%20top-level%2C%20%60brain_convergence%60%20correctly%20emits%20%60%22insufficient_data%22%60%20when%20%60len%28counts%29%20%3C%203%60.%20But%20the%20per-category%20branch%20maps%20every%20%60%22no_trend%22%60%20result%20straight%20to%20%60%22converged%22%60%3A%0A%0A%60%60%60python%0Acat_trend%20%3D%20%22converging%22%20if%20cat_mk%20%3D%3D%20%22decreasing%22%20else%20%28%0A%20%20%20%20%22diverging%22%20if%20cat_mk%20%3D%3D%20%22increasing%22%20else%20%22converged%22%29%0A%60%60%60%0A%0A%60cat_counts%60%20is%20built%20with%20zeros%20for%20every%20session%20where%20the%20category%20had%20no%20corrections%2C%20so%20a%20category%20that%20appeared%20in%20only%20one%20or%20two%20sessions%20out%20of%20seven%20gets%20a%20list%20like%20%60%5B0%2C%200%2C%200%2C%205%2C%200%2C%200%2C%200%5D%60.%20Because%20this%20sequence%20has%20no%20monotonic%20trend%2C%20Mann-Kendall%20returns%20%60%22no_trend%22%60%20%E2%86%92%20%60%22converged%22%60.%20The%20convergence%20gate%20in%20%60_core.py%60%20then%20sees%20%60trend%20%3D%3D%20%22converged%22%60%20and%20**skips%20LLM%20extraction%20for%20future%20corrections%20in%20that%20category**%2C%20even%20though%20the%20category%20has%20never%20meaningfully%20converged%20%E2%80%94%20it%20simply%20has%20sparse%20history.%0A%0ASuggested%20fix%3A%0A%0A%60%60%60python%0Aif%20cat_mk%20%3D%3D%20%22decreasing%22%3A%0A%20%20%20%20cat_trend%20%3D%20%22converging%22%0Aelif%20cat_mk%20%3D%3D%20%22increasing%22%3A%0A%20%20%20%20cat_trend%20%3D%20%22diverging%22%0Aelif%20sum%28cat_counts%29%20%3C%203%3A%20%20%20%20%20%20%20%20%20%20%23%20not%20enough%20non-zero%20data%0A%20%20%20%20cat_trend%20%3D%20%22insufficient_data%22%0Aelse%3A%0A%20%20%20%20cat_trend%20%3D%20%22converged%22%0A%60%60%60%0A%0AThe%20convergence%20gate%20already%20checks%20%60cat_convergence.get%28%22trend%22%29%20%3D%3D%20%22converged%22%60%2C%20so%20adding%20the%20%60%22insufficient_data%22%60%20branch%20here%20is%20a%20backward-compatible%20fix%20%E2%80%94%20categories%20with%20thin%20history%20will%20continue%20to%20get%20LLM%20extraction.%0A%0A%23%23%23%20Issue%202%20of%205%0Asrc%2Fgradata%2Frules%2Frule_engine.py%3A494-502%0A**Unguarded%20%60bus.emit%60%20inside%20eligibility-filter%20loop%20%E2%80%94%20Rule%204%20violation**%0A%0AThe%20%60bus.emit%28%22rule_scoped_out%22%2C%20...%29%60%20call%20is%20inside%20a%20%60for%20lesson%20in%20eligible%60%20loop%20with%20no%20try-except%3A%0A%0A%60%60%60python%0Aif%20is_rule_disabled_for_domain%28lesson%2C%20current_domain%29%3A%0A%20%20%20%20if%20bus%3A%0A%20%20%20%20%20%20%20%20scores%20%3D%20lesson.domain_scores.get%28current_domain%2C%20%7B%7D%29%0A%20%20%20%20%20%20%20%20bus.emit%28%22rule_scoped_out%22%2C%20%7B%20...%20%7D%29%0A%60%60%60%0A%0APer%20Rule%204%2C%20EventBus%20emit%20calls%20must%20be%20wrapped%20so%20a%20misbehaving%20subscriber%20cannot%20propagate%20exceptions%20to%20the%20caller.%20If%20the%20handler%20raises%20here%2C%20the%20%60for%60%20loop%20terminates%20early%20%E2%80%94%20rules%20that%20should%20have%20been%20kept%20in%20%60eligible%60%20are%20silently%20dropped%2C%20producing%20a%20truncated%20rule%20set%20with%20no%20warning.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20is_rule_disabled_for_domain%28lesson%2C%20current_domain%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20bus%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20scores%20%3D%20lesson.domain_scores.get%28current_domain%2C%20%7B%7D%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20bus.emit%28%22rule_scoped_out%22%2C%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22lesson_category%22%3A%20lesson.category%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22lesson_description%22%3A%20lesson.description%5B%3A80%5D%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22domain%22%3A%20current_domain%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22misfire_rate%22%3A%20scores.get%28%22misfires%22%2C%200%29%20%2F%20max%281%2C%20scores.get%28%22fires%22%2C%201%29%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20except%20Exception%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20_log.debug%28%22rule_scoped_out%20emit%20failed%22%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%205%0Asrc%2Fgradata%2F_core.py%3A317-319%0A**%60locals%28%29%60%20inspection%20is%20fragile%20for%20%60desc%60-variable%20lookup**%0A%0A%60desc%60%20is%20assigned%20inside%20the%20broad%20%60try%60%20block%20that%20ends%20at%20line%20311.%20Whether%20it%20exists%20in%20the%20local%20namespace%20after%20the%20except%20depends%20on%20exactly%20how%20far%20execution%20got.%20Using%20%60'desc'%20in%20locals%28%29%60%20to%20probe%20this%20is%20an%20anti-pattern%20%E2%80%94%20easy%20to%20misread%20and%20could%20silently%20yield%20an%20empty%20%60correction_desc%60%20if%20the%20assignment%20was%20skipped%20part-way%20through%20the%20block.%0A%0AA%20cleaner%20approach%20is%20to%20initialise%20a%20dedicated%20variable%20before%20the%20try%20block%3A%0A%0A%60%60%60python%0A_extracted_desc%3A%20str%20%3D%20%22%22%20%20%23%20initialise%20before%20the%20try%20block%0A%23%20...%20inside%20the%20try%2C%20after%20desc%20is%20computed%3A%0A_extracted_desc%20%3D%20desc%0A%23%20...%20after%20the%20try%20block%3A%0Aif%20brain._fired_rules%20and%20%28category%20or%20classifications%29%3A%0A%20%20%20%20_attribute_domain_fires%28brain%2C%20category%20or%20%22UNKNOWN%22%2C%20_extracted_desc%20or%20summary%29%0A%60%60%60%0A%0AThis%20makes%20the%20intent%20explicit%20and%20eliminates%20the%20%60locals%28%29%60%20introspection.%0A%0A%23%23%23%20Issue%204%20of%205%0Atests%2Ftest_rule_scoping.py%3A1-2%0A**Missing%20%60from%20__future__%20import%20annotations%60%20%28Rule%206%29**%0A%0ABoth%20new%20test%20files%20added%20in%20this%20PR%20are%20missing%20the%20required%20first%20import.%20Per%20Rule%206%2C%20all%20%60.py%60%20files%20in%20the%20SDK%20should%20include%20%60from%20__future__%20import%20annotations%60%20to%20enable%20%60str%20%7C%20None%60%20syntax%20consistently%20and%20maintain%20Pyright%20strict-mode%20compatibility.%0A%0AThis%20applies%20here%20%28%60tests%2Ftest_rule_scoping.py%60%29%20and%20also%20to%20%60tests%2Ftest_convergence_gate.py%60%20line%201.%0A%0A%60%60%60suggestion%0Afrom%20__future__%20import%20annotations%0A%0A%22%22%22Tests%20for%20rule%20domain%20scoping%20%E2%80%94%20per-domain%20misfire%20tracking%20and%20auto-disable.%22%22%22%0A%60%60%60%0A%0A**Rule%20Used%3A**%20%23%20Code%20Review%20Rules%0A%0A%23%23%20Rule%201%3A%20Never%20use%20print%28%29%20...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Ddee613fe-ca52-4382-b9d7-fad6d0b079ec%29%29%0A%0A%23%23%23%20Issue%205%20of%205%0Asrc%2Fgradata%2F_core.py%3A1031%0A**%60corrections_avoided%60%20multiplier%20includes%20the%20baseline%20period%2C%20overestimating%20savings**%0A%0A%60%60%60python%0Acorrections_avoided%20%3D%20max%280%2C%20%28initial%20-%20recent%29%20*%20len%28counts%29%29%0A%60%60%60%0A%0AThis%20multiplies%20by%20the%20**total**%20session%20count%2C%20including%20the%20first%20three%20sessions%20used%20to%20establish%20%60initial%60.%20In%20a%2020-session%20brain%20with%20initial%20%3D%2010%2C%20recent%20%3D%204%2C%20the%20formula%20yields%20%606%20%C3%97%2020%20%3D%20120%60%20%E2%80%94%20but%20sessions%201%E2%80%933%20were%20already%20running%20at%20the%20initial%20correction%20rate%2C%20so%20nothing%20was%20avoided%20there.%0A%0AA%20more%20accurate%20%28still%20approximate%29%20estimate%20uses%20only%20post-baseline%20sessions%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20corrections_avoided%20%3D%20max%280%2C%20%28initial%20-%20recent%29%20*%20max%280%2C%20len%28counts%29%20-%203%29%29%0A%60%60%60%0A%0AThis%20is%20still%20labelled%20%22approximate%22%20in%20the%20docstring%2C%20but%20avoids%20inflating%20the%20reported%20savings%20for%20long-running%20brains.%0A%0A&repo=gradata%2Fgradata"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/gradata/_core.py
Line: 962-967

Comment:
**Per-category convergence has no `insufficient_data` guard**

At the top-level, `brain_convergence` correctly emits `"insufficient_data"` when `len(counts) < 3`. But the per-category branch maps every `"no_trend"` result straight to `"converged"`:

```python
cat_trend = "converging" if cat_mk == "decreasing" else (
    "diverging" if cat_mk == "increasing" else "converged")
```

`cat_counts` is built with zeros for every session where the category had no corrections, so a category that appeared in only one or two sessions out of seven gets a list like `[0, 0, 0, 5, 0, 0, 0]`. Because this sequence has no monotonic trend, Mann-Kendall returns `"no_trend"` → `"converged"`. The convergence gate in `_core.py` then sees `trend == "converged"` and **skips LLM extraction for future corrections in that category**, even though the category has never meaningfully converged — it simply has sparse history.

Suggested fix:

```python
if cat_mk == "decreasing":
    cat_trend = "converging"
elif cat_mk == "increasing":
    cat_trend = "diverging"
elif sum(cat_counts) < 3:          # not enough non-zero data
    cat_trend = "insufficient_data"
else:
    cat_trend = "converged"
```

The convergence gate already checks `cat_convergence.get("trend") == "converged"`, so adding the `"insufficient_data"` branch here is a backward-compatible fix — categories with thin history will continue to get LLM extraction.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/gradata/rules/rule_engine.py
Line: 494-502

Comment:
**Unguarded `bus.emit` inside eligibility-filter loop — Rule 4 violation**

The `bus.emit("rule_scoped_out", ...)` call is inside a `for lesson in eligible` loop with no try-except:

```python
if is_rule_disabled_for_domain(lesson, current_domain):
    if bus:
        scores = lesson.domain_scores.get(current_domain, {})
        bus.emit("rule_scoped_out", { ... })
```

Per Rule 4, EventBus emit calls must be wrapped so a misbehaving subscriber cannot propagate exceptions to the caller. If the handler raises here, the `for` loop terminates early — rules that should have been kept in `eligible` are silently dropped, producing a truncated rule set with no warning.

```suggestion
                if is_rule_disabled_for_domain(lesson, current_domain):
                    if bus:
                        try:
                            scores = lesson.domain_scores.get(current_domain, {})
                            bus.emit("rule_scoped_out", {
                                "lesson_category": lesson.category,
                                "lesson_description": lesson.description[:80],
                                "domain": current_domain,
                                "misfire_rate": scores.get("misfires", 0) / max(1, scores.get("fires", 1)),
                            })
                        except Exception:
                            _log.debug("rule_scoped_out emit failed")
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/gradata/_core.py
Line: 317-319

Comment:
**`locals()` inspection is fragile for `desc`-variable lookup**

`desc` is assigned inside the broad `try` block that ends at line 311. Whether it exists in the local namespace after the except depends on exactly how far execution got. Using `'desc' in locals()` to probe this is an anti-pattern — easy to misread and could silently yield an empty `correction_desc` if the assignment was skipped part-way through the block.

A cleaner approach is to initialise a dedicated variable before the try block:

```python
_extracted_desc: str = ""  # initialise before the try block
# ... inside the try, after desc is computed:
_extracted_desc = desc
# ... after the try block:
if brain._fired_rules and (category or classifications):
    _attribute_domain_fires(brain, category or "UNKNOWN", _extracted_desc or summary)
```

This makes the intent explicit and eliminates the `locals()` introspection.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: tests/test_rule_scoping.py
Line: 1-2

Comment:
**Missing `from __future__ import annotations` (Rule 6)**

Both new test files added in this PR are missing the required first import. Per Rule 6, all `.py` files in the SDK should include `from __future__ import annotations` to enable `str | None` syntax consistently and maintain Pyright strict-mode compatibility.

This applies here (`tests/test_rule_scoping.py`) and also to `tests/test_convergence_gate.py` line 1.

```suggestion
from __future__ import annotations

"""Tests for rule domain scoping — per-domain misfire tracking and auto-disable."""
```

**Rule Used:** # Code Review Rules

## Rule 1: Never use print() ... ([source](https://app.greptile.com/review/custom-context?memory=dee613fe-ca52-4382-b9d7-fad6d0b079ec))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/gradata/_core.py
Line: 1031

Comment:
**`corrections_avoided` multiplier includes the baseline period, overestimating savings**

```python
corrections_avoided = max(0, (initial - recent) * len(counts))
```

This multiplies by the **total** session count, including the first three sessions used to establish `initial`. In a 20-session brain with initial = 10, recent = 4, the formula yields `6 × 20 = 120` — but sessions 1–3 were already running at the initial correction rate, so nothing was avoided there.

A more accurate (still approximate) estimate uses only post-baseline sessions:

```suggestion
        corrections_avoided = max(0, (initial - recent) * max(0, len(counts) - 3))
```

This is still labelled "approximate" in the docstring, but avoids inflating the reported savings for long-running brains.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add brain.efficiency() — effort-sa..."](https://github.com/gradata/gradata/commit/6c1b5b67e531cfaffa7959035b008266d1775059) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27505741)</sub>

> Greptile also left **5 inline comments** on this PR.

**Context used:**

- Rule used - # Code Review Rules

## Rule 1: Never use print() ... ([source](https://app.greptile.com/review/custom-context?memory=dee613fe-ca52-4382-b9d7-fad6d0b079ec))

<!-- /greptile_comment -->