### PR TITLE
feat: SDK P0 hardening + security — 14 features, 1600+ tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ design-system/
 .env
 .env.local
 .env.*.local
+.gstack/

--- a/src/gradata/_core.py
+++ b/src/gradata/_core.py
@@ -403,6 +403,21 @@ def brain_correct(
         "source": "human",
     })
 
+    # Correction provenance — HMAC-signed proof of who corrected what
+    try:
+        import hashlib as _hashlib
+        from gradata.security.correction_provenance import create_provenance_record
+        correction_hash = _hashlib.sha256(f"{draft}|{final}".encode()).hexdigest()
+        user_id = context.get("user_id", "unknown") if context else "unknown"
+        provenance = create_provenance_record(
+            user_id=user_id, correction_hash=correction_hash,
+            session=session or 0,
+            salt=getattr(brain, "_brain_salt", ""),
+        )
+        event["provenance"] = provenance
+    except Exception:
+        pass  # Never block corrections
+
     return event
 
 

--- a/src/gradata/_core.py
+++ b/src/gradata/_core.py
@@ -452,7 +452,8 @@ def brain_end_session(
         # Previous threshold of 10 misclassified productive human sessions.
         is_machine = machine_mode if machine_mode is not None else (
             len(session_corrections or []) > 30)
-        active, graduated = graduate(lessons, machine_mode=is_machine)
+        _salt = getattr(brain, "_brain_salt", "")
+        active, graduated = graduate(lessons, machine_mode=is_machine, salt=_salt)
 
         promotions, demotions, kills = 0, 0, 0
         transitions = []

--- a/src/gradata/_core.py
+++ b/src/gradata/_core.py
@@ -131,6 +131,14 @@ def brain_correct(
     if not category and classifications:
         category = classifications[0].category.upper()
 
+    # PII redaction — runs AFTER extraction on full text, BEFORE storage
+    try:
+        from gradata.safety import redact_pii_with_report
+        draft_redacted, _ = redact_pii_with_report(draft)
+        final_redacted, _ = redact_pii_with_report(final)
+    except ImportError:
+        draft_redacted, final_redacted = draft, final
+
     scope_obj = build_scope(context) if context else None
     scope_data = {}
     if scope_obj:
@@ -142,7 +150,7 @@ def brain_correct(
     scope_data["correction_scope"] = correction_scope
 
     data = {
-        "draft_text": draft[:2000], "final_text": final[:2000],
+        "draft_text": draft_redacted[:2000], "final_text": final_redacted[:2000],
         "edit_distance": diff.edit_distance, "severity": diff.severity,
         "outcome": diff.severity, "major_edit": diff.severity in ("major", "discarded"),
         "category": category or "UNKNOWN", "summary": summary,
@@ -301,7 +309,7 @@ def brain_correct(
                                     "(lesson_category, lesson_description, draft_text, final_text, "
                                     "severity, correction_event_id, agent_type, created_at) "
                                     "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                                    (cat, desc[:500], draft[:2000], final[:2000],
+                                    (cat, desc[:500], draft_redacted[:2000], final_redacted[:2000],
                                      diff.severity, correction_id, agent_type or "",
                                      _date.today().isoformat()))
                         except Exception as e:
@@ -352,7 +360,7 @@ def brain_correct(
         from gradata._query import fts_index
         from datetime import date as _fts_date
         fts_index(source="corrections", file_type="correction",
-                  text=f"{category or 'UNKNOWN'}: {summary or diff.severity} - {final[:500]}",
+                  text=f"{category or 'UNKNOWN'}: {summary or diff.severity} - {final_redacted[:500]}",
                   embed_date=_fts_date.today().isoformat(), ctx=brain.ctx)
     except Exception as e:
         _log.debug("FTS index failed: %s", e)

--- a/src/gradata/_core.py
+++ b/src/gradata/_core.py
@@ -78,7 +78,7 @@ def brain_correct(
     category: str | None = None, context: dict | None = None,
     session: int | None = None, agent_type: str | None = None,
     approval_required: bool = False, dry_run: bool = False,
-    min_severity: str = "as-is",
+    min_severity: str = "as-is", scope: str | None = None,
 ) -> dict:
     """Record a correction: user edited draft into final version."""
     # Input validation
@@ -137,6 +137,10 @@ def brain_correct(
         from gradata._scope import scope_to_dict
         scope_data = scope_to_dict(scope_obj)
 
+    # Tag correction scope (default: domain)
+    correction_scope = scope or "domain"
+    scope_data["correction_scope"] = correction_scope
+
     data = {
         "draft_text": draft[:2000], "final_text": final[:2000],
         "edit_distance": diff.edit_distance, "severity": diff.severity,
@@ -146,6 +150,7 @@ def brain_correct(
                              "description": c.description} for c in classifications],
         "lines_added": diff.summary_stats.get("lines_added", 0),
         "lines_removed": diff.summary_stats.get("lines_removed", 0),
+        "correction_scope": correction_scope,
     }
     if scope_data:
         data["scope"] = scope_data
@@ -157,6 +162,7 @@ def brain_correct(
     event = brain.emit("CORRECTION", "brain.correct", data, tags, session)
     event["diff"] = diff
     event["classifications"] = classifications
+    event["correction_scope"] = correction_scope
 
     # Auto-extract patterns
     try:
@@ -252,15 +258,19 @@ def brain_correct(
                     except Exception as e:
                         _log.debug("Provenance emit failed: %s", e)
                 else:
+                    import json as _json
                     lesson_scope = ""
                     if agent_type or context:
-                        import json as _json
                         scope_ctx = dict(context or {})
                         if agent_type:
                             scope_ctx["agent_type"] = agent_type
                         scope_obj = build_scope(scope_ctx)
-                        lesson_scope = _json.dumps(
-                            {k: v for k, v in scope_obj.__dict__.items() if v and v != "normal"})
+                        scope_dict = {k: v for k, v in scope_obj.__dict__.items() if v and v != "normal"}
+                    else:
+                        scope_dict = {}
+                    # Always tag correction_scope on new lessons
+                    scope_dict["correction_scope"] = correction_scope
+                    lesson_scope = _json.dumps(scope_dict)
 
                     init_conf = 0.0 if approval_required else INITIAL_CONFIDENCE
                     correction_id = str(event.get("id", "")) if event.get("id") else ""

--- a/src/gradata/_core.py
+++ b/src/gradata/_core.py
@@ -509,6 +509,38 @@ def brain_end_session(
             except Exception as e:
                 _log.debug("Lineage logging failed: %s", e)
 
+            # Write rule provenance for promotions to PATTERN or RULE
+            try:
+                from gradata.audit import write_provenance
+                from gradata.inspection import _make_rule_id
+                from datetime import datetime, UTC
+                now_prov = datetime.now(UTC).isoformat()
+                for l, old_s, new_s in transitions:
+                    if new_s in ("PATTERN", "RULE"):
+                        rid = _make_rule_id(l)
+                        if l.correction_event_ids:
+                            for eid in l.correction_event_ids:
+                                write_provenance(
+                                    brain.db_path,
+                                    rule_id=rid,
+                                    correction_event_id=eid,
+                                    session=brain.session,
+                                    timestamp=now_prov,
+                                    user_context=session_type,
+                                )
+                        else:
+                            # Still record provenance even without event IDs
+                            write_provenance(
+                                brain.db_path,
+                                rule_id=rid,
+                                correction_event_id=None,
+                                session=brain.session,
+                                timestamp=now_prov,
+                                user_context=session_type,
+                            )
+            except Exception as e:
+                _log.debug("Provenance logging failed: %s", e)
+
         all_lessons = active + graduated
         from gradata._db import write_lessons_safe
         if all_lessons:  # guard against wiping lessons file when all lessons are killed

--- a/src/gradata/_core.py
+++ b/src/gradata/_core.py
@@ -575,12 +575,27 @@ def brain_end_session(
             except Exception as e:
                 _log.warning("Meta-rule discovery failed: %s", e)
 
+        # Build graduated_rules detail list from transitions
+        from gradata.inspection import _make_rule_id
+        graduated_rules = []
+        for l, old_s, new_s in transitions:
+            if new_s in ("PATTERN", "RULE"):
+                graduated_rules.append({
+                    "rule_id": _make_rule_id(l),
+                    "category": l.category,
+                    "description": l.description[:100],
+                    "old_state": old_s,
+                    "new_state": new_s,
+                    "confidence": l.confidence,
+                })
+
         result = {
             "session": current_session,
             "total_lessons": len(all_lessons), "active": len(active),
             "graduated": len(graduated), "promotions": promotions,
             "demotions": demotions, "kills": kills,
             "new_rules": [l.description[:60] for l in new_rules] if new_rules else [],
+            "graduated_rules": graduated_rules,
             "meta_rules_discovered": meta_rules_discovered}
 
         # Session boundary marker for dashboard queries

--- a/src/gradata/_core.py
+++ b/src/gradata/_core.py
@@ -94,6 +94,13 @@ def brain_correct(
     if session is not None and (not isinstance(session, int) or session < 1):
         raise ValueError(f"session must be a positive integer, got {session!r}")
 
+    # Normalize and validate scope
+    _VALID_SCOPES = {"domain", "one_off", "universal", "project"}
+    if scope is not None:
+        scope = str(scope).strip().lower() or None
+        if scope is not None and scope not in _VALID_SCOPES:
+            raise ValueError(f"Unsupported correction scope: {scope!r}. Must be one of {_VALID_SCOPES}")
+
     # Route to cloud if connected
     if brain._cloud and brain._cloud.connected:
         try:
@@ -329,7 +336,8 @@ def brain_correct(
                 correction_data = [{"category": cat, "severity_label": diff.severity, "description": desc}]
                 severity_data = {cat: diff.severity}
                 existing_lessons = update_confidence(
-                    existing_lessons, correction_data, severity_data=severity_data)
+                    existing_lessons, correction_data, severity_data=severity_data,
+                    salt=getattr(brain, "_brain_salt", ""))
 
                 from gradata._db import write_lessons_safe
                 write_lessons_safe(lessons_path, format_lessons(existing_lessons))
@@ -406,13 +414,20 @@ def brain_correct(
     # Correction provenance — HMAC-signed proof of who corrected what
     try:
         import hashlib as _hashlib
+        import json
         from gradata.security.correction_provenance import create_provenance_record
-        correction_hash = _hashlib.sha256(f"{draft}|{final}".encode()).hexdigest()
+        correction_hash = _hashlib.sha256(
+            json.dumps([draft, final], separators=(",", ":")).encode()
+        ).hexdigest()
         user_id = context.get("user_id", "unknown") if context else "unknown"
+        _prov_salt = getattr(brain, "_brain_salt", "")
+        if not _prov_salt:
+            _log.warning("brain._brain_salt is empty; skipping provenance HMAC")
+            raise ValueError("empty salt")
         provenance = create_provenance_record(
             user_id=user_id, correction_hash=correction_hash,
             session=session or 0,
-            salt=getattr(brain, "_brain_salt", ""),
+            salt=_prov_salt,
         )
         event["provenance"] = provenance
     except Exception:
@@ -461,7 +476,8 @@ def brain_end_session(
 
         lessons = update_confidence(
             lessons, session_corrections or [],
-            session_type=session_type, machine_mode=machine_mode)
+            session_type=session_type, machine_mode=machine_mode,
+            salt=getattr(brain, "_brain_salt", ""))
 
         # Auto-detect machine mode: human sessions rarely exceed 30 corrections.
         # Previous threshold of 10 misclassified productive human sessions.

--- a/src/gradata/_migrations.py
+++ b/src/gradata/_migrations.py
@@ -41,6 +41,14 @@ _BASE_TABLES: list[str] = [
         resolved_at TEXT,
         resolution TEXT
     )""",
+    """CREATE TABLE IF NOT EXISTS rule_provenance (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        rule_id TEXT NOT NULL,
+        correction_event_id TEXT,
+        session INTEGER,
+        timestamp TEXT NOT NULL,
+        user_context TEXT
+    )""",
 ]
 
 _MIGRATIONS: list[str] = [
@@ -55,6 +63,8 @@ _MIGRATIONS: list[str] = [
     "ALTER TABLE meta_rules ADD COLUMN applies_when TEXT",
     "ALTER TABLE meta_rules ADD COLUMN never_when TEXT",
     "ALTER TABLE meta_rules ADD COLUMN transfer_scope TEXT DEFAULT 'personal'",
+    # Rule provenance index
+    "CREATE INDEX IF NOT EXISTS idx_provenance_rule_id ON rule_provenance(rule_id)",
     # Super-meta-rules table
     "ALTER TABLE super_meta_rules ADD COLUMN applies_when TEXT",
     "ALTER TABLE super_meta_rules ADD COLUMN never_when TEXT",

--- a/src/gradata/_types.py
+++ b/src/gradata/_types.py
@@ -108,6 +108,31 @@ def transition(current: LessonState, action: str) -> LessonState:
 
 
 @dataclass
+class RuleMetadata:
+    """5W1H metadata + dual utility/safety scores for graduated rules.
+
+    Tracks provenance (who, what, why, when, where, how) and dual scores
+    that let the injection pipeline balance usefulness vs safety.
+    """
+    what: str = ""
+    why: str = ""
+    who: str = ""
+    when_created: str = ""
+    when_validated: str = ""
+    where_scope: str = ""
+    how_enforced: str = "injected"
+    utility_score: float = 0.5
+    safety_score: float = 0.5
+
+    def __post_init__(self) -> None:
+        self.utility_score = round(max(0.0, min(1.0, self.utility_score)), 2)
+        self.safety_score = round(max(0.0, min(1.0, self.safety_score)), 2)
+
+    def to_dict(self) -> dict:
+        return {f: getattr(self, f) for f in self.__dataclass_fields__}
+
+
+@dataclass
 class Lesson:
     """A single learned lesson with confidence tracking."""
     date: str                          # ISO date when the lesson was created
@@ -131,6 +156,7 @@ class Lesson:
     parent_meta_rule_id: str | None = None  # Meta-rule this lesson contributed to
     memory_ids: list[str] = field(default_factory=list)  # Linked memory IDs
     domain_scores: dict[str, dict[str, int]] = field(default_factory=dict)  # Per-domain fire/misfire tracking
+    metadata: RuleMetadata = field(default_factory=RuleMetadata)  # 5W1H + dual scores
 
     def __post_init__(self) -> None:
         self.confidence = round(max(0.0, min(1.0, self.confidence)), 2)

--- a/src/gradata/_types.py
+++ b/src/gradata/_types.py
@@ -33,6 +33,14 @@ class RuleTransferScope(Enum):
     UNIVERSAL = "universal"  # Everyone benefits (no AI tells, verify data, don't fabricate)
 
 
+class CorrectionScope(Enum):
+    """Hierarchical scope for corrections — controls graduation ceiling."""
+    UNIVERSAL = "universal"    # Applies everywhere
+    DOMAIN = "domain"          # Default: applies within this domain
+    PROJECT = "project"        # Applies only to this project
+    ONE_OFF = "one_off"        # Never graduates past INSTINCT
+
+
 class LessonState(Enum):
     """Maturity tiers for a learned lesson."""
     INSTINCT = "INSTINCT"       # 0.00 - 0.59

--- a/src/gradata/audit.py
+++ b/src/gradata/audit.py
@@ -206,13 +206,14 @@ def trace_rule(
         try:
             with sqlite3.connect(str(db)) as conn:
                 conn.row_factory = sqlite3.Row
+                # Query by description[:100] to match how transitions are stored
                 rows = conn.execute(
                     """SELECT old_state, new_state, confidence, fire_count,
                               session, transitioned_at
                        FROM lesson_transitions
                        WHERE lesson_desc = ? AND category = ?
                        ORDER BY transitioned_at""",
-                    (target.description, target.category),
+                    (target.description[:100], target.category),
                 ).fetchall()
                 transitions = [dict(r) for r in rows]
         except Exception as e:

--- a/src/gradata/audit.py
+++ b/src/gradata/audit.py
@@ -82,20 +82,19 @@ def query_provenance(
         return []
 
     try:
-        conn = sqlite3.connect(str(db))
-        conn.row_factory = sqlite3.Row
-        if rule_id is not None:
-            rows = conn.execute(
-                "SELECT * FROM rule_provenance WHERE rule_id = ? ORDER BY id DESC LIMIT ?",
-                (rule_id, limit),
-            ).fetchall()
-        else:
-            rows = conn.execute(
-                "SELECT * FROM rule_provenance ORDER BY id DESC LIMIT ?",
-                (limit,),
-            ).fetchall()
-        conn.close()
-        return [dict(r) for r in rows]
+        with sqlite3.connect(str(db)) as conn:
+            conn.row_factory = sqlite3.Row
+            if rule_id is not None:
+                rows = conn.execute(
+                    "SELECT * FROM rule_provenance WHERE rule_id = ? ORDER BY id DESC LIMIT ?",
+                    (rule_id, limit),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM rule_provenance ORDER BY id DESC LIMIT ?",
+                    (limit,),
+                ).fetchall()
+            return [dict(r) for r in rows]
     except Exception as e:
         _log.debug("query_provenance failed: %s", e)
         return []
@@ -205,18 +204,17 @@ def trace_rule(
     db = Path(db_path)
     if db.is_file():
         try:
-            conn = sqlite3.connect(str(db))
-            conn.row_factory = sqlite3.Row
-            rows = conn.execute(
-                """SELECT old_state, new_state, confidence, fire_count,
-                          session, transitioned_at
-                   FROM lesson_transitions
-                   WHERE lesson_desc = ? AND category = ?
-                   ORDER BY transitioned_at""",
-                (target.description, target.category),
-            ).fetchall()
-            transitions = [dict(r) for r in rows]
-            conn.close()
+            with sqlite3.connect(str(db)) as conn:
+                conn.row_factory = sqlite3.Row
+                rows = conn.execute(
+                    """SELECT old_state, new_state, confidence, fire_count,
+                              session, transitioned_at
+                       FROM lesson_transitions
+                       WHERE lesson_desc = ? AND category = ?
+                       ORDER BY transitioned_at""",
+                    (target.description, target.category),
+                ).fetchall()
+                transitions = [dict(r) for r in rows]
         except Exception as e:
             _log.debug("Failed to query lesson_transitions: %s", e)
 

--- a/src/gradata/audit.py
+++ b/src/gradata/audit.py
@@ -1,0 +1,229 @@
+"""
+Audit Trail + Provenance — SQLite-backed rule provenance tracking.
+===================================================================
+SDK LAYER: Layer 0 (no Brain dependency). All functions take primitive
+paths so they can be used without instantiating a Brain object.
+Brain gets a thin 1-line trace() wrapper.
+
+Tracks which corrections led to which rules, enabling full lineage
+from correction → lesson → graduated rule.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from pathlib import Path
+
+_log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Write provenance
+# ---------------------------------------------------------------------------
+
+def write_provenance(
+    db_path: str | Path,
+    *,
+    rule_id: str,
+    correction_event_id: str | None,
+    session: int | None,
+    timestamp: str,
+    user_context: str | None,
+) -> None:
+    """Insert a provenance row linking a rule to a correction event.
+
+    Args:
+        db_path: Path to system.db.
+        rule_id: Stable rule ID (sha256 hash from inspection._make_rule_id).
+        correction_event_id: Event ID from events.jsonl that created this rule.
+        session: Session number when the graduation occurred.
+        timestamp: ISO timestamp of the graduation.
+        user_context: Optional context string (e.g. task type, working dir).
+    """
+    from gradata._db import get_connection
+
+    try:
+        with get_connection(db_path) as conn:
+            conn.execute(
+                "INSERT INTO rule_provenance "
+                "(rule_id, correction_event_id, session, timestamp, user_context) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (rule_id, correction_event_id, session, timestamp, user_context),
+            )
+    except Exception as e:
+        _log.debug("write_provenance failed: %s", e)
+
+
+# ---------------------------------------------------------------------------
+# Query provenance
+# ---------------------------------------------------------------------------
+
+def query_provenance(
+    db_path: str | Path,
+    *,
+    rule_id: str | None = None,
+    limit: int = 50,
+) -> list[dict]:
+    """Query the rule_provenance table.
+
+    Args:
+        db_path: Path to system.db.
+        rule_id: Filter by rule_id. If None, returns all rows.
+        limit: Max rows to return (default 50).
+
+    Returns:
+        List of provenance dicts with keys: id, rule_id, correction_event_id,
+        session, timestamp, user_context.
+    """
+    db = Path(db_path)
+    if not db.is_file():
+        return []
+
+    try:
+        conn = sqlite3.connect(str(db))
+        conn.row_factory = sqlite3.Row
+        if rule_id is not None:
+            rows = conn.execute(
+                "SELECT * FROM rule_provenance WHERE rule_id = ? ORDER BY id DESC LIMIT ?",
+                (rule_id, limit),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM rule_provenance ORDER BY id DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        conn.close()
+        return [dict(r) for r in rows]
+    except Exception as e:
+        _log.debug("query_provenance failed: %s", e)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Scan events.jsonl for specific IDs
+# ---------------------------------------------------------------------------
+
+def _scan_events_for_ids(
+    events_path: str | Path,
+    event_ids: list[str],
+) -> list[dict]:
+    """Scan events.jsonl for events matching the given IDs.
+
+    Args:
+        events_path: Path to events.jsonl file.
+        event_ids: List of event IDs to find.
+
+    Returns:
+        List of matching event dicts.
+    """
+    p = Path(events_path)
+    if not p.is_file():
+        return []
+
+    target_ids = set(event_ids)
+    found: list[dict] = []
+
+    try:
+        with p.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    evt = json.loads(line)
+                    if evt.get("id") in target_ids:
+                        found.append(evt)
+                        # Early exit if all found
+                        if len(found) == len(target_ids):
+                            break
+                except json.JSONDecodeError:
+                    continue
+    except Exception as e:
+        _log.debug("_scan_events_for_ids failed: %s", e)
+
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Full trace: provenance + events + transitions
+# ---------------------------------------------------------------------------
+
+def trace_rule(
+    db_path: str | Path,
+    events_path: str | Path,
+    lessons_path: str | Path,
+    rule_id: str,
+) -> dict:
+    """Full trace of a rule: provenance table, events fallback, transitions.
+
+    Args:
+        db_path: Path to system.db.
+        events_path: Path to events.jsonl.
+        lessons_path: Path to lessons.md.
+        rule_id: Stable rule ID to trace.
+
+    Returns:
+        Dict with keys: rule_id, rule, provenance, corrections, transitions.
+        Returns {"error": "..."} if rule_id not found in lessons.
+    """
+    from gradata.inspection import _load_lessons_from_path, _make_rule_id, _lesson_to_dict
+
+    lessons = _load_lessons_from_path(lessons_path)
+
+    # Find the lesson matching this rule_id
+    target = None
+    for lesson in lessons:
+        if _make_rule_id(lesson) == rule_id:
+            target = lesson
+            break
+
+    if target is None:
+        return {"error": f"Rule not found: {rule_id}"}
+
+    # Get provenance rows from SQLite
+    provenance = query_provenance(db_path, rule_id=rule_id)
+
+    # Get correction events — from provenance table first, fallback to lesson's IDs
+    correction_event_ids: list[str] = []
+    if provenance:
+        correction_event_ids = [
+            r["correction_event_id"] for r in provenance
+            if r.get("correction_event_id")
+        ]
+    if not correction_event_ids and target.correction_event_ids:
+        correction_event_ids = target.correction_event_ids
+
+    # Scan events.jsonl for the actual correction events
+    corrections: list[dict] = []
+    if correction_event_ids:
+        corrections = _scan_events_for_ids(events_path, correction_event_ids)
+
+    # Get transitions from SQLite
+    transitions: list[dict] = []
+    db = Path(db_path)
+    if db.is_file():
+        try:
+            conn = sqlite3.connect(str(db))
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                """SELECT old_state, new_state, confidence, fire_count,
+                          session, transitioned_at
+                   FROM lesson_transitions
+                   WHERE lesson_desc = ? AND category = ?
+                   ORDER BY transitioned_at""",
+                (target.description, target.category),
+            ).fetchall()
+            transitions = [dict(r) for r in rows]
+            conn.close()
+        except Exception as e:
+            _log.debug("Failed to query lesson_transitions: %s", e)
+
+    return {
+        "rule_id": rule_id,
+        "rule": _lesson_to_dict(target),
+        "provenance": provenance,
+        "corrections": corrections,
+        "transitions": transitions,
+    }

--- a/src/gradata/brain.py
+++ b/src/gradata/brain.py
@@ -720,6 +720,104 @@ class Brain:
                             lessons_path=self._find_lessons_path() or self.dir / "lessons.md",
                             output_format=output_format)
 
+    # ── Batch Approval at Session End ─────────────────────────────────
+
+    def pending_promotions(self) -> list[dict]:
+        """List rules that have graduated (PATTERN or RULE state).
+
+        Silent during work — call at session end to review what graduated.
+        Returns list of rule dicts with id, category, state, confidence, etc.
+        """
+        from gradata.inspection import list_rules
+        return list_rules(
+            db_path=self.db_path,
+            lessons_path=self._find_lessons_path() or self.dir / "lessons.md",
+        )
+
+    def approve_promotion(self, rule_id: str) -> dict:
+        """Explicitly endorse a graduated rule.
+
+        No-op on data — the rule already passed threshold and is persisted.
+        Emits a 'promotion.approved' event for audit trail.
+
+        Args:
+            rule_id: Stable rule ID from pending_promotions().
+
+        Returns:
+            {"approved": True} on success, {"error": "..."} if not found.
+        """
+        from gradata.inspection import _make_rule_id, _load_lessons_from_path
+
+        lessons_path = self._find_lessons_path() or self.dir / "lessons.md"
+        lessons = _load_lessons_from_path(lessons_path)
+        target = None
+        for lesson in lessons:
+            if _make_rule_id(lesson) == rule_id:
+                target = lesson
+                break
+        if target is None:
+            return {"error": f"Rule not found: {rule_id}"}
+
+        try:
+            self.bus.emit("promotion.approved", {
+                "rule_id": rule_id,
+                "category": target.category,
+                "description": target.description[:200],
+                "state": target.state.value,
+                "confidence": target.confidence,
+            })
+        except Exception as e:
+            logger.debug("promotion.approved emit failed: %s", e)
+
+        return {"approved": True}
+
+    def reject_promotion(self, rule_id: str) -> dict:
+        """Reject a graduated rule — demotes back to INSTINCT with confidence 0.40.
+
+        Rewrites lessons file with the demoted lesson. Emits 'promotion.rejected'.
+
+        Args:
+            rule_id: Stable rule ID from pending_promotions().
+
+        Returns:
+            {"rejected": True, "demoted_from": old_state} on success,
+            {"error": "..."} if not found.
+        """
+        from gradata.inspection import _make_rule_id, _load_lessons_from_path
+        from gradata.enhancements.self_improvement import format_lessons
+        from gradata._db import write_lessons_safe
+        from gradata._types import LessonState
+
+        lessons_path = self._find_lessons_path() or self.dir / "lessons.md"
+        lessons = _load_lessons_from_path(lessons_path)
+        target = None
+        for lesson in lessons:
+            if _make_rule_id(lesson) == rule_id:
+                target = lesson
+                break
+        if target is None:
+            return {"error": f"Rule not found: {rule_id}"}
+
+        old_state = target.state.value
+        target.state = LessonState.INSTINCT
+        target.confidence = 0.40
+
+        write_lessons_safe(lessons_path, format_lessons(lessons))
+
+        try:
+            self.bus.emit("promotion.rejected", {
+                "rule_id": rule_id,
+                "category": target.category,
+                "description": target.description[:200],
+                "demoted_from": old_state,
+                "new_state": "INSTINCT",
+                "confidence": 0.40,
+            })
+        except Exception as e:
+            logger.debug("promotion.rejected emit failed: %s", e)
+
+        return {"rejected": True, "demoted_from": old_state}
+
     # ── Events ─────────────────────────────────────────────────────────
 
     def emit(self, event_type: str, source: str, data: dict | None = None,

--- a/src/gradata/brain.py
+++ b/src/gradata/brain.py
@@ -695,6 +695,30 @@ class Brain:
         from gradata._core import brain_export_skills
         return brain_export_skills(self, output_dir=output_dir, min_state=min_state)
 
+    # ── Rule Inspection API ────────────────────────────────────────────
+
+    def rules(self, *, include_all: bool = False, category: str | None = None) -> list[dict]:
+        """List graduated brain rules. See gradata.inspection.list_rules."""
+        from gradata.inspection import list_rules
+        return list_rules(db_path=self.db_path,
+                          lessons_path=self._find_lessons_path() or self.dir / "lessons.md",
+                          include_all=include_all, category=category)
+
+    def explain(self, rule_id: str) -> dict:
+        """Trace a rule to its source corrections. See gradata.inspection.explain_rule."""
+        from gradata.inspection import explain_rule
+        return explain_rule(db_path=self.db_path,
+                            events_path=self.ctx.events_path if hasattr(self.ctx, "events_path") else self.dir / "events.jsonl",
+                            rule_id=rule_id,
+                            lessons_path=self._find_lessons_path() or self.dir / "lessons.md")
+
+    def export_data(self, *, format: str = "json") -> str:
+        """Export rules as JSON or YAML. See gradata.inspection.export_rules."""
+        from gradata.inspection import export_rules
+        return export_rules(db_path=self.db_path,
+                            lessons_path=self._find_lessons_path() or self.dir / "lessons.md",
+                            format=format)
+
     # ── Events ─────────────────────────────────────────────────────────
 
     def emit(self, event_type: str, source: str, data: dict | None = None,

--- a/src/gradata/brain.py
+++ b/src/gradata/brain.py
@@ -167,6 +167,10 @@ class Brain:
         # Cloud connection (None = local-only mode)
         self._cloud = None
 
+        # Per-brain salt for non-deterministic graduation thresholds
+        from gradata.security.brain_salt import load_or_create_salt
+        self._brain_salt = load_or_create_salt(self.dir)
+
     @property
     def session(self) -> int:
         """Current session number (from event log or loop-state.md)."""

--- a/src/gradata/brain.py
+++ b/src/gradata/brain.py
@@ -47,7 +47,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger("gradata")
 
 
-class Brain:
+from gradata.brain_inspection import BrainInspectionMixin
+
+
+class Brain(BrainInspectionMixin):
     """A personal AI brain backed by a directory of knowledge files."""
 
     def __init__(self, brain_dir: str | Path, working_dir: str | Path | None = None,
@@ -429,6 +432,7 @@ class Brain:
         self._query_budget.record("apply_rules")
         if self._query_budget.is_rate_exceeded("apply_rules"):
             logger.warning("Query budget exceeded for apply_rules")
+            return ""  # enforce: block injection when budget exhausted
         if self._cloud and self._cloud.connected:
             try:
                 return self._cloud.apply_rules(task, context)
@@ -465,27 +469,77 @@ class Brain:
 
     # ── Lesson Management ──────────────────────────────────────────────
 
-    def forget(self, description: str | None = None, category: str | None = None) -> int:
-        """Remove lessons matching description or category."""
-        if not description and not category:
-            raise ValueError("Provide at least one of description or category")
-        lessons_path = self._find_lessons_path()
-        if not lessons_path or not lessons_path.is_file():
-            return 0
+    def forget(self, what: str = "last") -> dict | list[dict]:
+        """Human-friendly way to undo lessons.
+
+        Examples:
+            brain.forget("last")           # most recent lesson
+            brain.forget("last 3")         # last 3 lessons
+            brain.forget("casual tone")    # fuzzy match description
+            brain.forget("all tone")       # everything in TONE category
+        """
         try:
             from gradata.enhancements.self_improvement import parse_lessons, format_lessons
         except ImportError:
-            return 0
+            return {"rolled_back": False, "error": "enhancements not installed"}
+        from gradata._types import LessonState
+        from gradata._db import write_lessons_safe
+
+        lessons_path = self._find_lessons_path()
+        if not lessons_path or not lessons_path.is_file():
+            return {"rolled_back": False, "error": "no lessons file"}
         lessons = parse_lessons(lessons_path.read_text(encoding="utf-8"))
-        before = len(lessons)
-        filtered = [l for l in lessons if not (
-            (description and description.lower() in l.description.lower()) or
-            (category and l.category.upper() == category.upper()))]
-        removed = before - len(filtered)
-        if removed > 0:
-            from gradata._db import write_lessons_safe
-            write_lessons_safe(lessons_path, format_lessons(filtered))
-        return removed
+
+        what = what.strip()
+        wl = what.lower()
+
+        # Resolve target indices
+        active = [(i, l) for i, l in enumerate(lessons)
+                  if l.state in (LessonState.INSTINCT, LessonState.PATTERN, LessonState.RULE)]
+        targets: list[int] = []
+
+        if wl == "last" or wl.startswith("last "):
+            parts = wl.split()
+            n = int(parts[1]) if len(parts) == 2 and parts[1].isdigit() else 1
+            if not active:
+                return {"rolled_back": False, "error": "no active lessons"}
+            targets = [i for i, _ in active[-n:]]
+
+        elif wl.startswith("all "):
+            cat = what[4:].strip()
+            targets = [i for i, l in active if l.category.upper() == cat.upper()]
+            if not targets:
+                return {"rolled_back": False, "error": f"no active lessons in '{cat}'"}
+
+        else:
+            # Fuzzy match on description — single target
+            return self.rollback(description=what)
+
+        # Batch kill: mutate in memory, write once
+        results = []
+        for idx in targets:
+            lesson = lessons[idx]
+            old_state, old_conf = lesson.state.value, lesson.confidence
+            lesson.state, lesson.confidence = LessonState.KILLED, 0.0
+            results.append({"rolled_back": True, "lesson_index": idx,
+                            "category": lesson.category, "description": lesson.description,
+                            "previous_state": old_state, "previous_confidence": old_conf})
+        write_lessons_safe(lessons_path, format_lessons(lessons))
+
+        for r in results:
+            try:
+                self.emit("LESSON_CHANGE", "brain.forget", {
+                    "action": "rolled_back", "lesson_index": r["lesson_index"],
+                    "lesson_category": r["category"],
+                    "lesson_description": r["description"][:200],
+                    "previous_state": r["previous_state"],
+                    "previous_confidence": r["previous_confidence"],
+                    "kill_reason": "manual_forget",
+                }, [f"category:{r['category']}", "rollback"], 0)
+            except Exception:
+                pass
+
+        return results[0] if len(results) == 1 else results
 
     def rollback(self, lesson_id: int | None = None, description: str | None = None,
                  category: str | None = None) -> dict:
@@ -707,137 +761,10 @@ class Brain:
         from gradata._core import brain_export_skills
         return brain_export_skills(self, output_dir=output_dir, min_state=min_state)
 
-    # ── Rule Inspection API ────────────────────────────────────────────
-
-    def rules(self, *, include_all: bool = False, category: str | None = None) -> list[dict]:
-        """List graduated brain rules. See gradata.inspection.list_rules."""
-        from gradata.inspection import list_rules
-        return list_rules(db_path=self.db_path,
-                          lessons_path=self._find_lessons_path() or self.dir / "lessons.md",
-                          include_all=include_all, category=category)
-
-    def explain(self, rule_id: str) -> dict:
-        """Trace a rule to its source corrections. See gradata.inspection.explain_rule."""
-        from gradata.inspection import explain_rule
-        return explain_rule(db_path=self.db_path,
-                            events_path=self.ctx.events_jsonl if hasattr(self.ctx, "events_jsonl") else self.dir / "events.jsonl",
-                            rule_id=rule_id,
-                            lessons_path=self._find_lessons_path() or self.dir / "lessons.md")
-
-    def trace(self, rule_id: str) -> dict:
-        """Trace a rule's full provenance chain. See gradata.audit.trace_rule."""
-        from gradata.audit import trace_rule
-        return trace_rule(
-            db_path=self.db_path,
-            events_path=self.ctx.events_jsonl if hasattr(self.ctx, "events_jsonl") else self.dir / "events.jsonl",
-            lessons_path=self._find_lessons_path() or self.dir / "lessons.md",
-            rule_id=rule_id,
-        )
-
-    def export_data(self, *, output_format: str = "json") -> str:
-        """Export rules as JSON or YAML. See gradata.inspection.export_rules."""
-        from gradata.inspection import export_rules
-        return export_rules(db_path=self.db_path,
-                            lessons_path=self._find_lessons_path() or self.dir / "lessons.md",
-                            output_format=output_format)
-
-    # ── Batch Approval at Session End ─────────────────────────────────
-
-    def pending_promotions(self) -> list[dict]:
-        """List rules that have graduated (PATTERN or RULE state).
-
-        Silent during work — call at session end to review what graduated.
-        Returns list of rule dicts with id, category, state, confidence, etc.
-        """
-        from gradata.inspection import list_rules
-        return list_rules(
-            db_path=self.db_path,
-            lessons_path=self._find_lessons_path() or self.dir / "lessons.md",
-        )
-
-    def approve_promotion(self, rule_id: str) -> dict:
-        """Explicitly endorse a graduated rule.
-
-        No-op on data — the rule already passed threshold and is persisted.
-        Emits a 'promotion.approved' event for audit trail.
-
-        Args:
-            rule_id: Stable rule ID from pending_promotions().
-
-        Returns:
-            {"approved": True} on success, {"error": "..."} if not found.
-        """
-        from gradata.inspection import _make_rule_id, _load_lessons_from_path
-
-        lessons_path = self._find_lessons_path() or self.dir / "lessons.md"
-        lessons = _load_lessons_from_path(lessons_path)
-        target = None
-        for lesson in lessons:
-            if _make_rule_id(lesson) == rule_id:
-                target = lesson
-                break
-        if target is None:
-            return {"error": f"Rule not found: {rule_id}"}
-
-        try:
-            self.bus.emit("promotion.approved", {
-                "rule_id": rule_id,
-                "category": target.category,
-                "description": target.description[:200],
-                "state": target.state.value,
-                "confidence": target.confidence,
-            })
-        except Exception as e:
-            logger.debug("promotion.approved emit failed: %s", e)
-
-        return {"approved": True}
-
-    def reject_promotion(self, rule_id: str) -> dict:
-        """Reject a graduated rule — demotes back to INSTINCT with confidence 0.40.
-
-        Rewrites lessons file with the demoted lesson. Emits 'promotion.rejected'.
-
-        Args:
-            rule_id: Stable rule ID from pending_promotions().
-
-        Returns:
-            {"rejected": True, "demoted_from": old_state} on success,
-            {"error": "..."} if not found.
-        """
-        from gradata.inspection import _make_rule_id, _load_lessons_from_path
-        from gradata.enhancements.self_improvement import format_lessons
-        from gradata._db import write_lessons_safe
-        from gradata._types import LessonState
-
-        lessons_path = self._find_lessons_path() or self.dir / "lessons.md"
-        lessons = _load_lessons_from_path(lessons_path)
-        target = None
-        for lesson in lessons:
-            if _make_rule_id(lesson) == rule_id:
-                target = lesson
-                break
-        if target is None:
-            return {"error": f"Rule not found: {rule_id}"}
-
-        old_state = target.state.value
-        target.state = LessonState.INSTINCT
-        target.confidence = 0.40
-
-        write_lessons_safe(lessons_path, format_lessons(lessons))
-
-        try:
-            self.bus.emit("promotion.rejected", {
-                "rule_id": rule_id,
-                "category": target.category,
-                "description": target.description[:200],
-                "demoted_from": old_state,
-                "new_state": "INSTINCT",
-                "confidence": 0.40,
-            })
-        except Exception as e:
-            logger.debug("promotion.rejected emit failed: %s", e)
-
-        return {"rejected": True, "demoted_from": old_state}
+    # ── Rule Inspection API + Batch Approval ─────────────────────────
+    # Provided by BrainInspectionMixin (brain_inspection.py):
+    #   rules(), explain(), trace(), export_data(),
+    #   pending_promotions(), approve_promotion(), reject_promotion()
 
     # ── Events ─────────────────────────────────────────────────────────
 

--- a/src/gradata/brain.py
+++ b/src/gradata/brain.py
@@ -708,16 +708,16 @@ class Brain:
         """Trace a rule to its source corrections. See gradata.inspection.explain_rule."""
         from gradata.inspection import explain_rule
         return explain_rule(db_path=self.db_path,
-                            events_path=self.ctx.events_path if hasattr(self.ctx, "events_path") else self.dir / "events.jsonl",
+                            events_path=self.ctx.events_jsonl if hasattr(self.ctx, "events_jsonl") else self.dir / "events.jsonl",
                             rule_id=rule_id,
                             lessons_path=self._find_lessons_path() or self.dir / "lessons.md")
 
-    def export_data(self, *, format: str = "json") -> str:
+    def export_data(self, *, output_format: str = "json") -> str:
         """Export rules as JSON or YAML. See gradata.inspection.export_rules."""
         from gradata.inspection import export_rules
         return export_rules(db_path=self.db_path,
                             lessons_path=self._find_lessons_path() or self.dir / "lessons.md",
-                            format=format)
+                            output_format=output_format)
 
     # ── Events ─────────────────────────────────────────────────────────
 

--- a/src/gradata/brain.py
+++ b/src/gradata/brain.py
@@ -713,6 +713,16 @@ class Brain:
                             rule_id=rule_id,
                             lessons_path=self._find_lessons_path() or self.dir / "lessons.md")
 
+    def trace(self, rule_id: str) -> dict:
+        """Trace a rule's full provenance chain. See gradata.audit.trace_rule."""
+        from gradata.audit import trace_rule
+        return trace_rule(
+            db_path=self.db_path,
+            events_path=self.ctx.events_jsonl if hasattr(self.ctx, "events_jsonl") else self.dir / "events.jsonl",
+            lessons_path=self._find_lessons_path() or self.dir / "lessons.md",
+            rule_id=rule_id,
+        )
+
     def export_data(self, *, output_format: str = "json") -> str:
         """Export rules as JSON or YAML. See gradata.inspection.export_rules."""
         from gradata.inspection import export_rules

--- a/src/gradata/brain.py
+++ b/src/gradata/brain.py
@@ -164,6 +164,10 @@ class Brain:
         except ImportError:
             pass
 
+        # Query budget — sliding-window rate limiter
+        from gradata.security.query_budget import QueryBudget
+        self._query_budget = QueryBudget()
+
         # Cloud connection (None = local-only mode)
         self._cloud = None
 
@@ -422,6 +426,9 @@ class Brain:
     def apply_brain_rules(self, task: str, context: dict | None = None,
                           agent_type: str | None = None) -> str:
         """Get applicable brain rules for a task, formatted for prompt injection."""
+        self._query_budget.record("apply_rules")
+        if self._query_budget.is_rate_exceeded("apply_rules"):
+            logger.warning("Query budget exceeded for apply_rules")
         if self._cloud and self._cloud.connected:
             try:
                 return self._cloud.apply_rules(task, context)

--- a/src/gradata/brain.py
+++ b/src/gradata/brain.py
@@ -313,13 +313,14 @@ class Brain:
     def correct(self, draft: str, final: str, category: str | None = None,
                 context: dict | None = None, session: int | None = None,
                 agent_type: str | None = None, approval_required: bool = False,
-                dry_run: bool = False, min_severity: str = "as-is") -> dict:
+                dry_run: bool = False, min_severity: str = "as-is",
+                scope: str | None = None) -> dict:
         """Record a correction: user edited draft into final version."""
         from gradata._core import brain_correct
         return brain_correct(self, draft, final, category=category, context=context,
                              session=session, agent_type=agent_type,
                              approval_required=approval_required, dry_run=dry_run,
-                             min_severity=min_severity)
+                             min_severity=min_severity, scope=scope)
 
     def end_session(self, session_corrections: list[dict] | None = None,
                     session_type: str = "full", machine_mode: bool | None = None,

--- a/src/gradata/brain_inspection.py
+++ b/src/gradata/brain_inspection.py
@@ -1,0 +1,166 @@
+"""Brain inspection mixin — rule inspection, approval, and export methods.
+
+Extracted from Brain to keep brain.py under 500 lines.  All methods access
+the same attributes (self.db_path, self.dir, self.ctx, self.bus, self.emit,
+self._find_lessons_path) so they work transparently via multiple inheritance.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class BrainInspectionMixin:
+    """Mixin providing rule inspection, export, and batch approval methods.
+
+    Must be mixed into Brain which provides: db_path, dir, ctx, bus,
+    _find_lessons_path(), emit().
+    """
+
+    # Declared for Pyright — actual values come from Brain.__init__
+    db_path: Path
+    dir: Path
+    ctx: Any
+    bus: Any
+
+    def _find_lessons_path(self) -> Path | None: ...
+    def emit(self, event_type: str, source: str, data: dict | None = None,
+             tags: list | None = None, session: int | None = None) -> dict: ...
+
+    # ── Rule Inspection API ────────────────────────────────────────────
+
+    def rules(self, *, include_all: bool = False, category: str | None = None) -> list[dict]:
+        """List graduated brain rules. See gradata.inspection.list_rules."""
+        from gradata.inspection import list_rules
+        return list_rules(db_path=self.db_path,
+                          lessons_path=self._find_lessons_path() or self.dir / "lessons.md",
+                          include_all=include_all, category=category)
+
+    def explain(self, rule_id: str) -> dict:
+        """Trace a rule to its source corrections. See gradata.inspection.explain_rule."""
+        from gradata.inspection import explain_rule
+        return explain_rule(db_path=self.db_path,
+                            events_path=self.ctx.events_jsonl if hasattr(self.ctx, "events_jsonl") else self.dir / "events.jsonl",
+                            rule_id=rule_id,
+                            lessons_path=self._find_lessons_path() or self.dir / "lessons.md")
+
+    def trace(self, rule_id: str) -> dict:
+        """Trace a rule's full provenance chain. See gradata.audit.trace_rule."""
+        from gradata.audit import trace_rule
+        return trace_rule(
+            db_path=self.db_path,
+            events_path=self.ctx.events_jsonl if hasattr(self.ctx, "events_jsonl") else self.dir / "events.jsonl",
+            lessons_path=self._find_lessons_path() or self.dir / "lessons.md",
+            rule_id=rule_id,
+        )
+
+    def export_data(self, *, output_format: str = "json") -> str:
+        """Export rules as JSON or YAML. See gradata.inspection.export_rules."""
+        from gradata.inspection import export_rules
+        return export_rules(db_path=self.db_path,
+                            lessons_path=self._find_lessons_path() or self.dir / "lessons.md",
+                            output_format=output_format)
+
+    # ── Batch Approval at Session End ─────────────────────────────────
+
+    def pending_promotions(self) -> list[dict]:
+        """List rules that have graduated (PATTERN or RULE state).
+
+        Silent during work — call at session end to review what graduated.
+        Returns list of rule dicts with id, category, state, confidence, etc.
+        """
+        from gradata.inspection import list_rules
+        return list_rules(
+            db_path=self.db_path,
+            lessons_path=self._find_lessons_path() or self.dir / "lessons.md",
+        )
+
+    def approve_promotion(self, rule_id: str) -> dict:
+        """Explicitly endorse a graduated rule — persists reviewed flag to disk.
+
+        Args:
+            rule_id: Stable rule ID from pending_promotions().
+
+        Returns:
+            {"approved": True} on success, {"error": "..."} if not found.
+        """
+        from gradata.inspection import _make_rule_id, _load_lessons_from_path
+        from gradata.enhancements.self_improvement import format_lessons
+        from gradata._db import write_lessons_safe
+
+        lessons_path = self._find_lessons_path() or self.dir / "lessons.md"
+        lessons = _load_lessons_from_path(lessons_path)
+        target = None
+        for lesson in lessons:
+            if _make_rule_id(lesson) == rule_id:
+                target = lesson
+                break
+        if target is None:
+            return {"error": f"Rule not found: {rule_id}"}
+
+        target.pending_approval = False
+        write_lessons_safe(lessons_path, format_lessons(lessons))
+
+        try:
+            self.emit("PROMOTION_APPROVED", "brain.approve_promotion", {
+                "rule_id": rule_id,
+                "category": target.category,
+                "description": target.description[:200],
+                "state": target.state.value,
+                "confidence": target.confidence,
+            })
+        except Exception as e:
+            logger.debug("promotion.approved emit failed: %s", e)
+
+        return {"approved": True}
+
+    def reject_promotion(self, rule_id: str) -> dict:
+        """Reject a graduated rule — demotes back to INSTINCT with confidence 0.40.
+
+        Rewrites lessons file with the demoted lesson. Emits 'promotion.rejected'.
+
+        Args:
+            rule_id: Stable rule ID from pending_promotions().
+
+        Returns:
+            {"rejected": True, "demoted_from": old_state} on success,
+            {"error": "..."} if not found.
+        """
+        from gradata.inspection import _make_rule_id, _load_lessons_from_path
+        from gradata.enhancements.self_improvement import format_lessons
+        from gradata._db import write_lessons_safe
+        from gradata._types import LessonState
+
+        lessons_path = self._find_lessons_path() or self.dir / "lessons.md"
+        lessons = _load_lessons_from_path(lessons_path)
+        target = None
+        for lesson in lessons:
+            if _make_rule_id(lesson) == rule_id:
+                target = lesson
+                break
+        if target is None:
+            return {"error": f"Rule not found: {rule_id}"}
+
+        old_state = target.state.value
+        target.state = LessonState.INSTINCT
+        target.confidence = 0.40
+
+        write_lessons_safe(lessons_path, format_lessons(lessons))
+
+        try:
+            self.emit("PROMOTION_REJECTED", "brain.reject_promotion", {
+                "rule_id": rule_id,
+                "category": target.category,
+                "description": target.description[:200],
+                "demoted_from": old_state,
+                "new_state": "INSTINCT",
+                "confidence": 0.40,
+            })
+        except Exception as e:
+            logger.debug("promotion.rejected emit failed: %s", e)
+
+        return {"rejected": True, "demoted_from": old_state}

--- a/src/gradata/enhancements/self_improvement.py
+++ b/src/gradata/enhancements/self_improvement.py
@@ -659,6 +659,7 @@ def graduate(
     maturity: str = "INFANT",
     renter: bool = False,
     machine_mode: bool = False,
+    salt: str = "",
 ) -> tuple[list[Lesson], list[Lesson]]:
     """Apply state transitions and split into active vs graduated.
 
@@ -678,7 +679,16 @@ def graduate(
         maturity: Brain maturity phase for kill-switch thresholds.
         renter: If True, skip all mutations (renter mode: lessons frozen).
         machine_mode: If True, use extended kill limits for machine contexts.
+        salt: Per-brain salt for non-deterministic threshold jitter (+/-5%).
     """
+    # Compute effective thresholds (salted or default)
+    if salt:
+        from gradata.security.brain_salt import salt_threshold
+        eff_pattern_threshold = salt_threshold(PATTERN_THRESHOLD, salt, "PATTERN")
+        eff_rule_threshold = salt_threshold(RULE_THRESHOLD, salt, "RULE")
+    else:
+        eff_pattern_threshold = PATTERN_THRESHOLD
+        eff_rule_threshold = RULE_THRESHOLD
     if renter:
         active = [l for l in lessons if l.state in (LessonState.INSTINCT, LessonState.PATTERN)]
         graduated = [l for l in lessons if l.state not in (LessonState.INSTINCT, LessonState.PATTERN)]
@@ -700,10 +710,10 @@ def graduate(
         # large confidence jump (possible runaway boosting).
         if hasattr(lesson, '_pre_session_confidence'):
             jump = lesson.confidence - lesson._pre_session_confidence
-            if jump > PATTERN_THRESHOLD:
+            if jump > eff_pattern_threshold:
                 _log.warning(
                     "Safety assertion: confidence jump %.2f exceeds PATTERN_THRESHOLD %.2f for %s: %s",
-                    jump, PATTERN_THRESHOLD, lesson.category, lesson.description[:60],
+                    jump, eff_pattern_threshold, lesson.category, lesson.description[:60],
                 )
 
         if lesson.pending_approval:
@@ -757,7 +767,7 @@ def graduate(
         # Promote PATTERN -> RULE (with adversarial gates + wording refinement)
         if (
             lesson.state == LessonState.PATTERN
-            and lesson.confidence >= RULE_THRESHOLD
+            and lesson.confidence >= eff_rule_threshold
             and lesson.fire_count >= MIN_APPLICATIONS_FOR_RULE
         ):
             blocked = False
@@ -825,7 +835,7 @@ def graduate(
         # Promote INSTINCT -> PATTERN
         if (
             lesson.state == LessonState.INSTINCT
-            and lesson.confidence >= PATTERN_THRESHOLD
+            and lesson.confidence >= eff_pattern_threshold
             and lesson.fire_count >= MIN_APPLICATIONS_FOR_PATTERN
         ):
             lesson.state = transition(lesson.state, "promote")
@@ -834,7 +844,7 @@ def graduate(
         # Demote PATTERN -> INSTINCT
         if (
             lesson.state == LessonState.PATTERN
-            and lesson.confidence < PATTERN_THRESHOLD
+            and lesson.confidence < eff_pattern_threshold
         ):
             lesson.state = transition(lesson.state, "demote")
             continue

--- a/src/gradata/enhancements/self_improvement.py
+++ b/src/gradata/enhancements/self_improvement.py
@@ -283,6 +283,7 @@ def parse_lessons(text: str) -> list[Lesson]:
         pending_approval = False
         parent_meta_rule_id: str | None = None
         memory_ids: list[str] = []
+        scope_json: str = ""
         domain_scores: dict = {}
         j = i + 1
         while j < len(lines) and lines[j].startswith("  "):
@@ -302,6 +303,8 @@ def parse_lessons(text: str) -> list[Lesson]:
                 parent_meta_rule_id = meta_line[len("Parent meta-rule:"):].strip() or None
             elif meta_line.startswith("Memory links:"):
                 memory_ids = [x.strip() for x in meta_line[len("Memory links:"):].strip().split(",") if x.strip()]
+            elif meta_line.startswith("Scope:"):
+                scope_json = meta_line[len("Scope:"):].strip()
             elif meta_line.startswith("Domain scores:"):
                 import json as _json
                 try:
@@ -325,6 +328,7 @@ def parse_lessons(text: str) -> list[Lesson]:
             fire_count=fire_count,
             sessions_since_fire=sessions_since_fire,
             misfire_count=misfire_count,
+            scope_json=scope_json,
             agent_type=agent_type,
             kill_reason=kill_reason,
             correction_event_ids=correction_event_ids,
@@ -691,6 +695,18 @@ def graduate(
         if lesson.pending_approval:
             continue  # Awaiting human review — skip graduation entirely
 
+        # ONE_OFF scoped lessons never graduate past INSTINCT
+        if lesson.scope_json:
+            try:
+                import json as _json
+                _scope = _json.loads(lesson.scope_json)
+                if _scope.get("correction_scope") == "one_off":
+                    # Block promotion from INSTINCT; block PATTERN->RULE too
+                    if lesson.state in (LessonState.INSTINCT, LessonState.PATTERN):
+                        continue
+            except (ValueError, TypeError):
+                pass
+
         # UNTESTABLE lessons: check if they should be killed (enough idle sessions)
         if lesson.state == LessonState.UNTESTABLE:
             if lesson.sessions_since_fire >= kill_limit + 5:
@@ -897,6 +913,9 @@ def format_lessons(lessons: list[Lesson]) -> str:
 
         if lesson.memory_ids:
             lines.append(f"  Memory links: {','.join(lesson.memory_ids)}")
+
+        if lesson.scope_json:
+            lines.append(f"  Scope: {lesson.scope_json}")
 
         if lesson.domain_scores:
             import json as _json

--- a/src/gradata/enhancements/self_improvement.py
+++ b/src/gradata/enhancements/self_improvement.py
@@ -282,6 +282,7 @@ def parse_lessons(text: str) -> list[Lesson]:
         correction_event_ids: list[str] = []
         pending_approval = False
         parent_meta_rule_id: str | None = None
+        metadata_obj = None
         memory_ids: list[str] = []
         scope_json: str = ""
         domain_scores: dict = {}
@@ -311,6 +312,14 @@ def parse_lessons(text: str) -> list[Lesson]:
                     domain_scores = _json.loads(meta_line[len("Domain scores:"):].strip())
                 except _json.JSONDecodeError:
                     domain_scores = {}
+            elif meta_line.startswith("Metadata:"):
+                import json as _json_md
+                try:
+                    _md_dict = _json_md.loads(meta_line[len("Metadata:"):].strip())
+                    from gradata._types import RuleMetadata as _RM
+                    metadata_obj = _RM(**{k: v for k, v in _md_dict.items() if k in _RM.__dataclass_fields__})
+                except (ValueError, TypeError, _json_md.JSONDecodeError):
+                    metadata_obj = None
             meta_m = _META_RE.search(meta_line)
             if meta_m:
                 fire_count = int(meta_m.group(1))
@@ -318,7 +327,7 @@ def parse_lessons(text: str) -> list[Lesson]:
                 misfire_count = int(meta_m.group(3))
             j += 1
 
-        lessons.append(Lesson(
+        _lesson = Lesson(
             date=date_str,
             state=state,
             confidence=confidence,
@@ -336,7 +345,10 @@ def parse_lessons(text: str) -> list[Lesson]:
             parent_meta_rule_id=parent_meta_rule_id,
             memory_ids=memory_ids,
             domain_scores=domain_scores,
-        ))
+        )
+        if metadata_obj is not None:
+            _lesson.metadata = metadata_obj
+        lessons.append(_lesson)
         i = j if j > i + 1 else i + 1
 
     return lessons
@@ -448,6 +460,7 @@ def update_confidence(
     maturity: str = "INFANT",
     renter: bool = False,
     machine_mode: bool | None = None,
+    salt: str = "",
 ) -> list[Lesson]:
     """Update confidence for each lesson based on session corrections.
 
@@ -624,24 +637,33 @@ def update_confidence(
     # Inline promotion/demotion after confidence updates
     # (UNTESTABLE detection already handled above — don't re-run
     # full graduate() which would kill newly-flagged UNTESTABLE lessons)
+    # Use salted thresholds consistent with graduate()
+    if salt:
+        from gradata.security.brain_salt import salt_threshold
+        _uc_pattern_thr = salt_threshold(PATTERN_THRESHOLD, salt, "PATTERN")
+        _uc_rule_thr = salt_threshold(RULE_THRESHOLD, salt, "RULE")
+    else:
+        _uc_pattern_thr = PATTERN_THRESHOLD
+        _uc_rule_thr = RULE_THRESHOLD
+
     for lesson in lessons:
         if lesson.state in (LessonState.KILLED, LessonState.ARCHIVED, LessonState.UNTESTABLE):
             continue
         # Promote PATTERN -> RULE
         if (
             lesson.state == LessonState.PATTERN
-            and lesson.confidence >= RULE_THRESHOLD
+            and lesson.confidence >= _uc_rule_thr
             and lesson.fire_count >= MIN_APPLICATIONS_FOR_RULE
         ) or (
             lesson.state == LessonState.INSTINCT
-            and lesson.confidence >= PATTERN_THRESHOLD
+            and lesson.confidence >= _uc_pattern_thr
             and lesson.fire_count >= MIN_APPLICATIONS_FOR_PATTERN
         ):
             lesson.state = transition(lesson.state, "promote")
         # Demote PATTERN -> INSTINCT
         elif (
             lesson.state == LessonState.PATTERN
-            and lesson.confidence < PATTERN_THRESHOLD
+            and lesson.confidence < _uc_pattern_thr
         ):
             lesson.state = transition(lesson.state, "demote")
 
@@ -708,8 +730,9 @@ def graduate(
 
         # Safety assertion: warn if a single session caused an unusually
         # large confidence jump (possible runaway boosting).
-        if hasattr(lesson, '_pre_session_confidence'):
-            jump = lesson.confidence - lesson._pre_session_confidence
+        pre_conf = getattr(lesson, '_pre_session_confidence', None)
+        if isinstance(pre_conf, (int, float)):
+            jump = lesson.confidence - pre_conf
             if jump > eff_pattern_threshold:
                 _log.warning(
                     "Safety assertion: confidence jump %.2f exceeds PATTERN_THRESHOLD %.2f for %s: %s",
@@ -720,14 +743,14 @@ def graduate(
             continue  # Awaiting human review — skip graduation entirely
 
         # ONE_OFF scoped lessons never graduate past INSTINCT
+        block_promotion = False
         if lesson.scope_json:
             try:
                 import json as _json
                 _scope = _json.loads(lesson.scope_json)
                 if _scope.get("correction_scope") == "one_off":
-                    # Block promotion from INSTINCT; block PATTERN->RULE too
                     if lesson.state in (LessonState.INSTINCT, LessonState.PATTERN):
-                        continue
+                        block_promotion = True
             except (ValueError, TypeError):
                 pass
 
@@ -766,7 +789,8 @@ def graduate(
 
         # Promote PATTERN -> RULE (with adversarial gates + wording refinement)
         if (
-            lesson.state == LessonState.PATTERN
+            not block_promotion
+            and lesson.state == LessonState.PATTERN
             and lesson.confidence >= eff_rule_threshold
             and lesson.fire_count >= MIN_APPLICATIONS_FOR_RULE
         ):
@@ -834,7 +858,8 @@ def graduate(
 
         # Promote INSTINCT -> PATTERN
         if (
-            lesson.state == LessonState.INSTINCT
+            not block_promotion
+            and lesson.state == LessonState.INSTINCT
             and lesson.confidence >= eff_pattern_threshold
             and lesson.fire_count >= MIN_APPLICATIONS_FOR_PATTERN
         ):
@@ -944,6 +969,12 @@ def format_lessons(lessons: list[Lesson]) -> str:
         if lesson.domain_scores:
             import json as _json
             lines.append(f"  Domain scores: {_json.dumps(lesson.domain_scores)}")
+
+        if hasattr(lesson, "metadata") and lesson.metadata is not None:
+            import json as _json_meta
+            md = lesson.metadata.to_dict() if hasattr(lesson.metadata, "to_dict") else {}
+            if any(v for v in md.values() if v and v != 0.5):  # only write non-default
+                lines.append(f"  Metadata: {_json_meta.dumps(md)}")
 
         lines.append("")  # blank line between lessons
 

--- a/src/gradata/enhancements/self_improvement.py
+++ b/src/gradata/enhancements/self_improvement.py
@@ -667,7 +667,11 @@ def graduate(
       - graduated = RULE + UNTESTABLE + KILLED + ARCHIVED (terminal or proven)
 
     SPEC guardrail: no promotion from silence. fire_count must meet
-    minimum thresholds even if confidence is high enough.
+    minimum thresholds even if confidence is high enough:
+      - INSTINCT -> PATTERN requires fire_count >= 3 (MIN_APPLICATIONS_FOR_PATTERN).
+      - PATTERN -> RULE requires fire_count >= 5 (MIN_APPLICATIONS_FOR_RULE).
+    A single session cannot fast-track promotion; the fire-count gates are
+    non-bypassable regardless of confidence level.
 
     Args:
         lessons: Lessons to evaluate for promotion/demotion/kill.
@@ -691,6 +695,16 @@ def graduate(
     for lesson in lessons:
         if lesson.state in (LessonState.KILLED, LessonState.ARCHIVED):
             continue
+
+        # Safety assertion: warn if a single session caused an unusually
+        # large confidence jump (possible runaway boosting).
+        if hasattr(lesson, '_pre_session_confidence'):
+            jump = lesson.confidence - lesson._pre_session_confidence
+            if jump > PATTERN_THRESHOLD:
+                _log.warning(
+                    "Safety assertion: confidence jump %.2f exceeds PATTERN_THRESHOLD %.2f for %s: %s",
+                    jump, PATTERN_THRESHOLD, lesson.category, lesson.description[:60],
+                )
 
         if lesson.pending_approval:
             continue  # Awaiting human review — skip graduation entirely

--- a/src/gradata/inspection.py
+++ b/src/gradata/inspection.py
@@ -8,7 +8,6 @@ a Brain object. Brain gets thin 1-2 line wrappers.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 import sqlite3
@@ -16,18 +15,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from gradata._types import ELIGIBLE_STATES, Lesson, LessonState
+from gradata.rules.rule_engine import _make_rule_id
 
 _log = logging.getLogger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _make_rule_id(lesson: Lesson) -> str:
-    """Generate a stable, deterministic ID from category + description."""
-    key = f"{lesson.category}:{lesson.description}"
-    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:12]
 
 
 def _load_lessons_from_path(lessons_path: Path | str) -> list[Lesson]:

--- a/src/gradata/inspection.py
+++ b/src/gradata/inspection.py
@@ -32,7 +32,7 @@ def _load_lessons_from_path(lessons_path: Path | str) -> list[Lesson]:
 
 def _lesson_to_dict(lesson: Lesson) -> dict:
     """Convert a Lesson dataclass to a serializable dict with a stable ID."""
-    return {
+    d = {
         "id": _make_rule_id(lesson),
         "date": lesson.date,
         "state": lesson.state.value,
@@ -45,6 +45,9 @@ def _lesson_to_dict(lesson: Lesson) -> dict:
         "misfire_count": lesson.misfire_count,
         "correction_event_ids": lesson.correction_event_ids,
     }
+    if hasattr(lesson, "metadata") and lesson.metadata is not None:
+        d["metadata"] = lesson.metadata.to_dict() if hasattr(lesson.metadata, "to_dict") else lesson.metadata
+    return d
 
 
 # ---------------------------------------------------------------------------

--- a/src/gradata/inspection.py
+++ b/src/gradata/inspection.py
@@ -83,15 +83,15 @@ def list_rules(
     lessons = _load_lessons_from_path(lessons_path)
 
     if not include_all:
-        lessons = [l for l in lessons if l.state in ELIGIBLE_STATES]
+        lessons = [lesson for lesson in lessons if lesson.state in ELIGIBLE_STATES]
 
     if category:
-        lessons = [l for l in lessons if l.category.upper() == category.upper()]
+        lessons = [lesson for lesson in lessons if lesson.category.upper() == category.upper()]
 
     # Sort by confidence descending
-    lessons.sort(key=lambda l: l.confidence, reverse=True)
+    lessons.sort(key=lambda lesson: lesson.confidence, reverse=True)
 
-    return [_lesson_to_dict(l) for l in lessons]
+    return [_lesson_to_dict(lesson) for lesson in lessons]
 
 
 def explain_rule(
@@ -105,7 +105,7 @@ def explain_rule(
 
     Args:
         db_path: Path to system.db.
-        events_path: Path to events.jsonl.
+        events_path: Reserved for future provenance event lookup.
         rule_id: The stable rule ID (from list_rules).
         lessons_path: Path to lessons.md.
 
@@ -132,18 +132,17 @@ def explain_rule(
     db = Path(db_path)
     if db.is_file():
         try:
-            conn = sqlite3.connect(str(db))
-            conn.row_factory = sqlite3.Row
-            rows = conn.execute(
-                """SELECT old_state, new_state, confidence, fire_count,
-                          session, transitioned_at
-                   FROM lesson_transitions
-                   WHERE lesson_desc = ? AND category = ?
-                   ORDER BY transitioned_at""",
-                (target.description, target.category),
-            ).fetchall()
-            transitions = [dict(r) for r in rows]
-            conn.close()
+            with sqlite3.connect(str(db)) as conn:
+                conn.row_factory = sqlite3.Row
+                rows = conn.execute(
+                    """SELECT old_state, new_state, confidence, fire_count,
+                              session, transitioned_at
+                       FROM lesson_transitions
+                       WHERE lesson_desc = ? AND category = ?
+                       ORDER BY transitioned_at""",
+                    (target.description, target.category),
+                ).fetchall()
+                transitions = [dict(r) for r in rows]
         except Exception as e:
             _log.debug("Failed to query lesson_transitions: %s", e)
 
@@ -155,20 +154,20 @@ def export_rules(
     *,
     db_path: Path | str,
     lessons_path: Path | str,
-    format: str = "json",
+    output_format: str = "json",
 ) -> str:
     """Export rules in the specified format.
 
     Args:
         db_path: Path to system.db.
         lessons_path: Path to lessons.md.
-        format: "json" or "yaml". Raises ValueError for unsupported formats.
+        output_format: "json" or "yaml". Raises ValueError for unsupported formats.
 
     Returns:
         Serialized string in the requested format.
     """
-    if format not in ("json", "yaml"):
-        raise ValueError(f"Unsupported format: {format!r}. Use 'json' or 'yaml'.")
+    if output_format not in ("json", "yaml"):
+        raise ValueError(f"Unsupported format: {output_format!r}. Use 'json' or 'yaml'.")
 
     rules = list_rules(db_path=db_path, lessons_path=lessons_path)
     payload = {
@@ -176,11 +175,11 @@ def export_rules(
         "metadata": {
             "exported_at": datetime.now(timezone.utc).isoformat(),
             "count": len(rules),
-            "format": format,
+            "format": output_format,
         },
     }
 
-    if format == "json":
+    if output_format == "json":
         return json.dumps(payload, indent=2, default=str)
 
     # YAML — minimal serializer, no PyYAML dependency
@@ -200,6 +199,8 @@ def _yaml_val(v: object) -> str:
     if isinstance(v, (int, float)):
         return str(v)
     s = str(v)
+    # Escape embedded double quotes before wrapping
+    s = s.replace('"', '\\"')
     # Quote strings that could be misinterpreted
     if s == "" or ":" in s or "#" in s or s.startswith(("-", "[", "{")):
         return f'"{s}"'

--- a/src/gradata/inspection.py
+++ b/src/gradata/inspection.py
@@ -1,0 +1,252 @@
+"""
+Rule Inspection API — standalone functions for introspecting brain rules.
+=========================================================================
+SDK LAYER: Layer 0 (no Brain dependency). All functions take primitive
+paths (db_path, lessons_path) so they can be used without instantiating
+a Brain object. Brain gets thin 1-2 line wrappers.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+from gradata._types import ELIGIBLE_STATES, Lesson, LessonState
+
+_log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_rule_id(lesson: Lesson) -> str:
+    """Generate a stable, deterministic ID from category + description."""
+    key = f"{lesson.category}:{lesson.description}"
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:12]
+
+
+def _load_lessons_from_path(lessons_path: Path | str) -> list[Lesson]:
+    """Read and parse lessons.md from a file path."""
+    from gradata.enhancements.self_improvement import parse_lessons
+
+    p = Path(lessons_path)
+    if not p.is_file():
+        return []
+    return parse_lessons(p.read_text(encoding="utf-8"))
+
+
+def _lesson_to_dict(lesson: Lesson) -> dict:
+    """Convert a Lesson dataclass to a serializable dict with a stable ID."""
+    return {
+        "id": _make_rule_id(lesson),
+        "date": lesson.date,
+        "state": lesson.state.value,
+        "confidence": lesson.confidence,
+        "category": lesson.category,
+        "description": lesson.description,
+        "root_cause": lesson.root_cause,
+        "fire_count": lesson.fire_count,
+        "sessions_since_fire": lesson.sessions_since_fire,
+        "misfire_count": lesson.misfire_count,
+        "correction_event_ids": lesson.correction_event_ids,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Core API
+# ---------------------------------------------------------------------------
+
+def list_rules(
+    *,
+    db_path: Path | str,
+    lessons_path: Path | str,
+    include_all: bool = False,
+    category: str | None = None,
+) -> list[dict]:
+    """List brain rules from lessons.md.
+
+    Args:
+        db_path: Path to system.db (reserved for future enrichment).
+        lessons_path: Path to lessons.md file.
+        include_all: If True, return all lessons regardless of state.
+            Default returns only PATTERN + RULE (ELIGIBLE_STATES).
+        category: Optional category filter (e.g. "DRAFTING").
+
+    Returns:
+        List of rule dicts sorted by confidence descending.
+    """
+    lessons = _load_lessons_from_path(lessons_path)
+
+    if not include_all:
+        lessons = [l for l in lessons if l.state in ELIGIBLE_STATES]
+
+    if category:
+        lessons = [l for l in lessons if l.category.upper() == category.upper()]
+
+    # Sort by confidence descending
+    lessons.sort(key=lambda l: l.confidence, reverse=True)
+
+    return [_lesson_to_dict(l) for l in lessons]
+
+
+def explain_rule(
+    *,
+    db_path: Path | str,
+    events_path: Path | str,
+    rule_id: str,
+    lessons_path: Path | str,
+) -> dict:
+    """Trace a rule back to its source corrections and transitions.
+
+    Args:
+        db_path: Path to system.db.
+        events_path: Path to events.jsonl.
+        rule_id: The stable rule ID (from list_rules).
+        lessons_path: Path to lessons.md.
+
+    Returns:
+        Dict with rule metadata, correction_ids, transitions, and root_cause.
+        Returns {"error": "..."} if rule_id not found.
+    """
+    lessons = _load_lessons_from_path(lessons_path)
+
+    # Find the lesson matching this rule_id
+    target: Lesson | None = None
+    for lesson in lessons:
+        if _make_rule_id(lesson) == rule_id:
+            target = lesson
+            break
+
+    if target is None:
+        return {"error": f"Rule not found: {rule_id}"}
+
+    result = _lesson_to_dict(target)
+
+    # Fetch transitions from SQLite
+    transitions: list[dict] = []
+    db = Path(db_path)
+    if db.is_file():
+        try:
+            conn = sqlite3.connect(str(db))
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                """SELECT old_state, new_state, confidence, fire_count,
+                          session, transitioned_at
+                   FROM lesson_transitions
+                   WHERE lesson_desc = ? AND category = ?
+                   ORDER BY transitioned_at""",
+                (target.description, target.category),
+            ).fetchall()
+            transitions = [dict(r) for r in rows]
+            conn.close()
+        except Exception as e:
+            _log.debug("Failed to query lesson_transitions: %s", e)
+
+    result["transitions"] = transitions
+    return result
+
+
+def export_rules(
+    *,
+    db_path: Path | str,
+    lessons_path: Path | str,
+    format: str = "json",
+) -> str:
+    """Export rules in the specified format.
+
+    Args:
+        db_path: Path to system.db.
+        lessons_path: Path to lessons.md.
+        format: "json" or "yaml". Raises ValueError for unsupported formats.
+
+    Returns:
+        Serialized string in the requested format.
+    """
+    if format not in ("json", "yaml"):
+        raise ValueError(f"Unsupported format: {format!r}. Use 'json' or 'yaml'.")
+
+    rules = list_rules(db_path=db_path, lessons_path=lessons_path)
+    payload = {
+        "rules": rules,
+        "metadata": {
+            "exported_at": datetime.now(timezone.utc).isoformat(),
+            "count": len(rules),
+            "format": format,
+        },
+    }
+
+    if format == "json":
+        return json.dumps(payload, indent=2, default=str)
+
+    # YAML — minimal serializer, no PyYAML dependency
+    return _dict_to_yaml(payload)
+
+
+# ---------------------------------------------------------------------------
+# Minimal YAML serializer (~30 lines, no PyYAML dependency)
+# ---------------------------------------------------------------------------
+
+def _yaml_val(v: object) -> str:
+    """Format a scalar value for YAML output."""
+    if v is None:
+        return "null"
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, (int, float)):
+        return str(v)
+    s = str(v)
+    # Quote strings that could be misinterpreted
+    if s == "" or ":" in s or "#" in s or s.startswith(("-", "[", "{")):
+        return f'"{s}"'
+    return s
+
+
+def _dict_to_yaml(d: object, indent: int = 0) -> str:
+    """Convert a dict/list/scalar to minimal YAML string."""
+    prefix = "  " * indent
+    lines: list[str] = []
+
+    if isinstance(d, dict):
+        for key, val in d.items():
+            if isinstance(val, dict):
+                lines.append(f"{prefix}{key}:")
+                lines.append(_dict_to_yaml(val, indent + 1))
+            elif isinstance(val, list):
+                lines.append(f"{prefix}{key}:")
+                for item in val:
+                    if isinstance(item, dict):
+                        # First key on the "- " line, rest indented
+                        items = list(item.items())
+                        if items:
+                            k0, v0 = items[0]
+                            if isinstance(v0, (dict, list)):
+                                lines.append(f"{prefix}  - {k0}:")
+                                lines.append(_dict_to_yaml(v0, indent + 3))
+                            else:
+                                lines.append(f"{prefix}  - {k0}: {_yaml_val(v0)}")
+                            for k, v in items[1:]:
+                                if isinstance(v, (dict, list)):
+                                    lines.append(f"{prefix}    {k}:")
+                                    lines.append(_dict_to_yaml(v, indent + 3))
+                                else:
+                                    lines.append(f"{prefix}    {k}: {_yaml_val(v)}")
+                    else:
+                        lines.append(f"{prefix}  - {_yaml_val(item)}")
+            else:
+                lines.append(f"{prefix}{key}: {_yaml_val(val)}")
+    elif isinstance(d, list):
+        for item in d:
+            if isinstance(item, (dict, list)):
+                lines.append(f"{prefix}-")
+                lines.append(_dict_to_yaml(item, indent + 1))
+            else:
+                lines.append(f"{prefix}- {_yaml_val(item)}")
+    else:
+        lines.append(f"{prefix}{_yaml_val(d)}")
+
+    return "\n".join(lines)

--- a/src/gradata/rules/rule_engine.py
+++ b/src/gradata/rules/rule_engine.py
@@ -44,6 +44,12 @@ from gradata.security.score_obfuscation import truncate_score
 
 _log = logging.getLogger(__name__)
 
+
+def _tier_label(lesson: Lesson) -> str:
+    """Return the display tier for a lesson — state name if available, else confidence bucket."""
+    return lesson.state.value if lesson.state else truncate_score(lesson.confidence)
+
+
 # ---------------------------------------------------------------------------
 # Data Model
 # ---------------------------------------------------------------------------
@@ -288,9 +294,8 @@ def compute_scope_weight(
 def _make_rule_id(lesson: Lesson) -> str:
     """Derive a stable, opaque rule identifier from a lesson.
 
-    Format: ``"CATEGORY:NNNN"`` where NNNN is a 4-digit decimal derived
-    from the description hash modulo 10 000.  Collisions are possible but
-    rare enough for the current scale.
+    Format: ``"CATEGORY:HHHHHHHH"`` where HHHHHHHH is an 8-char hex
+    digest of category+description for global uniqueness.
 
     Args:
         lesson: Source lesson.
@@ -298,8 +303,10 @@ def _make_rule_id(lesson: Lesson) -> str:
     Returns:
         Rule identifier string.
     """
-    desc_hash = int(hashlib.sha256(lesson.description.encode()).hexdigest(), 16)
-    return f"{lesson.category}:{desc_hash % 10000:04d}"
+    digest = hashlib.sha256(
+        f"{lesson.category}:{lesson.description}".encode()
+    ).hexdigest()[:8]
+    return f"{lesson.category}:{digest}"
 
 
 # ---------------------------------------------------------------------------
@@ -646,7 +653,7 @@ def apply_rules(
     applied: list[AppliedRule] = []
     for lesson, relevance in scored[:max_rules]:
         rule_id = _make_rule_id(lesson)
-        tier_label = truncate_score(lesson.confidence)
+        tier_label = _tier_label(lesson)
         instruction = (
             f"[{tier_label}]"
             f" {lesson.category}: {lesson.description}"
@@ -688,7 +695,7 @@ def merge_related_rules(rules: list[AppliedRule], min_group_size: int = 2) -> li
         best = max(group, key=lambda r: r.lesson.confidence)
         descriptions = [r.lesson.description for r in group]
         merged_desc = ". ".join(d.rstrip(".") for d in descriptions) + "."
-        merged_tier = truncate_score(best.lesson.confidence)
+        merged_tier = _tier_label(best.lesson)
         merged_instruction = f"[{merged_tier}] {cat}: {merged_desc}"
         merged_rule = AppliedRule(
             rule_id=f"merged_{cat.lower()}",

--- a/src/gradata/rules/rule_engine.py
+++ b/src/gradata/rules/rule_engine.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import random
+import secrets
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -702,6 +704,7 @@ def format_rules_for_prompt(
     rules: list[AppliedRule],
     merge: bool = True,
     scope_filter: RuleTransferScope | None = None,
+    shuffle_seed: int | None = None,
 ) -> str:
     """Format applied rules into an XML-tagged LLM-injectable block.
 
@@ -734,17 +737,30 @@ def format_rules_for_prompt(
     if merge:
         rules = merge_related_rules(rules)
 
-    # Sort by priority: RULE state first, then difficulty (harder rules up),
-    # then confidence descending. Primacy positioning: best rules at top
-    # where LLMs attend most strongly.
-    rules.sort(
-        key=lambda r: (
-            1 if r.lesson.state.value == "RULE" else 0,
-            _difficulty_from_lesson(r.lesson),
-            r.lesson.confidence,
-        ),
-        reverse=True,
-    )
+    # Bucketed shuffle: group by tier, shuffle within each tier, concatenate
+    # in tier order (RULE first). Prevents adversaries from inferring
+    # confidence rankings via injection order.
+    tier_order = [LessonState.RULE, LessonState.PATTERN, LessonState.INSTINCT]
+    buckets: dict[LessonState, list[AppliedRule]] = {t: [] for t in tier_order}
+    for r in rules:
+        bucket = buckets.get(r.lesson.state)
+        if bucket is not None:
+            bucket.append(r)
+    # Shuffle within each tier
+    if shuffle_seed is not None:
+        rng = random.Random(shuffle_seed)
+        for tier in tier_order:
+            rng.shuffle(buckets[tier])
+    else:
+        for tier in tier_order:
+            # Production: use secrets for non-deterministic shuffle
+            bucket = buckets[tier]
+            for i in range(len(bucket) - 1, 0, -1):
+                j = secrets.randbelow(i + 1)
+                bucket[i], bucket[j] = bucket[j], bucket[i]
+    rules = []
+    for tier in tier_order:
+        rules.extend(buckets[tier])
 
     lines = [
         "<brain-rules>",

--- a/src/gradata/rules/rule_engine.py
+++ b/src/gradata/rules/rule_engine.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
 
 from gradata._scope import RuleScope, scope_matches
 from gradata._types import ELIGIBLE_STATES, CorrectionType, Lesson, LessonState, RuleTransferScope
+from gradata.security.score_obfuscation import truncate_score
 # evaluate_conditions lives in meta_rules.py — not re-exported here
 # to avoid circular dependency. Callers should import from meta_rules directly.
 
@@ -643,8 +644,9 @@ def apply_rules(
     applied: list[AppliedRule] = []
     for lesson, relevance in scored[:max_rules]:
         rule_id = _make_rule_id(lesson)
+        tier_label = truncate_score(lesson.confidence)
         instruction = (
-            f"[{lesson.state.value}:{lesson.confidence:.2f}]"
+            f"[{tier_label}]"
             f" {lesson.category}: {lesson.description}"
         )
         applied.append(
@@ -684,7 +686,8 @@ def merge_related_rules(rules: list[AppliedRule], min_group_size: int = 2) -> li
         best = max(group, key=lambda r: r.lesson.confidence)
         descriptions = [r.lesson.description for r in group]
         merged_desc = ". ".join(d.rstrip(".") for d in descriptions) + "."
-        merged_instruction = f"{cat}: {merged_desc} [{best.lesson.confidence:.2f}]"
+        merged_tier = truncate_score(best.lesson.confidence)
+        merged_instruction = f"[{merged_tier}] {cat}: {merged_desc}"
         merged_rule = AppliedRule(
             rule_id=f"merged_{cat.lower()}",
             lesson=best.lesson,

--- a/src/gradata/safety.py
+++ b/src/gradata/safety.py
@@ -16,18 +16,18 @@ _PII_PATTERNS: list[tuple[str, str, re.Pattern[str]]] = [
     ("openai_api_key", "[REDACTED_OPENAI_KEY]",
      re.compile(r"sk-(?:proj-)?[A-Za-z0-9_-]{20,}")),
     ("github_token", "[REDACTED_GITHUB_TOKEN]",
-     re.compile(r"ghp_[A-Za-z0-9]{20,}")),
+     re.compile(r"(?:ghp_|github_pat_)[A-Za-z0-9_]{20,}")),
     ("slack_token", "[REDACTED_SLACK_TOKEN]",
-     re.compile(r"xoxb-[A-Za-z0-9\-]{20,}")),
+     re.compile(r"(?:xoxb|xoxp|xapp|xwfp)-[A-Za-z0-9\-]{20,}")),
     ("aws_access_key", "[REDACTED_AWS_KEY]",
      re.compile(r"AKIA[A-Z0-9]{16}")),
     ("google_api_key", "[REDACTED_GOOGLE_KEY]",
      re.compile(r"AIza[A-Za-z0-9_-]{35}")),
     ("gitlab_token", "[REDACTED_GITLAB_TOKEN]",
      re.compile(r"glpat-[A-Za-z0-9_-]{20,}")),
-    # Credit card numbers (13-19 digits, optional separators)
+    # Credit card numbers (4-4-4-4 grouped format only to avoid false positives)
     ("credit_card", "[REDACTED_CC]",
-     re.compile(r"\b(?:\d[ -]*?){13,19}\b")),
+     re.compile(r"\b(?:\d{4}[- ]){3}\d{4}\b")),
     # SSN (xxx-xx-xxxx)
     ("ssn", "[REDACTED_SSN]",
      re.compile(r"\b\d{3}-\d{2}-\d{4}\b")),

--- a/src/gradata/safety.py
+++ b/src/gradata/safety.py
@@ -1,0 +1,77 @@
+"""PII and credential detection/redaction for the Gradata pipeline.
+
+Critical pipeline order: diff engine and behavioral extraction run on FULL text
+first, THEN PII is redacted BEFORE writing to events.jsonl.
+
+Zero external dependencies — regex only.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Order matters: API keys before emails to avoid partial matches on key prefixes.
+_PII_PATTERNS: list[tuple[str, str, re.Pattern[str]]] = [
+    # API keys / secrets
+    ("openai_api_key", "[REDACTED_OPENAI_KEY]",
+     re.compile(r"sk-(?:proj-)?[A-Za-z0-9_-]{20,}")),
+    ("github_token", "[REDACTED_GITHUB_TOKEN]",
+     re.compile(r"ghp_[A-Za-z0-9]{20,}")),
+    ("slack_token", "[REDACTED_SLACK_TOKEN]",
+     re.compile(r"xoxb-[A-Za-z0-9\-]{20,}")),
+    ("aws_access_key", "[REDACTED_AWS_KEY]",
+     re.compile(r"AKIA[A-Z0-9]{16}")),
+    ("google_api_key", "[REDACTED_GOOGLE_KEY]",
+     re.compile(r"AIza[A-Za-z0-9_-]{35}")),
+    ("gitlab_token", "[REDACTED_GITLAB_TOKEN]",
+     re.compile(r"glpat-[A-Za-z0-9_-]{20,}")),
+    # Credit card numbers (13-19 digits, optional separators)
+    ("credit_card", "[REDACTED_CC]",
+     re.compile(r"\b(?:\d[ -]*?){13,19}\b")),
+    # SSN (xxx-xx-xxxx)
+    ("ssn", "[REDACTED_SSN]",
+     re.compile(r"\b\d{3}-\d{2}-\d{4}\b")),
+    # Phone numbers (various formats)
+    ("phone", "[REDACTED_PHONE]",
+     re.compile(r"(?<!\d)(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}(?!\d)")),
+    # Email addresses (last to avoid clashing with API key patterns)
+    ("email", "[REDACTED_EMAIL]",
+     re.compile(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}")),
+]
+
+
+def redact_pii(text: str) -> str:
+    """Return *text* with all detected PII replaced by placeholders."""
+    if not text:
+        return text
+    for _label, placeholder, pattern in _PII_PATTERNS:
+        text = pattern.sub(placeholder, text)
+    return text
+
+
+def redact_pii_with_report(text: str) -> tuple[str, dict]:
+    """Return (cleaned_text, report_dict).
+
+    Report dict keys:
+        redactions_count  – total number of replacements made
+        types_found       – list of distinct PII type labels found
+        redacted          – bool, True if any replacement was made
+    """
+    if not text:
+        return text, {"redactions_count": 0, "types_found": [], "redacted": False}
+
+    total = 0
+    types_found: list[str] = []
+    for label, placeholder, pattern in _PII_PATTERNS:
+        new_text, n = pattern.subn(placeholder, text)
+        if n > 0:
+            total += n
+            types_found.append(label)
+            text = new_text
+
+    report = {
+        "redactions_count": total,
+        "types_found": types_found,
+        "redacted": total > 0,
+    }
+    return text, report

--- a/src/gradata/security/__init__.py
+++ b/src/gradata/security/__init__.py
@@ -1,0 +1,8 @@
+"""Security utilities for Gradata SDK."""
+
+from gradata.security.score_obfuscation import (
+    obfuscate_instruction,
+    truncate_score,
+)
+
+__all__ = ["truncate_score", "obfuscate_instruction"]

--- a/src/gradata/security/__init__.py
+++ b/src/gradata/security/__init__.py
@@ -11,6 +11,10 @@ from gradata.security.brain_salt import (
 )
 from gradata.security.query_budget import QueryBudget
 from gradata.security.manifest_signing import sign_manifest, verify_manifest
+from gradata.security.correction_provenance import (
+    create_provenance_record,
+    verify_provenance,
+)
 
 __all__ = [
     "truncate_score",
@@ -21,4 +25,6 @@ __all__ = [
     "QueryBudget",
     "sign_manifest",
     "verify_manifest",
+    "create_provenance_record",
+    "verify_provenance",
 ]

--- a/src/gradata/security/__init__.py
+++ b/src/gradata/security/__init__.py
@@ -4,5 +4,16 @@ from gradata.security.score_obfuscation import (
     obfuscate_instruction,
     truncate_score,
 )
+from gradata.security.brain_salt import (
+    generate_brain_salt,
+    load_or_create_salt,
+    salt_threshold,
+)
 
-__all__ = ["truncate_score", "obfuscate_instruction"]
+__all__ = [
+    "truncate_score",
+    "obfuscate_instruction",
+    "generate_brain_salt",
+    "load_or_create_salt",
+    "salt_threshold",
+]

--- a/src/gradata/security/__init__.py
+++ b/src/gradata/security/__init__.py
@@ -10,6 +10,7 @@ from gradata.security.brain_salt import (
     salt_threshold,
 )
 from gradata.security.query_budget import QueryBudget
+from gradata.security.manifest_signing import sign_manifest, verify_manifest
 
 __all__ = [
     "truncate_score",
@@ -18,4 +19,6 @@ __all__ = [
     "load_or_create_salt",
     "salt_threshold",
     "QueryBudget",
+    "sign_manifest",
+    "verify_manifest",
 ]

--- a/src/gradata/security/__init__.py
+++ b/src/gradata/security/__init__.py
@@ -9,6 +9,7 @@ from gradata.security.brain_salt import (
     load_or_create_salt,
     salt_threshold,
 )
+from gradata.security.query_budget import QueryBudget
 
 __all__ = [
     "truncate_score",
@@ -16,4 +17,5 @@ __all__ = [
     "generate_brain_salt",
     "load_or_create_salt",
     "salt_threshold",
+    "QueryBudget",
 ]

--- a/src/gradata/security/__init__.py
+++ b/src/gradata/security/__init__.py
@@ -1,8 +1,11 @@
 """Security utilities for Gradata SDK."""
 
+from __future__ import annotations
+
 from gradata.security.score_obfuscation import (
     obfuscate_instruction,
     truncate_score,
+    constant_time_pad,
 )
 from gradata.security.brain_salt import (
     generate_brain_salt,
@@ -19,6 +22,7 @@ from gradata.security.correction_provenance import (
 __all__ = [
     "truncate_score",
     "obfuscate_instruction",
+    "constant_time_pad",
     "generate_brain_salt",
     "load_or_create_salt",
     "salt_threshold",

--- a/src/gradata/security/brain_salt.py
+++ b/src/gradata/security/brain_salt.py
@@ -26,16 +26,31 @@ def load_or_create_salt(brain_dir: str | Path) -> str:
     Returns the 64-char hex salt string.  The file is created atomically
     on first call and reused on subsequent calls (idempotent).
     """
+    import os as _os
+
     brain_dir = Path(brain_dir)
+    brain_dir.mkdir(parents=True, exist_ok=True)
     salt_path = brain_dir / ".brain_salt"
 
+    # Fast path: file already exists and is valid
+    if salt_path.is_file():
+        content = salt_path.read_text(encoding="utf-8").strip()
+        if len(content) == 64:
+            return content
+
+    # Create atomically via temp file + rename
+    salt = generate_brain_salt()
+    tmp_path = salt_path.with_suffix(".tmp")
     try:
-        with open(salt_path, "x", encoding="utf-8") as f:
-            salt = generate_brain_salt()
+        with open(tmp_path, "w", encoding="utf-8") as f:
             f.write(salt)
-        return salt
-    except FileExistsError:
-        return salt_path.read_text(encoding="utf-8").strip()
+            f.flush()
+            _os.fsync(f.fileno())
+        _os.replace(str(tmp_path), str(salt_path))
+    except OSError:
+        # Fallback: direct write
+        salt_path.write_text(salt, encoding="utf-8")
+    return salt
 
 
 def salt_threshold(base: float, salt: str, tier_name: str) -> float:

--- a/src/gradata/security/brain_salt.py
+++ b/src/gradata/security/brain_salt.py
@@ -1,0 +1,66 @@
+"""Per-brain salt for non-deterministic graduation thresholds.
+
+Each brain gets a unique 32-byte salt stored as `.brain_salt` in the vault.
+The salt jitters PATTERN_THRESHOLD and RULE_THRESHOLD by +/-5% so that
+an attacker who knows the graduation algorithm cannot predict the exact
+confidence boundary for any specific brain.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+import struct
+from pathlib import Path
+
+
+def generate_brain_salt() -> str:
+    """Generate a 32-byte random salt as a 64-char hex string."""
+    return secrets.token_hex(32)
+
+
+def load_or_create_salt(brain_dir: str | Path) -> str:
+    """Load .brain_salt from *brain_dir*, creating it if absent.
+
+    Returns the 64-char hex salt string.  The file is created atomically
+    on first call and reused on subsequent calls (idempotent).
+    """
+    brain_dir = Path(brain_dir)
+    salt_path = brain_dir / ".brain_salt"
+
+    if salt_path.exists():
+        return salt_path.read_text(encoding="utf-8").strip()
+
+    salt = generate_brain_salt()
+    salt_path.write_text(salt, encoding="utf-8")
+    return salt
+
+
+def salt_threshold(base: float, salt: str, tier_name: str) -> float:
+    """Compute a salted threshold by jittering *base* within +/-5%.
+
+    Uses HMAC-SHA256(salt, tier_name) to derive a deterministic but
+    unpredictable jitter for each (brain, tier) pair.
+
+    Args:
+        base: The nominal threshold (e.g. 0.60 or 0.90).
+        salt: The brain's 64-char hex salt.
+        tier_name: Graduation tier identifier (e.g. "PATTERN" or "RULE").
+
+    Returns:
+        A float in [base * 0.95, base * 1.05].
+    """
+    digest = hmac.new(
+        salt.encode("utf-8"),
+        tier_name.encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+
+    # Map first 4 bytes to a float in [0, 1)
+    (value,) = struct.unpack(">I", digest[:4])
+    fraction = value / 0xFFFFFFFF  # [0, 1]
+
+    # Map to [-0.05, +0.05] of base
+    jitter = (fraction * 0.10 - 0.05) * base
+    return base + jitter

--- a/src/gradata/security/brain_salt.py
+++ b/src/gradata/security/brain_salt.py
@@ -29,12 +29,13 @@ def load_or_create_salt(brain_dir: str | Path) -> str:
     brain_dir = Path(brain_dir)
     salt_path = brain_dir / ".brain_salt"
 
-    if salt_path.exists():
+    try:
+        with open(salt_path, "x", encoding="utf-8") as f:
+            salt = generate_brain_salt()
+            f.write(salt)
+        return salt
+    except FileExistsError:
         return salt_path.read_text(encoding="utf-8").strip()
-
-    salt = generate_brain_salt()
-    salt_path.write_text(salt, encoding="utf-8")
-    return salt
 
 
 def salt_threshold(base: float, salt: str, tier_name: str) -> float:

--- a/src/gradata/security/correction_provenance.py
+++ b/src/gradata/security/correction_provenance.py
@@ -30,6 +30,14 @@ def create_provenance_record(
     Returns:
         Dict with user_id, correction_hash, session, timestamp, and hmac.
     """
+    if not user_id or not user_id.strip():
+        raise ValueError("user_id must be a non-empty string")
+    if not correction_hash or not correction_hash.strip():
+        raise ValueError("correction_hash must be a non-empty string")
+    if not isinstance(session, int) or session < 0:
+        raise ValueError(f"session must be a non-negative integer, got {session!r}")
+    if not salt or not salt.strip():
+        raise ValueError("salt must be a non-empty string")
     timestamp = datetime.now(timezone.utc).isoformat()
     message = f"{user_id}|{correction_hash}|{session}|{timestamp}"
     signature = hmac.new(

--- a/src/gradata/security/correction_provenance.py
+++ b/src/gradata/security/correction_provenance.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
-import time
+from datetime import datetime, timezone
 
 
 def create_provenance_record(
@@ -30,7 +30,7 @@ def create_provenance_record(
     Returns:
         Dict with user_id, correction_hash, session, timestamp, and hmac.
     """
-    timestamp = time.time()
+    timestamp = datetime.now(timezone.utc).isoformat()
     message = f"{user_id}|{correction_hash}|{session}|{timestamp}"
     signature = hmac.new(
         salt.encode(), message.encode(), hashlib.sha256,

--- a/src/gradata/security/correction_provenance.py
+++ b/src/gradata/security/correction_provenance.py
@@ -1,0 +1,67 @@
+"""Correction provenance authentication via HMAC-SHA256.
+
+Each correction gets a signed provenance record that proves:
+- Who made the correction (user_id)
+- Which session it occurred in
+- What was corrected (correction_hash)
+
+Anomaly detection intentionally excluded. Relying on provenance +
+audit trail + 3-signal graduation for integrity guarantees.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+
+
+def create_provenance_record(
+    *, user_id: str, correction_hash: str, session: int, salt: str,
+) -> dict:
+    """Create an HMAC-SHA256 signed provenance record for a correction.
+
+    Args:
+        user_id: Identifier for the user who made the correction.
+        correction_hash: SHA-256 hash of the correction content.
+        session: Session number where the correction occurred.
+        salt: Per-brain salt used as HMAC key.
+
+    Returns:
+        Dict with user_id, correction_hash, session, timestamp, and hmac.
+    """
+    timestamp = time.time()
+    message = f"{user_id}|{correction_hash}|{session}|{timestamp}"
+    signature = hmac.new(
+        salt.encode(), message.encode(), hashlib.sha256,
+    ).hexdigest()
+    return {
+        "user_id": user_id,
+        "correction_hash": correction_hash,
+        "session": session,
+        "timestamp": timestamp,
+        "hmac": signature,
+    }
+
+
+def verify_provenance(record: dict, salt: str) -> bool:
+    """Verify an HMAC-SHA256 signed provenance record.
+
+    Args:
+        record: Provenance record from create_provenance_record().
+        salt: Per-brain salt (must match the one used to create).
+
+    Returns:
+        True if the record is authentic and untampered.
+    """
+    try:
+        message = (
+            f"{record['user_id']}|{record['correction_hash']}"
+            f"|{record['session']}|{record['timestamp']}"
+        )
+        expected = hmac.new(
+            salt.encode(), message.encode(), hashlib.sha256,
+        ).hexdigest()
+        return hmac.compare_digest(expected, record["hmac"])
+    except (KeyError, TypeError):
+        return False

--- a/src/gradata/security/manifest_signing.py
+++ b/src/gradata/security/manifest_signing.py
@@ -17,6 +17,10 @@ def sign_manifest(manifest: dict, salt: str) -> dict:
 
     The original *manifest* is never mutated.
     """
+    if not isinstance(manifest, dict):
+        raise TypeError("manifest must be a dict")
+    if not isinstance(salt, str) or not salt.strip():
+        raise ValueError("salt must be a non-empty string")
     payload = _canonical_payload(manifest)
     sig = hmac.new(salt.encode(), payload, hashlib.sha256).hexdigest()
     signed = dict(manifest)
@@ -32,7 +36,7 @@ def verify_manifest(manifest: dict, salt: str) -> bool:
     Uses ``hmac.compare_digest`` for timing-safe comparison.
     """
     stored_sig = manifest.get("signature")
-    if not stored_sig:
+    if not isinstance(stored_sig, str) or not stored_sig:
         return False
 
     payload = _canonical_payload(manifest)

--- a/src/gradata/security/manifest_signing.py
+++ b/src/gradata/security/manifest_signing.py
@@ -1,0 +1,47 @@
+"""HMAC-SHA256 manifest signing and verification.
+
+Signs brain manifests with a per-brain salt so tampering is detectable.
+Uses ``hmac.compare_digest`` for timing-safe verification.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from datetime import datetime, timezone
+
+
+def sign_manifest(manifest: dict, salt: str) -> dict:
+    """Return a **new** dict with ``signature`` and ``signed_at`` fields added.
+
+    The original *manifest* is never mutated.
+    """
+    payload = _canonical_payload(manifest)
+    sig = hmac.new(salt.encode(), payload, hashlib.sha256).hexdigest()
+    signed = dict(manifest)
+    signed["signature"] = sig
+    signed["signed_at"] = datetime.now(timezone.utc).isoformat()
+    return signed
+
+
+def verify_manifest(manifest: dict, salt: str) -> bool:
+    """Verify that *manifest* has a valid HMAC-SHA256 signature.
+
+    Returns ``False`` if the signature field is missing or invalid.
+    Uses ``hmac.compare_digest`` for timing-safe comparison.
+    """
+    stored_sig = manifest.get("signature")
+    if not stored_sig:
+        return False
+
+    payload = _canonical_payload(manifest)
+    expected = hmac.new(salt.encode(), payload, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(stored_sig, expected)
+
+
+def _canonical_payload(manifest: dict) -> bytes:
+    """Produce canonical JSON bytes, excluding ``signature`` and ``signed_at``."""
+    filtered = {k: v for k, v in manifest.items()
+                if k not in ("signature", "signed_at")}
+    return json.dumps(filtered, sort_keys=True, separators=(",", ":")).encode()

--- a/src/gradata/security/query_budget.py
+++ b/src/gradata/security/query_budget.py
@@ -1,0 +1,114 @@
+"""Sliding-window query budgeting — rate limiting and burst detection.
+
+Tracks per-endpoint call timestamps using ``time.monotonic()`` and a
+``collections.defaultdict``.  Zero external dependencies.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+
+
+class QueryBudget:
+    """Sliding-window rate limiter with burst anomaly detection.
+
+    Parameters
+    ----------
+    window_seconds:
+        Length of the sliding window in seconds (default 300 = 5 min).
+    max_calls:
+        Maximum allowed calls per endpoint inside the window.
+    """
+
+    def __init__(self, window_seconds: float = 300, max_calls: int = 500) -> None:
+        self.window_seconds = window_seconds
+        self.max_calls = max_calls
+        self._calls: dict[str, list[float]] = defaultdict(list)
+
+    # ── Core API ──────────────────────────────────────────────────────
+
+    def record(self, endpoint: str) -> None:
+        """Log a call timestamp for *endpoint*."""
+        self._calls[endpoint].append(time.monotonic())
+
+    def count(self, endpoint: str) -> int:
+        """Return the number of calls for *endpoint* inside the current window.
+
+        Expired entries are pruned as a side-effect.
+        """
+        self._prune(endpoint)
+        return len(self._calls[endpoint])
+
+    def is_rate_exceeded(self, endpoint: str) -> bool:
+        """Return ``True`` if *endpoint* has exceeded ``max_calls``."""
+        return self.count(endpoint) > self.max_calls
+
+    def detect_anomalies(self, endpoint: str) -> dict:
+        """Detect burst anomalies for *endpoint*.
+
+        A burst is flagged when:
+        1. There are at least 10 calls in the window, **and**
+        2. The rate in the most recent 5-second sub-window exceeds 3x
+           the average rate across the full window.
+
+        Returns a dict with a ``burst`` boolean flag.
+        """
+        self._prune(endpoint)
+        timestamps = self._calls[endpoint]
+
+        if len(timestamps) < 10:
+            return {"burst": False}
+
+        now = time.monotonic()
+        window_start = timestamps[0]
+        window_duration = now - window_start
+        if window_duration <= 0:
+            return {"burst": False}
+
+        # Split into recent (last 5s sub-window) vs older
+        sub_window = 5.0
+        cutoff = now - sub_window
+        recent = [t for t in timestamps if t >= cutoff]
+        older = [t for t in timestamps if t < cutoff]
+
+        if not recent:
+            return {"burst": False}
+
+        # If all data falls within the sub-window, compare the last 20%
+        # of timestamps against the first 80% by inter-arrival density
+        if not older:
+            n = len(timestamps)
+            split = max(1, int(n * 0.8))
+            first_chunk = timestamps[:split]
+            last_chunk = timestamps[split:]
+            if len(first_chunk) < 2 or not last_chunk:
+                return {"burst": False}
+            first_span = first_chunk[-1] - first_chunk[0]
+            last_span = max(now - last_chunk[0], 1e-9)
+            if first_span <= 0:
+                return {"burst": False}
+            first_rate = len(first_chunk) / first_span
+            last_rate = len(last_chunk) / last_span
+            return {"burst": last_rate > 3 * first_rate}
+
+        # Normal case: compare recent sub-window rate to older rate
+        older_duration = cutoff - window_start
+        if older_duration <= 0:
+            return {"burst": False}
+
+        older_rate = len(older) / older_duration
+        recent_duration = now - cutoff
+        recent_rate = len(recent) / recent_duration
+
+        return {"burst": recent_rate > 3 * older_rate}
+
+    # ── Internals ─────────────────────────────────────────────────────
+
+    def _prune(self, endpoint: str) -> None:
+        """Remove timestamps older than the sliding window."""
+        cutoff = time.monotonic() - self.window_seconds
+        calls = self._calls[endpoint]
+        # Binary-ish fast path: timestamps are monotonically ordered
+        while calls and calls[0] < cutoff:
+            calls.pop(0)

--- a/src/gradata/security/query_budget.py
+++ b/src/gradata/security/query_budget.py
@@ -78,10 +78,11 @@ class QueryBudget:
         # If all data falls within the sub-window, compare the last 20%
         # of timestamps against the first 80% by inter-arrival density
         if not older:
-            n = len(timestamps)
+            ts_list = list(timestamps)
+            n = len(ts_list)
             split = max(1, int(n * 0.8))
-            first_chunk = timestamps[:split]
-            last_chunk = timestamps[split:]
+            first_chunk = ts_list[:split]
+            last_chunk = ts_list[split:]
             if len(first_chunk) < 2 or not last_chunk:
                 return {"burst": False}
             first_span = first_chunk[-1] - first_chunk[0]

--- a/src/gradata/security/query_budget.py
+++ b/src/gradata/security/query_budget.py
@@ -7,7 +7,7 @@ Tracks per-endpoint call timestamps using ``time.monotonic()`` and a
 from __future__ import annotations
 
 import time
-from collections import defaultdict
+from collections import defaultdict, deque
 
 
 class QueryBudget:
@@ -24,7 +24,7 @@ class QueryBudget:
     def __init__(self, window_seconds: float = 300, max_calls: int = 500) -> None:
         self.window_seconds = window_seconds
         self.max_calls = max_calls
-        self._calls: dict[str, list[float]] = defaultdict(list)
+        self._calls: dict[str, deque[float]] = defaultdict(deque)
 
     # ── Core API ──────────────────────────────────────────────────────
 
@@ -55,7 +55,7 @@ class QueryBudget:
         Returns a dict with a ``burst`` boolean flag.
         """
         self._prune(endpoint)
-        timestamps = self._calls[endpoint]
+        timestamps = list(self._calls[endpoint])
 
         if len(timestamps) < 10:
             return {"burst": False}
@@ -111,4 +111,4 @@ class QueryBudget:
         calls = self._calls[endpoint]
         # Binary-ish fast path: timestamps are monotonically ordered
         while calls and calls[0] < cutoff:
-            calls.pop(0)
+            calls.popleft()

--- a/src/gradata/security/query_budget.py
+++ b/src/gradata/security/query_budget.py
@@ -22,6 +22,10 @@ class QueryBudget:
     """
 
     def __init__(self, window_seconds: float = 300, max_calls: int = 500) -> None:
+        if window_seconds <= 0:
+            raise ValueError(f"window_seconds must be positive, got {window_seconds}")
+        if max_calls < 0:
+            raise ValueError(f"max_calls must be non-negative, got {max_calls}")
         self.window_seconds = window_seconds
         self.max_calls = max_calls
         self._calls: dict[str, deque[float]] = defaultdict(deque)
@@ -113,3 +117,5 @@ class QueryBudget:
         # Binary-ish fast path: timestamps are monotonically ordered
         while calls and calls[0] < cutoff:
             calls.popleft()
+        if not calls:
+            self._calls.pop(endpoint, None)

--- a/src/gradata/security/score_obfuscation.py
+++ b/src/gradata/security/score_obfuscation.py
@@ -11,6 +11,8 @@ brain.rules(), brain.efficiency()).
 from __future__ import annotations
 
 import re
+import secrets
+import time
 
 # Regex matching bracketed tier labels with trailing float, e.g. [RULE:0.95]
 _SCORE_PATTERN = re.compile(r"\[(RULE|PATTERN|INSTINCT):([\d.]+)\]")
@@ -50,3 +52,29 @@ def obfuscate_instruction(instruction: str) -> str:
         Instruction with all ``[TIER:float]`` replaced by ``[TIER]``.
     """
     return _SCORE_PATTERN.sub(r"[\1]", instruction)
+
+
+def constant_time_pad(fn, min_ms: float = 20.0, jitter_ms: float = 5.0):
+    """Execute *fn* and pad to minimum duration with random jitter.
+
+    Prevents timing side-channels by ensuring that every call takes at
+    least ``min_ms + random(0, jitter_ms)`` milliseconds, regardless of
+    how fast *fn* completes.
+
+    Args:
+        fn: Zero-argument callable to execute.
+        min_ms: Minimum execution time in milliseconds.
+        jitter_ms: Maximum random jitter added on top of *min_ms*.
+
+    Returns:
+        Whatever *fn* returns.
+    """
+    start = time.perf_counter()
+    result = fn()
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    jitter = (secrets.randbelow(int(jitter_ms * 1000)) / 1000) if jitter_ms > 0 else 0.0
+    target_ms = min_ms + jitter
+    remaining_ms = target_ms - elapsed_ms
+    if remaining_ms > 0:
+        time.sleep(remaining_ms / 1000)
+    return result

--- a/src/gradata/security/score_obfuscation.py
+++ b/src/gradata/security/score_obfuscation.py
@@ -1,0 +1,52 @@
+"""Score obfuscation — strip raw confidence floats from prompt-injected rules.
+
+Raw confidence scores (e.g. ``[RULE:0.95]``) leak internal state into LLM
+prompts, enabling prompt injection attacks that reference or manipulate
+specific thresholds.  This module replaces raw floats with tier labels
+(``[RULE]``, ``[PATTERN]``, ``[INSTINCT]``) for prompt injection while
+keeping raw floats available in local dev tools (brain.prove(),
+brain.rules(), brain.efficiency()).
+"""
+
+from __future__ import annotations
+
+import re
+
+# Regex matching bracketed tier labels with trailing float, e.g. [RULE:0.95]
+_SCORE_PATTERN = re.compile(r"\[(RULE|PATTERN|INSTINCT):([\d.]+)\]")
+
+
+def truncate_score(confidence: float) -> str:
+    """Map a raw confidence float to its tier label.
+
+    Thresholds match the graduation pipeline:
+      - 0.90+ -> "RULE"
+      - 0.60-0.89 -> "PATTERN"
+      - below 0.60 -> "INSTINCT"
+
+    Args:
+        confidence: Raw confidence float in [0.0, 1.0].
+
+    Returns:
+        Tier label string.
+    """
+    if confidence >= 0.90:
+        return "RULE"
+    if confidence >= 0.60:
+        return "PATTERN"
+    return "INSTINCT"
+
+
+def obfuscate_instruction(instruction: str) -> str:
+    """Strip raw confidence floats from a formatted instruction string.
+
+    Replaces patterns like ``[RULE:0.95]`` with ``[RULE]``, removing the
+    numeric score while preserving the tier label.
+
+    Args:
+        instruction: Instruction string that may contain bracketed scores.
+
+    Returns:
+        Instruction with all ``[TIER:float]`` replaced by ``[TIER]``.
+    """
+    return _SCORE_PATTERN.sub(r"[\1]", instruction)

--- a/src/gradata/security/score_obfuscation.py
+++ b/src/gradata/security/score_obfuscation.py
@@ -72,7 +72,7 @@ def constant_time_pad(fn, min_ms: float = 20.0, jitter_ms: float = 5.0):
     start = time.perf_counter()
     result = fn()
     elapsed_ms = (time.perf_counter() - start) * 1000
-    jitter = (secrets.randbelow(int(jitter_ms * 1000)) / 1000) if jitter_ms > 0 else 0.0
+    jitter = (secrets.randbelow(int(jitter_ms * 1000)) / 1000) if jitter_ms >= 0.001 else 0.0
     target_ms = min_ms + jitter
     remaining_ms = target_ms - elapsed_ms
     if remaining_ms > 0:

--- a/src/gradata/security/score_obfuscation.py
+++ b/src/gradata/security/score_obfuscation.py
@@ -32,6 +32,8 @@ def truncate_score(confidence: float) -> str:
     Returns:
         Tier label string.
     """
+    if not (0.0 <= confidence <= 1.0):
+        raise ValueError(f"confidence must be in [0.0, 1.0], got {confidence}")
     if confidence >= 0.90:
         return "RULE"
     if confidence >= 0.60:
@@ -69,6 +71,8 @@ def constant_time_pad(fn, min_ms: float = 20.0, jitter_ms: float = 5.0):
     Returns:
         Whatever *fn* returns.
     """
+    if min_ms < 0 or jitter_ms < 0:
+        raise ValueError("min_ms and jitter_ms must be non-negative")
     start = time.perf_counter()
     result = fn()
     elapsed_ms = (time.perf_counter() - start) * 1000

--- a/tests/test_audit_provenance.py
+++ b/tests/test_audit_provenance.py
@@ -1,0 +1,302 @@
+"""Tests for the Audit Trail + Provenance API (audit.py + Brain.trace wrapper)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import textwrap
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from gradata.audit import (
+    _scan_events_for_ids,
+    query_provenance,
+    trace_rule,
+    write_provenance,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+SAMPLE_LESSONS = textwrap.dedent("""\
+    # Lessons
+
+    [2026-01-15] [RULE:0.95] DRAFTING: Never use em dashes in email prose
+      Root cause: User corrected em dashes 8 times across sessions
+      Fire count: 12 | Sessions since fire: 1 | Misfires: 0
+      Correction event IDs: evt_abc123, evt_def456
+
+    [2026-02-10] [PATTERN:0.72] ACCURACY: Always verify data before sending
+      Root cause: Sent unverified stats in demo prep
+      Fire count: 5 | Sessions since fire: 3 | Misfires: 1
+      Correction event IDs: evt_ghi789
+
+    [2026-03-01] [INSTINCT:0.42] PROCESS: Check calendar before scheduling
+      Root cause: Double-booked a meeting
+      Fire count: 2 | Sessions since fire: 7 | Misfires: 0
+""")
+
+
+@pytest.fixture()
+def brain_dir(tmp_path: Path) -> Path:
+    """Create a minimal brain directory with lessons.md, system.db, and events.jsonl."""
+    d = tmp_path / "test-brain"
+    d.mkdir()
+
+    # Write lessons.md
+    (d / "lessons.md").write_text(SAMPLE_LESSONS, encoding="utf-8")
+
+    # Create system.db with required tables
+    db = d / "system.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS lesson_transitions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            lesson_desc TEXT NOT NULL,
+            category TEXT NOT NULL,
+            old_state TEXT NOT NULL,
+            new_state TEXT NOT NULL,
+            confidence REAL,
+            fire_count INTEGER DEFAULT 0,
+            session INTEGER,
+            transitioned_at TEXT NOT NULL
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS rule_provenance (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            rule_id TEXT NOT NULL,
+            correction_event_id TEXT,
+            session INTEGER,
+            timestamp TEXT NOT NULL,
+            user_context TEXT
+        )"""
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_provenance_rule_id ON rule_provenance(rule_id)"
+    )
+    # Insert a transition for the RULE lesson
+    conn.execute(
+        "INSERT INTO lesson_transitions "
+        "(lesson_desc, category, old_state, new_state, confidence, fire_count, session, transitioned_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        ("Never use em dashes in email prose", "DRAFTING", "PATTERN", "RULE", 0.95, 12, 5, "2026-01-15T00:00:00"),
+    )
+    conn.commit()
+    conn.close()
+
+    # Write events.jsonl with sample events
+    events = [
+        {"id": "evt_abc123", "type": "CORRECTION", "ts": "2026-01-10T10:00:00Z",
+         "data": {"draft": "old text", "final": "new text"}, "session": 3},
+        {"id": "evt_def456", "type": "CORRECTION", "ts": "2026-01-12T14:00:00Z",
+         "data": {"draft": "another old", "final": "another new"}, "session": 4},
+        {"id": "evt_other", "type": "SESSION_END", "ts": "2026-01-12T15:00:00Z",
+         "data": {}, "session": 4},
+    ]
+    events_path = d / "events.jsonl"
+    with events_path.open("w", encoding="utf-8") as f:
+        for evt in events:
+            f.write(json.dumps(evt) + "\n")
+
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Tests: rule_provenance table
+# ---------------------------------------------------------------------------
+
+
+class TestRuleProvenanceTable:
+    """Test that rule_provenance table exists and has correct schema."""
+
+    def test_table_exists_after_migration(self, brain_dir: Path) -> None:
+        """rule_provenance table should exist after migrations run."""
+        from gradata._migrations import run_migrations
+        # Run migrations on our test DB (table already created in fixture,
+        # but verify migrations don't break it)
+        run_migrations(brain_dir / "system.db")
+
+        conn = sqlite3.connect(str(brain_dir / "system.db"))
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='rule_provenance'"
+        )
+        assert cursor.fetchone() is not None
+        conn.close()
+
+    def test_table_has_correct_columns(self, brain_dir: Path) -> None:
+        """rule_provenance should have the expected columns."""
+        conn = sqlite3.connect(str(brain_dir / "system.db"))
+        cursor = conn.execute("PRAGMA table_info(rule_provenance)")
+        columns = {row[1] for row in cursor.fetchall()}
+        conn.close()
+        expected = {"id", "rule_id", "correction_event_id", "session", "timestamp", "user_context"}
+        assert expected == columns
+
+
+# ---------------------------------------------------------------------------
+# Tests: write_provenance + query_provenance
+# ---------------------------------------------------------------------------
+
+
+class TestWriteAndQueryProvenance:
+    """Test write_provenance inserts and query_provenance reads."""
+
+    def test_write_and_query(self, brain_dir: Path) -> None:
+        """Written provenance rows should be queryable."""
+        db = brain_dir / "system.db"
+        now = datetime.now(timezone.utc).isoformat()
+        write_provenance(db, rule_id="abc123", correction_event_id="evt_001",
+                         session=5, timestamp=now, user_context="test context")
+        rows = query_provenance(db, rule_id="abc123")
+        assert len(rows) == 1
+        assert rows[0]["rule_id"] == "abc123"
+        assert rows[0]["correction_event_id"] == "evt_001"
+        assert rows[0]["session"] == 5
+        assert rows[0]["user_context"] == "test context"
+
+    def test_query_empty_for_no_matches(self, brain_dir: Path) -> None:
+        """query_provenance should return empty list for unknown rule_id."""
+        db = brain_dir / "system.db"
+        rows = query_provenance(db, rule_id="nonexistent_rule")
+        assert rows == []
+
+    def test_query_all_without_filter(self, brain_dir: Path) -> None:
+        """query_provenance without rule_id returns all rows."""
+        db = brain_dir / "system.db"
+        now = datetime.now(timezone.utc).isoformat()
+        write_provenance(db, rule_id="r1", correction_event_id="e1",
+                         session=1, timestamp=now, user_context=None)
+        write_provenance(db, rule_id="r2", correction_event_id="e2",
+                         session=2, timestamp=now, user_context=None)
+        rows = query_provenance(db)
+        assert len(rows) >= 2
+
+    def test_query_limit(self, brain_dir: Path) -> None:
+        """query_provenance respects limit parameter."""
+        db = brain_dir / "system.db"
+        now = datetime.now(timezone.utc).isoformat()
+        for i in range(10):
+            write_provenance(db, rule_id="same", correction_event_id=f"e{i}",
+                             session=i, timestamp=now, user_context=None)
+        rows = query_provenance(db, rule_id="same", limit=3)
+        assert len(rows) == 3
+
+
+# ---------------------------------------------------------------------------
+# Tests: _scan_events_for_ids
+# ---------------------------------------------------------------------------
+
+
+class TestScanEventsForIds:
+    """Test events.jsonl scanning."""
+
+    def test_finds_matching_events(self, brain_dir: Path) -> None:
+        """Should find events by their IDs."""
+        events_path = brain_dir / "events.jsonl"
+        found = _scan_events_for_ids(events_path, ["evt_abc123", "evt_def456"])
+        assert len(found) == 2
+        ids = {e["id"] for e in found}
+        assert "evt_abc123" in ids
+        assert "evt_def456" in ids
+
+    def test_ignores_non_matching_ids(self, brain_dir: Path) -> None:
+        """Should not return events that don't match requested IDs."""
+        events_path = brain_dir / "events.jsonl"
+        found = _scan_events_for_ids(events_path, ["evt_abc123"])
+        assert len(found) == 1
+        assert found[0]["id"] == "evt_abc123"
+
+    def test_returns_empty_for_missing_file(self, tmp_path: Path) -> None:
+        """Should return empty list if events.jsonl doesn't exist."""
+        found = _scan_events_for_ids(tmp_path / "missing.jsonl", ["evt_abc123"])
+        assert found == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: trace_rule
+# ---------------------------------------------------------------------------
+
+
+class TestTraceRule:
+    """Test the full trace_rule function."""
+
+    def test_trace_known_rule(self, brain_dir: Path) -> None:
+        """trace_rule should return provenance for a known rule."""
+        from gradata.inspection import _make_rule_id, _load_lessons_from_path
+
+        lessons = _load_lessons_from_path(brain_dir / "lessons.md")
+        rule_lesson = [l for l in lessons if l.state.value == "RULE"][0]
+        rid = _make_rule_id(rule_lesson)
+
+        # Write provenance for this rule
+        db = brain_dir / "system.db"
+        now = datetime.now(timezone.utc).isoformat()
+        write_provenance(db, rule_id=rid, correction_event_id="evt_abc123",
+                         session=3, timestamp=now, user_context="test")
+
+        result = trace_rule(db, brain_dir / "events.jsonl",
+                            brain_dir / "lessons.md", rid)
+
+        assert result["rule_id"] == rid
+        assert "provenance" in result
+        assert len(result["provenance"]) >= 1
+        assert "corrections" in result
+
+    def test_trace_unknown_rule(self, brain_dir: Path) -> None:
+        """trace_rule should return error for unknown rule_id."""
+        db = brain_dir / "system.db"
+        result = trace_rule(db, brain_dir / "events.jsonl",
+                            brain_dir / "lessons.md", "unknown_rule_id")
+        assert "error" in result
+
+    def test_trace_includes_transitions(self, brain_dir: Path) -> None:
+        """trace_rule should include lesson_transitions from SQLite."""
+        from gradata.inspection import _make_rule_id, _load_lessons_from_path
+
+        lessons = _load_lessons_from_path(brain_dir / "lessons.md")
+        rule_lesson = [l for l in lessons if l.state.value == "RULE"][0]
+        rid = _make_rule_id(rule_lesson)
+
+        result = trace_rule(db_path=brain_dir / "system.db",
+                            events_path=brain_dir / "events.jsonl",
+                            lessons_path=brain_dir / "lessons.md",
+                            rule_id=rid)
+
+        assert "transitions" in result
+        assert len(result["transitions"]) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: Brain.trace() wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestBrainTrace:
+    """Test the Brain.trace() thin wrapper."""
+
+    def test_brain_trace_returns_provenance(self, brain_dir: Path) -> None:
+        """brain.trace() should delegate to audit.trace_rule."""
+        from gradata.brain import Brain
+        from gradata.inspection import _make_rule_id, _load_lessons_from_path
+
+        brain = Brain(brain_dir)
+        lessons = _load_lessons_from_path(brain_dir / "lessons.md")
+        rule_lesson = [l for l in lessons if l.state.value == "RULE"][0]
+        rid = _make_rule_id(rule_lesson)
+
+        result = brain.trace(rid)
+        assert result["rule_id"] == rid
+        assert "provenance" in result
+        assert "corrections" in result
+
+    def test_brain_trace_unknown_returns_error(self, brain_dir: Path) -> None:
+        """brain.trace() should return error dict for unknown rule_id."""
+        from gradata.brain import Brain
+        brain = Brain(brain_dir)
+        result = brain.trace("nonexistent_id")
+        assert "error" in result

--- a/tests/test_audit_provenance.py
+++ b/tests/test_audit_provenance.py
@@ -28,12 +28,12 @@ SAMPLE_LESSONS = textwrap.dedent("""\
     [2026-01-15] [RULE:0.95] DRAFTING: Never use em dashes in email prose
       Root cause: User corrected em dashes 8 times across sessions
       Fire count: 12 | Sessions since fire: 1 | Misfires: 0
-      Correction event IDs: evt_abc123, evt_def456
+      Corrections: evt_abc123, evt_def456
 
     [2026-02-10] [PATTERN:0.72] ACCURACY: Always verify data before sending
       Root cause: Sent unverified stats in demo prep
       Fire count: 5 | Sessions since fire: 3 | Misfires: 1
-      Correction event IDs: evt_ghi789
+      Corrections: evt_ghi789
 
     [2026-03-01] [INSTINCT:0.42] PROCESS: Check calendar before scheduling
       Root cause: Double-booked a meeting
@@ -117,11 +117,16 @@ class TestRuleProvenanceTable:
     def test_table_exists_after_migration(self, brain_dir: Path) -> None:
         """rule_provenance table should exist after migrations run."""
         from gradata._migrations import run_migrations
-        # Run migrations on our test DB (table already created in fixture,
-        # but verify migrations don't break it)
-        run_migrations(brain_dir / "system.db")
+        # Drop the table first so we verify migrations actually create it
+        db_path = brain_dir / "system.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("DROP TABLE IF EXISTS rule_provenance")
+        conn.commit()
+        conn.close()
 
-        conn = sqlite3.connect(str(brain_dir / "system.db"))
+        run_migrations(db_path)
+
+        conn = sqlite3.connect(str(db_path))
         cursor = conn.execute(
             "SELECT name FROM sqlite_master WHERE type='table' AND name='rule_provenance'"
         )

--- a/tests/test_batch_approval.py
+++ b/tests/test_batch_approval.py
@@ -241,8 +241,15 @@ class TestRulesPersistWithoutReview:
 
     def test_unreviewed_rules_survive_end_session(self, brain):
         """After end_session, graduated rules still exist even without review."""
-        before_count = len(brain.pending_promotions())
+        before = brain.pending_promotions()
+        before_ids = {r["id"] for r in before}
+        assert len(before_ids) > 0
+
         brain.end_session()
-        # Rules may change state during graduation sweep, but they persist
+
+        # Same rule IDs should still be present in the full rule set
         all_rules = brain.rules(include_all=True)
-        assert len(all_rules) > 0
+        after_ids = {r["id"] for r in all_rules}
+        assert before_ids.issubset(after_ids), (
+            f"Missing rules after end_session: {before_ids - after_ids}"
+        )

--- a/tests/test_batch_approval.py
+++ b/tests/test_batch_approval.py
@@ -1,0 +1,248 @@
+"""Tests for batch approval at session end (Task 4).
+
+Tests:
+- pending_promotions() returns list with rule_id/category/state
+- approve_promotion() returns {approved: True}
+- reject_promotion() demotes and returns {rejected: True}
+- end_session returns graduated_rules key
+- Not reviewing = rules persist (they already passed threshold)
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from gradata._types import Lesson, LessonState
+
+
+# ---------------------------------------------------------------------------
+# Sample lessons: 1 RULE, 1 PATTERN, 1 INSTINCT
+# ---------------------------------------------------------------------------
+
+SAMPLE_LESSONS = textwrap.dedent("""\
+    # Lessons
+
+    [2026-01-15] [RULE:0.95] DRAFTING: Never use em dashes in email prose
+      Root cause: User corrected em dashes 8 times across sessions
+      Fire count: 12 | Sessions since fire: 1 | Misfires: 0
+
+    [2026-02-10] [PATTERN:0.72] ACCURACY: Always verify data before sending
+      Root cause: Sent unverified stats in demo prep
+      Fire count: 5 | Sessions since fire: 3 | Misfires: 1
+
+    [2026-03-01] [INSTINCT:0.42] PROCESS: Check calendar before scheduling
+      Root cause: Double-booked a meeting
+      Fire count: 2 | Sessions since fire: 7 | Misfires: 0
+""")
+
+
+@pytest.fixture()
+def brain_dir(tmp_path: Path) -> Path:
+    """Create a minimal brain directory with lessons.md and system.db."""
+    d = tmp_path / "test-brain"
+    d.mkdir()
+    (d / "lessons.md").write_text(SAMPLE_LESSONS, encoding="utf-8")
+
+    db = d / "system.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS lesson_transitions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            lesson_desc TEXT NOT NULL,
+            category TEXT NOT NULL,
+            old_state TEXT NOT NULL,
+            new_state TEXT NOT NULL,
+            confidence REAL,
+            fire_count INTEGER DEFAULT 0,
+            session INTEGER,
+            transitioned_at TEXT NOT NULL
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts TEXT NOT NULL,
+            session INTEGER,
+            type TEXT NOT NULL,
+            source TEXT,
+            data_json TEXT,
+            tags_json TEXT
+        )"""
+    )
+    conn.commit()
+    conn.close()
+    (d / "events.jsonl").write_text("", encoding="utf-8")
+    return d
+
+
+@pytest.fixture()
+def brain(brain_dir: Path):
+    from gradata.brain import Brain
+    return Brain.init(brain_dir, name="Test", domain="Testing",
+                      embedding="local", interactive=False)
+
+
+# ---------------------------------------------------------------------------
+# pending_promotions tests
+# ---------------------------------------------------------------------------
+
+class TestPendingPromotions:
+    def test_returns_list(self, brain):
+        result = brain.pending_promotions()
+        assert isinstance(result, list)
+
+    def test_contains_pattern_and_rule(self, brain):
+        """Should return lessons in PATTERN or RULE state."""
+        result = brain.pending_promotions()
+        assert len(result) == 2
+        states = {r["state"] for r in result}
+        assert states == {"RULE", "PATTERN"}
+
+    def test_each_item_has_rule_id(self, brain):
+        result = brain.pending_promotions()
+        for item in result:
+            assert "id" in item
+            assert len(item["id"]) > 0
+
+    def test_each_item_has_category(self, brain):
+        result = brain.pending_promotions()
+        for item in result:
+            assert "category" in item
+            assert item["category"] in ("DRAFTING", "ACCURACY")
+
+    def test_each_item_has_state(self, brain):
+        result = brain.pending_promotions()
+        for item in result:
+            assert "state" in item
+            assert item["state"] in ("PATTERN", "RULE")
+
+    def test_instinct_excluded(self, brain):
+        """INSTINCT lessons should not appear in pending promotions."""
+        result = brain.pending_promotions()
+        for item in result:
+            assert item["state"] != "INSTINCT"
+
+    def test_empty_brain(self, tmp_path: Path):
+        """Brain with no lessons returns empty list."""
+        from gradata.brain import Brain
+        d = tmp_path / "empty-brain"
+        b = Brain.init(d, name="Empty", domain="Test",
+                       embedding="local", interactive=False)
+        result = b.pending_promotions()
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# approve_promotion tests
+# ---------------------------------------------------------------------------
+
+class TestApprovePromotion:
+    def test_approve_returns_approved_true(self, brain):
+        promotions = brain.pending_promotions()
+        assert len(promotions) > 0
+        rule_id = promotions[0]["id"]
+        result = brain.approve_promotion(rule_id)
+        assert result["approved"] is True
+
+    def test_approve_nonexistent_returns_error(self, brain):
+        result = brain.approve_promotion("nonexistent-id")
+        assert "error" in result
+
+    def test_approve_preserves_lesson_state(self, brain):
+        """Approving a promotion should not alter the lesson's state or confidence."""
+        promotions = brain.pending_promotions()
+        rule_id = promotions[0]["id"]
+        old_state = promotions[0]["state"]
+        old_conf = promotions[0]["confidence"]
+
+        brain.approve_promotion(rule_id)
+
+        after = brain.pending_promotions()
+        matched = [r for r in after if r["id"] == rule_id]
+        assert len(matched) == 1
+        assert matched[0]["state"] == old_state
+        assert matched[0]["confidence"] == old_conf
+
+
+# ---------------------------------------------------------------------------
+# reject_promotion tests
+# ---------------------------------------------------------------------------
+
+class TestRejectPromotion:
+    def test_reject_returns_rejected_true(self, brain):
+        promotions = brain.pending_promotions()
+        assert len(promotions) > 0
+        rule_id = promotions[0]["id"]
+        result = brain.reject_promotion(rule_id)
+        assert result["rejected"] is True
+
+    def test_reject_returns_demoted_from(self, brain):
+        promotions = brain.pending_promotions()
+        rule_id = promotions[0]["id"]
+        old_state = promotions[0]["state"]
+        result = brain.reject_promotion(rule_id)
+        assert result["demoted_from"] == old_state
+
+    def test_reject_demotes_to_instinct(self, brain):
+        """After rejection, the lesson should be INSTINCT with confidence 0.40."""
+        promotions = brain.pending_promotions()
+        rule_id = promotions[0]["id"]
+        brain.reject_promotion(rule_id)
+
+        # Check that it no longer appears in pending promotions
+        after = brain.pending_promotions()
+        matching = [r for r in after if r["id"] == rule_id]
+        assert len(matching) == 0
+
+        # Check it exists as INSTINCT in all rules
+        all_rules = brain.rules(include_all=True)
+        matching = [r for r in all_rules if r["id"] == rule_id]
+        assert len(matching) == 1
+        assert matching[0]["state"] == "INSTINCT"
+        assert matching[0]["confidence"] == 0.40
+
+    def test_reject_nonexistent_returns_error(self, brain):
+        result = brain.reject_promotion("nonexistent-id")
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# end_session graduated_rules tests
+# ---------------------------------------------------------------------------
+
+class TestEndSessionGraduatedRules:
+    def test_end_session_has_promotions_key(self, brain):
+        result = brain.end_session()
+        assert "promotions" in result
+
+    def test_end_session_has_graduated_rules_key(self, brain):
+        result = brain.end_session()
+        assert "graduated_rules" in result
+        assert isinstance(result["graduated_rules"], list)
+
+
+# ---------------------------------------------------------------------------
+# Not reviewing = rules persist
+# ---------------------------------------------------------------------------
+
+class TestRulesPersistWithoutReview:
+    def test_unreviewed_rules_persist(self, brain):
+        """Rules that passed threshold persist without explicit approval."""
+        before = brain.pending_promotions()
+        assert len(before) > 0
+
+        # Don't call approve or reject — just verify they're still there
+        after = brain.pending_promotions()
+        assert before == after
+
+    def test_unreviewed_rules_survive_end_session(self, brain):
+        """After end_session, graduated rules still exist even without review."""
+        before_count = len(brain.pending_promotions())
+        brain.end_session()
+        # Rules may change state during graduation sweep, but they persist
+        all_rules = brain.rules(include_all=True)
+        assert len(all_rules) > 0

--- a/tests/test_brain_learning.py
+++ b/tests/test_brain_learning.py
@@ -155,66 +155,58 @@ class TestDetectImplicitFeedback:
 # ---------------------------------------------------------------------------
 
 class TestForget:
-    """forget() removes lessons matching description or category."""
+    """forget() — human-friendly undo via plain English strings."""
 
-    def test_raises_if_no_filter_provided(self, fresh_brain):
-        with pytest.raises(ValueError, match="Provide at least one"):
-            fresh_brain.forget()
+    def test_forget_last_no_lessons(self, fresh_brain):
+        result = fresh_brain.forget("last")
+        assert result.get("forgot") is False or result.get("rolled_back") is False
 
-    def test_returns_zero_when_no_lessons_file(self, fresh_brain):
-        # No lessons.md has been created yet — forget() should return 0
-        removed = fresh_brain.forget(description="anything")
-        assert removed == 0
-
-    def test_removes_lessons_by_description_substring(self, tmp_path):
+    def test_forget_last_kills_most_recent(self, tmp_path):
         brain = init_brain(tmp_path)
         _seed_lessons(brain, n=3, category="TONE")
-        removed = brain.forget(description="lesson 1")
-        assert removed == 1
+        result = brain.forget("last")
+        assert result.get("rolled_back") is True
 
-    def test_removes_lessons_by_category(self, tmp_path):
+    def test_forget_last_n(self, tmp_path):
         brain = init_brain(tmp_path)
         _seed_lessons(brain, n=3, category="TONE")
-        removed = brain.forget(category="TONE")
-        assert removed == 3
+        results = brain.forget("last 2")
+        assert isinstance(results, list)
+        assert len(results) == 2
 
-    def test_removes_only_matching_subset(self, tmp_path):
+    def test_forget_by_description_fuzzy(self, tmp_path):
         brain = init_brain(tmp_path)
-        _seed_lessons(brain, n=2, category="TONE")
-        _seed_lessons(brain, n=2, category="FORMAT")
-        removed = brain.forget(category="TONE")
-        assert removed == 2
+        _seed_lessons(brain, n=3, category="TONE")
+        result = brain.forget("lesson 1")
+        assert result.get("rolled_back") is True
 
-    def test_returns_zero_when_nothing_matches(self, tmp_path):
+    def test_forget_all_category(self, tmp_path):
         brain = init_brain(tmp_path)
-        _seed_lessons(brain, n=2, category="TONE")
-        removed = brain.forget(description="this description does not exist xyz999")
-        assert removed == 0
+        _seed_lessons(brain, n=3, category="TONE")
+        results = brain.forget("all TONE")
+        if isinstance(results, list):
+            assert len(results) == 3
+        else:
+            assert results.get("rolled_back") is True
 
-    def test_category_match_is_case_insensitive(self, tmp_path):
-        brain = init_brain(tmp_path)
-        _seed_lessons(brain, n=1, category="TONE")
-        removed = brain.forget(category="tone")
-        assert removed == 1
-
-    def test_lessons_file_updated_after_forget(self, tmp_path):
-        brain = init_brain(tmp_path)
-        _seed_lessons(brain, n=2, category="TONE")
-        brain.forget(category="TONE")
-        # Lessons file is at brain.dir / "lessons.md" (first path _find_lessons_path checks)
-        lessons_path = brain.dir / "lessons.md"
-        if lessons_path.exists():
-            content = lessons_path.read_text(encoding="utf-8")
-            assert "TONE" not in content
-
-    def test_both_filters_applied_as_union(self, tmp_path):
-        """description OR category — both conditions remove matching lessons."""
+    def test_forget_all_category_case_insensitive(self, tmp_path):
         brain = init_brain(tmp_path)
         _seed_lessons(brain, n=1, category="TONE")
-        _seed_lessons(brain, n=1, category="FORMAT")
-        # description matches first TONE lesson, category matches all FORMAT
-        removed = brain.forget(description="lesson 0", category="FORMAT")
-        assert removed >= 2
+        result = brain.forget("all tone")
+        if isinstance(result, dict):
+            assert result.get("rolled_back") is True
+
+    def test_forget_no_match_returns_error(self, tmp_path):
+        brain = init_brain(tmp_path)
+        _seed_lessons(brain, n=2, category="TONE")
+        result = brain.forget("this description does not exist xyz999")
+        assert result.get("rolled_back") is False
+
+    def test_forget_defaults_to_last(self, tmp_path):
+        brain = init_brain(tmp_path)
+        _seed_lessons(brain, n=2, category="TONE")
+        result = brain.forget()
+        assert result.get("rolled_back") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_brain_salt.py
+++ b/tests/test_brain_salt.py
@@ -1,0 +1,102 @@
+"""Tests for per-brain salt — non-deterministic graduation thresholds."""
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+class TestGenerateBrainSalt:
+    """generate_brain_salt() returns a 32-byte random hex string."""
+
+    def test_returns_64_char_hex(self):
+        from gradata.security.brain_salt import generate_brain_salt
+        salt = generate_brain_salt()
+        assert len(salt) == 64
+        assert all(c in "0123456789abcdef" for c in salt)
+
+    def test_100_salts_unique(self):
+        from gradata.security.brain_salt import generate_brain_salt
+        salts = {generate_brain_salt() for _ in range(100)}
+        assert len(salts) == 100
+
+
+class TestLoadOrCreateSalt:
+    """load_or_create_salt() persists and reloads .brain_salt."""
+
+    def test_creates_file(self, tmp_path):
+        from gradata.security.brain_salt import load_or_create_salt
+        salt = load_or_create_salt(tmp_path)
+        salt_file = tmp_path / ".brain_salt"
+        assert salt_file.exists()
+        assert len(salt) == 64
+
+    def test_idempotent(self, tmp_path):
+        from gradata.security.brain_salt import load_or_create_salt
+        salt1 = load_or_create_salt(tmp_path)
+        salt2 = load_or_create_salt(tmp_path)
+        assert salt1 == salt2
+
+    def test_reads_existing_file(self, tmp_path):
+        salt_file = tmp_path / ".brain_salt"
+        salt_file.write_text("aa" * 32)
+        from gradata.security.brain_salt import load_or_create_salt
+        assert load_or_create_salt(tmp_path) == "aa" * 32
+
+
+class TestSaltThreshold:
+    """salt_threshold() perturbs base within +/-5%."""
+
+    def test_within_bounds(self):
+        from gradata.security.brain_salt import salt_threshold, generate_brain_salt
+        salt = generate_brain_salt()
+        for base in [0.60, 0.90]:
+            result = salt_threshold(base, salt, "PATTERN")
+            lo = base * 0.95
+            hi = base * 1.05
+            assert lo <= result <= hi, f"{result} not in [{lo}, {hi}]"
+
+    def test_deterministic_same_salt_and_tier(self):
+        from gradata.security.brain_salt import salt_threshold, generate_brain_salt
+        salt = generate_brain_salt()
+        r1 = salt_threshold(0.60, salt, "PATTERN")
+        r2 = salt_threshold(0.60, salt, "PATTERN")
+        assert r1 == r2
+
+    def test_different_salts_differ(self):
+        from gradata.security.brain_salt import salt_threshold
+        # Use known distinct salts
+        s1 = "aa" * 32
+        s2 = "bb" * 32
+        r1 = salt_threshold(0.60, s1, "PATTERN")
+        r2 = salt_threshold(0.60, s2, "PATTERN")
+        assert r1 != r2
+
+    def test_different_tiers_differ(self):
+        from gradata.security.brain_salt import salt_threshold, generate_brain_salt
+        salt = generate_brain_salt()
+        r_pattern = salt_threshold(0.60, salt, "PATTERN")
+        r_rule = salt_threshold(0.90, salt, "RULE")
+        # Different base AND tier name -> almost certainly different
+        assert r_pattern != r_rule
+
+    def test_same_salt_different_tier_names_differ(self):
+        """Same salt + same base but different tier names produce different jitter."""
+        from gradata.security.brain_salt import salt_threshold
+        salt = "cc" * 32
+        r1 = salt_threshold(0.60, salt, "PATTERN")
+        r2 = salt_threshold(0.60, salt, "RULE")
+        assert r1 != r2
+
+    def test_many_salts_distribution(self):
+        """Over 50 salts, results should spread across the range, not cluster."""
+        from gradata.security.brain_salt import salt_threshold, generate_brain_salt
+        base = 0.60
+        results = [salt_threshold(base, generate_brain_salt(), "PATTERN") for _ in range(50)]
+        lo = base * 0.95
+        hi = base * 1.05
+        for r in results:
+            assert lo <= r <= hi
+        # At least 5 distinct values out of 50
+        assert len(set(results)) >= 5

--- a/tests/test_brain_salt.py
+++ b/tests/test_brain_salt.py
@@ -45,6 +45,24 @@ class TestLoadOrCreateSalt:
         assert load_or_create_salt(tmp_path) == "aa" * 32
 
 
+    def test_creates_missing_parent_dir(self, tmp_path):
+        """load_or_create_salt should create missing parent directories."""
+        from gradata.security.brain_salt import load_or_create_salt
+        nested = tmp_path / "missing_dir" / "deep"
+        salt = load_or_create_salt(nested)
+        assert len(salt) == 64
+        assert (nested / ".brain_salt").exists()
+
+    def test_handles_partial_salt_file(self, tmp_path):
+        """Truncated .brain_salt should be detected and regenerated."""
+        from gradata.security.brain_salt import load_or_create_salt
+        salt_file = tmp_path / ".brain_salt"
+        salt_file.write_text("abcd1234")  # Only 8 chars, not 64
+        salt = load_or_create_salt(tmp_path)
+        assert len(salt) == 64
+        assert salt != "abcd1234"
+
+
 class TestSaltThreshold:
     """salt_threshold() perturbs base within +/-5%."""
 

--- a/tests/test_correction_provenance.py
+++ b/tests/test_correction_provenance.py
@@ -1,0 +1,78 @@
+"""Tests for correction provenance authentication (HMAC-SHA256)."""
+
+from gradata.security.correction_provenance import (
+    create_provenance_record,
+    verify_provenance,
+)
+
+
+class TestCreateProvenance:
+    def test_returns_dict_with_required_fields(self):
+        record = create_provenance_record(
+            user_id="oliver", correction_hash="abc123",
+            session=5, salt="test-salt",
+        )
+        assert isinstance(record, dict)
+        assert record["user_id"] == "oliver"
+        assert record["session"] == 5
+        assert isinstance(record["hmac"], str)
+        assert len(record["hmac"]) == 64  # SHA-256 hex digest
+
+    def test_hmac_is_deterministic_for_same_timestamp(self):
+        """Same inputs + same timestamp = same HMAC."""
+        r1 = create_provenance_record(
+            user_id="u", correction_hash="h", session=1, salt="s",
+        )
+        # Manually rebuild to verify
+        import hashlib, hmac, time
+        msg = f"u|h|1|{r1['timestamp']}"
+        expected = hmac.new(b"s", msg.encode(), hashlib.sha256).hexdigest()
+        assert r1["hmac"] == expected
+
+
+class TestVerifyProvenance:
+    def test_valid_record(self):
+        salt = "my-brain-salt"
+        record = create_provenance_record(
+            user_id="oliver", correction_hash="deadbeef",
+            session=10, salt=salt,
+        )
+        assert verify_provenance(record, salt) is True
+
+    def test_tampered_user_id(self):
+        salt = "salt"
+        record = create_provenance_record(
+            user_id="oliver", correction_hash="abc",
+            session=1, salt=salt,
+        )
+        record["user_id"] = "attacker"
+        assert verify_provenance(record, salt) is False
+
+    def test_tampered_correction_hash(self):
+        salt = "salt"
+        record = create_provenance_record(
+            user_id="oliver", correction_hash="abc",
+            session=1, salt=salt,
+        )
+        record["correction_hash"] = "tampered"
+        assert verify_provenance(record, salt) is False
+
+    def test_tampered_session(self):
+        salt = "salt"
+        record = create_provenance_record(
+            user_id="oliver", correction_hash="abc",
+            session=1, salt=salt,
+        )
+        record["session"] = 999
+        assert verify_provenance(record, salt) is False
+
+    def test_wrong_salt(self):
+        record = create_provenance_record(
+            user_id="oliver", correction_hash="abc",
+            session=1, salt="correct-salt",
+        )
+        assert verify_provenance(record, "wrong-salt") is False
+
+    def test_missing_fields(self):
+        assert verify_provenance({}, "salt") is False
+        assert verify_provenance({"user_id": "x"}, "salt") is False

--- a/tests/test_injection_order.py
+++ b/tests/test_injection_order.py
@@ -1,0 +1,136 @@
+"""Tests for bucketed shuffle injection order — Security Task 4."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from gradata._scope import RuleScope
+from gradata._types import Lesson, LessonState
+from gradata.rules.rule_engine import AppliedRule, format_rules_for_prompt, _make_rule_id
+from gradata.security.score_obfuscation import truncate_score
+
+
+def _make_applied(category: str, state: LessonState, confidence: float) -> AppliedRule:
+    """Helper to build an AppliedRule for testing."""
+    lesson = Lesson(
+        date="2026-04-07",
+        category=category,
+        description=f"{category} rule at {confidence}",
+        state=state,
+        confidence=confidence,
+    )
+    tier = truncate_score(confidence)
+    return AppliedRule(
+        rule_id=_make_rule_id(lesson),
+        lesson=lesson,
+        relevance=0.9,
+        instruction=f"[{tier}] {category}: {lesson.description}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tier ordering
+# ---------------------------------------------------------------------------
+
+
+class TestTierOrdering:
+    """RULE tier before PATTERN, PATTERN before INSTINCT."""
+
+    def test_rule_before_pattern(self) -> None:
+        rules = [
+            _make_applied("PATTERN_CAT", LessonState.PATTERN, 0.75),
+            _make_applied("RULE_CAT", LessonState.RULE, 0.95),
+        ]
+        prompt = format_rules_for_prompt(rules, merge=False, shuffle_seed=42)
+        rule_pos = prompt.index("[RULE]")
+        pattern_pos = prompt.index("[PATTERN]")
+        assert rule_pos < pattern_pos
+
+    def test_pattern_before_instinct(self) -> None:
+        rules = [
+            _make_applied("INSTINCT_CAT", LessonState.INSTINCT, 0.40),
+            _make_applied("PATTERN_CAT", LessonState.PATTERN, 0.70),
+        ]
+        prompt = format_rules_for_prompt(rules, merge=False, shuffle_seed=42)
+        pattern_pos = prompt.index("[PATTERN]")
+        instinct_pos = prompt.index("[INSTINCT]")
+        assert pattern_pos < instinct_pos
+
+    def test_all_three_tiers_ordered(self) -> None:
+        rules = [
+            _make_applied("I", LessonState.INSTINCT, 0.35),
+            _make_applied("P", LessonState.PATTERN, 0.65),
+            _make_applied("R", LessonState.RULE, 0.92),
+        ]
+        prompt = format_rules_for_prompt(rules, merge=False, shuffle_seed=1)
+        rule_pos = prompt.index("[RULE]")
+        pattern_pos = prompt.index("[PATTERN]")
+        instinct_pos = prompt.index("[INSTINCT]")
+        assert rule_pos < pattern_pos < instinct_pos
+
+
+# ---------------------------------------------------------------------------
+# Within-tier shuffle varies with seed
+# ---------------------------------------------------------------------------
+
+
+class TestWithinTierShuffle:
+    """Within-tier order should vary across different seeds."""
+
+    def test_different_seeds_different_order(self) -> None:
+        rules = [
+            _make_applied(f"R{i}", LessonState.RULE, 0.90 + i * 0.01)
+            for i in range(5)
+        ]
+        orders: set[tuple[str, ...]] = set()
+        for seed in range(20):
+            prompt = format_rules_for_prompt(
+                list(rules), merge=False, shuffle_seed=seed,
+            )
+            # Extract rule categories in order from the prompt
+            cats = re.findall(r"\[RULE\] (R\d):", prompt)
+            orders.add(tuple(cats))
+        # With 5 items and 20 seeds, we should see more than one ordering
+        assert len(orders) > 1, "Expected different orderings across seeds"
+
+    def test_same_seed_same_order(self) -> None:
+        rules = [
+            _make_applied(f"R{i}", LessonState.RULE, 0.90 + i * 0.01)
+            for i in range(5)
+        ]
+        prompt1 = format_rules_for_prompt(list(rules), merge=False, shuffle_seed=99)
+        prompt2 = format_rules_for_prompt(list(rules), merge=False, shuffle_seed=99)
+        assert prompt1 == prompt2
+
+
+# ---------------------------------------------------------------------------
+# All rules present after shuffle
+# ---------------------------------------------------------------------------
+
+
+class TestAllRulesPresent:
+    """Every rule must appear in the output regardless of shuffle."""
+
+    def test_all_rules_present(self) -> None:
+        cats = ["ALPHA", "BRAVO", "CHARLIE", "DELTA", "ECHO"]
+        rules = [_make_applied(c, LessonState.RULE, 0.95) for c in cats]
+        prompt = format_rules_for_prompt(rules, merge=False, shuffle_seed=7)
+        for cat in cats:
+            assert cat in prompt, f"Missing rule category {cat} in output"
+
+    def test_mixed_tiers_all_present(self) -> None:
+        rules = [
+            _make_applied("R1", LessonState.RULE, 0.95),
+            _make_applied("R2", LessonState.RULE, 0.92),
+            _make_applied("P1", LessonState.PATTERN, 0.75),
+            _make_applied("P2", LessonState.PATTERN, 0.68),
+            _make_applied("I1", LessonState.INSTINCT, 0.40),
+        ]
+        prompt = format_rules_for_prompt(rules, merge=False, shuffle_seed=3)
+        for r in rules:
+            assert r.lesson.category in prompt
+
+    def test_empty_rules_returns_empty(self) -> None:
+        assert format_rules_for_prompt([], shuffle_seed=42) == ""

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -1,0 +1,287 @@
+"""Tests for the Rule Inspection API (inspection.py + Brain wrappers)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from gradata.inspection import (
+    _dict_to_yaml,
+    _make_rule_id,
+    export_rules,
+    explain_rule,
+    list_rules,
+)
+
+# ---------------------------------------------------------------------------
+# Sample lessons.md content — 3 lessons: 1 RULE, 1 PATTERN, 1 INSTINCT
+# ---------------------------------------------------------------------------
+
+SAMPLE_LESSONS = textwrap.dedent("""\
+    # Lessons
+
+    [2026-01-15] [RULE:0.95] DRAFTING: Never use em dashes in email prose
+      Root cause: User corrected em dashes 8 times across sessions
+      Fire count: 12 | Sessions since fire: 1 | Misfires: 0
+
+    [2026-02-10] [PATTERN:0.72] ACCURACY: Always verify data before sending
+      Root cause: Sent unverified stats in demo prep
+      Fire count: 5 | Sessions since fire: 3 | Misfires: 1
+
+    [2026-03-01] [INSTINCT:0.42] PROCESS: Check calendar before scheduling
+      Root cause: Double-booked a meeting
+      Fire count: 2 | Sessions since fire: 7 | Misfires: 0
+""")
+
+
+@pytest.fixture()
+def brain_dir(tmp_path: Path) -> Path:
+    """Create a minimal brain directory with lessons.md and system.db."""
+    d = tmp_path / "test-brain"
+    d.mkdir()
+
+    # Write lessons.md
+    (d / "lessons.md").write_text(SAMPLE_LESSONS, encoding="utf-8")
+
+    # Create system.db with required tables
+    db = d / "system.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS lesson_transitions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            lesson_desc TEXT NOT NULL,
+            category TEXT NOT NULL,
+            old_state TEXT NOT NULL,
+            new_state TEXT NOT NULL,
+            confidence REAL,
+            fire_count INTEGER DEFAULT 0,
+            session INTEGER,
+            transitioned_at TEXT NOT NULL
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts TEXT NOT NULL,
+            session INTEGER,
+            type TEXT NOT NULL,
+            source TEXT,
+            data_json TEXT,
+            tags_json TEXT
+        )"""
+    )
+    # Insert a transition for the RULE lesson
+    conn.execute(
+        """INSERT INTO lesson_transitions
+           (lesson_desc, category, old_state, new_state, confidence, fire_count, session, transitioned_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+        ("Never use em dashes in email prose", "DRAFTING", "PATTERN", "RULE", 0.95, 12, 50, "2026-01-15T10:00:00"),
+    )
+    conn.commit()
+    conn.close()
+
+    # Create events.jsonl (empty is fine)
+    (d / "events.jsonl").write_text("", encoding="utf-8")
+
+    return d
+
+
+# ---------------------------------------------------------------------------
+# list_rules tests
+# ---------------------------------------------------------------------------
+
+class TestListRules:
+    def test_default_filters_to_pattern_and_rule(self, brain_dir: Path):
+        """Default call returns only PATTERN + RULE lessons."""
+        result = list_rules(db_path=brain_dir / "system.db",
+                            lessons_path=brain_dir / "lessons.md")
+        assert len(result) == 2
+        states = {r["state"] for r in result}
+        assert states == {"RULE", "PATTERN"}
+
+    def test_include_all_returns_everything(self, brain_dir: Path):
+        """include_all=True returns all 3 lessons."""
+        result = list_rules(db_path=brain_dir / "system.db",
+                            lessons_path=brain_dir / "lessons.md",
+                            include_all=True)
+        assert len(result) == 3
+
+    def test_category_filter(self, brain_dir: Path):
+        """Category filter narrows results."""
+        result = list_rules(db_path=brain_dir / "system.db",
+                            lessons_path=brain_dir / "lessons.md",
+                            include_all=True,
+                            category="DRAFTING")
+        assert len(result) == 1
+        assert result[0]["category"] == "DRAFTING"
+
+    def test_empty_lessons_returns_empty_list(self, tmp_path: Path):
+        """No lessons.md returns empty list."""
+        d = tmp_path / "empty-brain"
+        d.mkdir()
+        (d / "lessons.md").write_text("", encoding="utf-8")
+        result = list_rules(db_path=d / "system.db",
+                            lessons_path=d / "lessons.md")
+        assert result == []
+
+    def test_rule_dict_has_expected_keys(self, brain_dir: Path):
+        """Each rule dict has id, state, confidence, category, description."""
+        result = list_rules(db_path=brain_dir / "system.db",
+                            lessons_path=brain_dir / "lessons.md")
+        for r in result:
+            assert "id" in r
+            assert "state" in r
+            assert "confidence" in r
+            assert "category" in r
+            assert "description" in r
+
+
+# ---------------------------------------------------------------------------
+# explain_rule tests
+# ---------------------------------------------------------------------------
+
+class TestExplainRule:
+    def test_explain_existing_rule(self, brain_dir: Path):
+        """explain_rule returns metadata + transitions for an existing rule."""
+        rules = list_rules(db_path=brain_dir / "system.db",
+                           lessons_path=brain_dir / "lessons.md")
+        rule_id = rules[0]["id"]  # first RULE/PATTERN
+        result = explain_rule(db_path=brain_dir / "system.db",
+                              events_path=brain_dir / "events.jsonl",
+                              rule_id=rule_id,
+                              lessons_path=brain_dir / "lessons.md")
+        assert "description" in result
+        assert "category" in result
+        assert "transitions" in result
+
+    def test_explain_nonexistent_rule(self, brain_dir: Path):
+        """explain_rule returns error dict for unknown rule_id."""
+        result = explain_rule(db_path=brain_dir / "system.db",
+                              events_path=brain_dir / "events.jsonl",
+                              rule_id="nonexistent-id",
+                              lessons_path=brain_dir / "lessons.md")
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# export_rules tests
+# ---------------------------------------------------------------------------
+
+class TestExportRules:
+    def test_json_format(self, brain_dir: Path):
+        """JSON export is valid JSON with expected keys."""
+        output = export_rules(db_path=brain_dir / "system.db",
+                              lessons_path=brain_dir / "lessons.md",
+                              format="json")
+        parsed = json.loads(output)
+        assert "rules" in parsed
+        assert "metadata" in parsed
+        assert len(parsed["rules"]) == 2  # default: PATTERN + RULE only
+
+    def test_yaml_format(self, brain_dir: Path):
+        """YAML export contains expected markers."""
+        output = export_rules(db_path=brain_dir / "system.db",
+                              lessons_path=brain_dir / "lessons.md",
+                              format="yaml")
+        assert "rules:" in output
+        assert "category:" in output
+
+    def test_invalid_format_raises(self, brain_dir: Path):
+        """Unsupported format raises ValueError."""
+        with pytest.raises(ValueError, match="Unsupported"):
+            export_rules(db_path=brain_dir / "system.db",
+                         lessons_path=brain_dir / "lessons.md",
+                         format="xml")
+
+
+# ---------------------------------------------------------------------------
+# _dict_to_yaml tests
+# ---------------------------------------------------------------------------
+
+class TestDictToYaml:
+    def test_simple_dict(self):
+        result = _dict_to_yaml({"name": "test", "count": 42})
+        assert "name: test" in result
+        assert "count: 42" in result
+
+    def test_nested_dict(self):
+        result = _dict_to_yaml({"outer": {"inner": "value"}})
+        assert "outer:" in result
+        assert "  inner: value" in result
+
+    def test_list_values(self):
+        result = _dict_to_yaml({"items": ["a", "b"]})
+        assert "- a" in result
+        assert "- b" in result
+
+
+# ---------------------------------------------------------------------------
+# _make_rule_id tests
+# ---------------------------------------------------------------------------
+
+class TestMakeRuleId:
+    def test_stable_id(self):
+        """Same input produces same ID."""
+        from gradata._types import Lesson, LessonState
+        lesson = Lesson(date="2026-01-01", state=LessonState.RULE,
+                        confidence=0.95, category="DRAFTING",
+                        description="Never use em dashes")
+        id1 = _make_rule_id(lesson)
+        id2 = _make_rule_id(lesson)
+        assert id1 == id2
+        assert len(id1) > 0
+
+    def test_different_lessons_different_ids(self):
+        from gradata._types import Lesson, LessonState
+        l1 = Lesson(date="2026-01-01", state=LessonState.RULE,
+                     confidence=0.95, category="DRAFTING",
+                     description="Never use em dashes")
+        l2 = Lesson(date="2026-01-01", state=LessonState.RULE,
+                     confidence=0.95, category="ACCURACY",
+                     description="Verify data first")
+        assert _make_rule_id(l1) != _make_rule_id(l2)
+
+
+# ---------------------------------------------------------------------------
+# Brain wrapper tests
+# ---------------------------------------------------------------------------
+
+class TestBrainWrappers:
+    @pytest.fixture()
+    def brain(self, brain_dir: Path):
+        from gradata.brain import Brain
+        return Brain.init(brain_dir, name="Test", domain="Testing",
+                          embedding="local", interactive=False)
+
+    def test_brain_rules_returns_list(self, brain):
+        result = brain.rules()
+        assert isinstance(result, list)
+
+    def test_brain_explain_returns_dict(self, brain):
+        rules = brain.rules()
+        if rules:
+            result = brain.explain(rules[0]["id"])
+            assert isinstance(result, dict)
+            assert "description" in result
+
+    def test_brain_export_data_json(self, brain):
+        output = brain.export_data(format="json")
+        parsed = json.loads(output)
+        assert "rules" in parsed
+
+    def test_brain_export_data_yaml(self, brain):
+        output = brain.export_data(format="yaml")
+        assert isinstance(output, str)
+
+    def test_brain_rules_empty(self, tmp_path: Path):
+        """Brain with no lessons returns empty list."""
+        from gradata.brain import Brain
+        d = tmp_path / "empty-brain"
+        b = Brain.init(d, name="Empty", domain="Test",
+                       embedding="local", interactive=False)
+        result = b.rules()
+        assert result == []

--- a/tests/test_inspection.py
+++ b/tests/test_inspection.py
@@ -176,7 +176,7 @@ class TestExportRules:
         """JSON export is valid JSON with expected keys."""
         output = export_rules(db_path=brain_dir / "system.db",
                               lessons_path=brain_dir / "lessons.md",
-                              format="json")
+                              output_format="json")
         parsed = json.loads(output)
         assert "rules" in parsed
         assert "metadata" in parsed
@@ -186,7 +186,7 @@ class TestExportRules:
         """YAML export contains expected markers."""
         output = export_rules(db_path=brain_dir / "system.db",
                               lessons_path=brain_dir / "lessons.md",
-                              format="yaml")
+                              output_format="yaml")
         assert "rules:" in output
         assert "category:" in output
 
@@ -195,7 +195,7 @@ class TestExportRules:
         with pytest.raises(ValueError, match="Unsupported"):
             export_rules(db_path=brain_dir / "system.db",
                          lessons_path=brain_dir / "lessons.md",
-                         format="xml")
+                         output_format="xml")
 
 
 # ---------------------------------------------------------------------------
@@ -263,18 +263,18 @@ class TestBrainWrappers:
 
     def test_brain_explain_returns_dict(self, brain):
         rules = brain.rules()
-        if rules:
-            result = brain.explain(rules[0]["id"])
-            assert isinstance(result, dict)
-            assert "description" in result
+        assert len(rules) > 0, "Fixture must seed PATTERN/RULE lessons"
+        result = brain.explain(rules[0]["id"])
+        assert isinstance(result, dict)
+        assert "description" in result
 
     def test_brain_export_data_json(self, brain):
-        output = brain.export_data(format="json")
+        output = brain.export_data(output_format="json")
         parsed = json.loads(output)
         assert "rules" in parsed
 
     def test_brain_export_data_yaml(self, brain):
-        output = brain.export_data(format="yaml")
+        output = brain.export_data(output_format="yaml")
         assert isinstance(output, str)
 
     def test_brain_rules_empty(self, tmp_path: Path):

--- a/tests/test_manifest_signing.py
+++ b/tests/test_manifest_signing.py
@@ -55,3 +55,9 @@ class TestVerifyManifest:
 
     def test_missing_signature_returns_false(self):
         assert verify_manifest(SAMPLE_MANIFEST, SALT) is False
+
+    def test_malformed_signature_type_returns_false(self):
+        """Non-string signature types should fail closed."""
+        for bad_sig in [42, {"key": "val"}, ["sig"], None, True]:
+            manifest = dict(SAMPLE_MANIFEST, signature=bad_sig)
+            assert verify_manifest(manifest, SALT) is False

--- a/tests/test_manifest_signing.py
+++ b/tests/test_manifest_signing.py
@@ -1,0 +1,57 @@
+"""Tests for HMAC-SHA256 manifest signing and verification."""
+
+import copy
+
+import pytest
+
+from gradata.security.manifest_signing import sign_manifest, verify_manifest
+
+
+SAMPLE_MANIFEST = {
+    "brain_id": "test-brain-001",
+    "version": "0.2.1",
+    "rules_count": 42,
+    "domains": ["sales", "engineering"],
+}
+
+SALT = "a" * 64  # deterministic test salt
+
+
+class TestSignManifest:
+    """sign_manifest() adds a 64-char hex signature."""
+
+    def test_adds_64_char_hex_signature(self):
+        signed = sign_manifest(SAMPLE_MANIFEST, SALT)
+        assert "signature" in signed
+        assert len(signed["signature"]) == 64
+        assert all(c in "0123456789abcdef" for c in signed["signature"])
+
+    def test_adds_signed_at(self):
+        signed = sign_manifest(SAMPLE_MANIFEST, SALT)
+        assert "signed_at" in signed
+
+    def test_does_not_mutate_original(self):
+        original = copy.deepcopy(SAMPLE_MANIFEST)
+        sign_manifest(SAMPLE_MANIFEST, SALT)
+        assert SAMPLE_MANIFEST == original
+        assert "signature" not in SAMPLE_MANIFEST
+
+
+class TestVerifyManifest:
+    """verify_manifest() checks HMAC integrity."""
+
+    def test_valid_signature_verifies(self):
+        signed = sign_manifest(SAMPLE_MANIFEST, SALT)
+        assert verify_manifest(signed, SALT) is True
+
+    def test_tampered_content_fails(self):
+        signed = sign_manifest(SAMPLE_MANIFEST, SALT)
+        signed["rules_count"] = 999
+        assert verify_manifest(signed, SALT) is False
+
+    def test_wrong_salt_fails(self):
+        signed = sign_manifest(SAMPLE_MANIFEST, SALT)
+        assert verify_manifest(signed, "b" * 64) is False
+
+    def test_missing_signature_returns_false(self):
+        assert verify_manifest(SAMPLE_MANIFEST, SALT) is False

--- a/tests/test_pii_redaction.py
+++ b/tests/test_pii_redaction.py
@@ -1,0 +1,175 @@
+"""Tests for gradata.safety — PII/credential detection and redaction."""
+
+from __future__ import annotations
+
+import pytest
+
+from gradata.safety import redact_pii, redact_pii_with_report
+
+
+def _build(parts: list[str]) -> str:
+    """Join parts at runtime to avoid static secret-pattern matches."""
+    return "".join(parts)
+
+
+# ── Unit: redact_pii ─────────────────────────────────────────────────
+
+class TestRedactPii:
+    """redact_pii replaces sensitive data with placeholders."""
+
+    def test_email(self):
+        assert redact_pii("contact alice@example.com now") == \
+            "contact [REDACTED_EMAIL] now"
+
+    def test_phone_us(self):
+        assert "[REDACTED_PHONE]" in redact_pii("Call me at (555) 123-4567")
+
+    def test_phone_with_country_code(self):
+        assert "[REDACTED_PHONE]" in redact_pii("Call +1-555-123-4567")
+
+    def test_openai_key(self):
+        # chr(115)+chr(107) = "sk", built to dodge static scanners
+        fake = _build([chr(115), chr(107), "-", "proj-", "a" * 30])
+        result = redact_pii(f"myval={fake}")
+        assert "[REDACTED_OPENAI_KEY]" in result
+        assert fake not in result
+
+    def test_openai_key_classic(self):
+        fake = _build([chr(115), chr(107), "-", "A" * 40])
+        result = redact_pii(f"export VAR={fake}")
+        assert "[REDACTED_OPENAI_KEY]" in result
+
+    def test_github_pat(self):
+        fake = _build(["gh", "p_", "X" * 36])
+        result = redact_pii(f"val: {fake}")
+        assert "[REDACTED_GITHUB_TOKEN]" in result
+        assert fake not in result
+
+    def test_slack_token_redacted(self):
+        fake = _build(["xox", "b-", "1234567890-", "a" * 20])
+        result = redact_pii(f"MYVAR={fake}")
+        assert "[REDACTED_SLACK_TOKEN]" in result
+
+    def test_aws_access_key(self):
+        fake = _build(["AKI", "A", "B" * 16])
+        result = redact_pii(f"val={fake}")
+        assert "[REDACTED_AWS_KEY]" in result
+
+    def test_google_key(self):
+        fake = _build(["AIz", "a", "c" * 35])
+        result = redact_pii(f"gval={fake}")
+        assert "[REDACTED_GOOGLE_KEY]" in result
+
+    def test_gitlab_pat(self):
+        fake = _build(["glpa", "t-", "d" * 20])
+        result = redact_pii(f"GL={fake}")
+        assert "[REDACTED_GITLAB_TOKEN]" in result
+
+    def test_credit_card(self):
+        result = redact_pii("Card: 4111 1111 1111 1111")
+        assert "[REDACTED_CC]" in result
+
+    def test_ssn(self):
+        result = redact_pii("SSN is 123-45-6789")
+        assert "[REDACTED_SSN]" in result
+
+    def test_preserves_normal_text(self):
+        normal = "This is a perfectly normal sentence with no PII."
+        assert redact_pii(normal) == normal
+
+    def test_empty_string(self):
+        assert redact_pii("") == ""
+
+    def test_multiple_same_type(self):
+        text = "a@b.com and c@d.com and e@f.com"
+        result = redact_pii(text)
+        assert result.count("[REDACTED_EMAIL]") == 3
+        assert "@" not in result
+
+    def test_multiple_different_types(self):
+        fake = _build([chr(115), chr(107), "-", "x" * 30])
+        text = f"val={fake} email=test@test.com ssn=123-45-6789"
+        result = redact_pii(text)
+        assert "[REDACTED_OPENAI_KEY]" in result
+        assert "[REDACTED_EMAIL]" in result
+        assert "[REDACTED_SSN]" in result
+
+
+# ── Unit: redact_pii_with_report ─────────────────────────────────────
+
+class TestRedactPiiWithReport:
+    """redact_pii_with_report returns cleaned text plus a report dict."""
+
+    def test_report_structure(self):
+        _, report = redact_pii_with_report("user@example.com")
+        assert "redactions_count" in report
+        assert "types_found" in report
+        assert "redacted" in report
+
+    def test_report_count(self):
+        text = "a@b.com and c@d.com"
+        _, report = redact_pii_with_report(text)
+        assert report["redactions_count"] == 2
+        assert report["types_found"] == ["email"]
+        assert report["redacted"] is True
+
+    def test_report_no_pii(self):
+        _, report = redact_pii_with_report("nothing sensitive here")
+        assert report["redactions_count"] == 0
+        assert report["types_found"] == []
+        assert report["redacted"] is False
+
+    def test_report_multiple_types(self):
+        text = "email test@test.com ssn 123-45-6789"
+        cleaned, report = redact_pii_with_report(text)
+        assert report["redactions_count"] == 2
+        assert "email" in report["types_found"]
+        assert "ssn" in report["types_found"]
+        assert report["redacted"] is True
+
+    def test_empty(self):
+        cleaned, report = redact_pii_with_report("")
+        assert cleaned == ""
+        assert report["redacted"] is False
+
+
+# ── Integration: brain.correct() with PII ────────────────────────────
+
+class TestBrainCorrectPiiIntegration:
+    """Verify that brain.correct() redacts PII before storage but
+    extracts behavioral instructions from full text."""
+
+    @pytest.fixture()
+    def brain(self, tmp_path):
+        from gradata.brain import Brain
+        return Brain(brain_dir=str(tmp_path))
+
+    def test_pii_redacted_in_stored_event(self, brain):
+        """PII in draft/final should be redacted in the emitted event data."""
+        draft = "Send report to alice@notify.com"
+        final = "Send report to the client"
+        result = brain.correct(draft, final)
+        stored_draft = result.get("data", {}).get("draft_text", "")
+        # The email in draft should be redacted
+        assert "alice@notify.com" not in stored_draft
+        assert "[REDACTED_EMAIL]" in stored_draft
+
+    def test_behavioral_extraction_uses_full_text(self, brain):
+        """Extraction should work on the full unredacted text, so
+        classifications/summary still reference meaningful content."""
+        draft = "Contact alice@notify.com for the credentials"
+        final = "Contact the client for access credentials"
+        result = brain.correct(draft, final)
+        # Should still produce valid classifications from the full diff
+        assert "classifications" in result
+        assert result.get("data", {}).get("severity") != "unknown"
+
+    def test_key_redacted_in_event(self, brain):
+        """Credential patterns in draft text must not leak to storage."""
+        fake = _build([chr(115), chr(107), "-", "proj-", "K" * 30])
+        draft = f"Use credential {fake} to authenticate"
+        final = "Use the provided credentials to authenticate"
+        result = brain.correct(draft, final)
+        stored_draft = result.get("data", {}).get("draft_text", "")
+        assert fake not in stored_draft
+        assert "[REDACTED_OPENAI_KEY]" in stored_draft

--- a/tests/test_pii_redaction.py
+++ b/tests/test_pii_redaction.py
@@ -155,14 +155,19 @@ class TestBrainCorrectPiiIntegration:
         assert "[REDACTED_EMAIL]" in stored_draft
 
     def test_behavioral_extraction_uses_full_text(self, brain):
-        """Extraction should work on the full unredacted text, so
-        classifications/summary still reference meaningful content."""
+        """Extraction should produce meaningful classification from unredacted text,
+        and redacted input should produce weaker results."""
         draft = "Contact alice@notify.com for the credentials"
         final = "Contact the client for access credentials"
         result = brain.correct(draft, final)
         # Should still produce valid classifications from the full diff
         assert "classifications" in result
-        assert result.get("data", {}).get("severity") != "unknown"
+        severity = result.get("data", {}).get("severity", "unknown")
+        assert severity != "unknown"
+        # Control: pre-redacted draft should still classify but may differ
+        redacted_draft = "Contact [REDACTED_EMAIL] for the credentials"
+        result_redacted = brain.correct(redacted_draft, final)
+        assert "classifications" in result_redacted
 
     def test_key_redacted_in_event(self, brain):
         """Credential patterns in draft text must not leak to storage."""

--- a/tests/test_query_budget.py
+++ b/tests/test_query_budget.py
@@ -1,6 +1,6 @@
 """Tests for sliding-window query budgeting."""
 
-import time
+from unittest.mock import patch
 
 import pytest
 
@@ -38,28 +38,46 @@ class TestBurstDetection:
     """detect_anomalies flags bursts when recent rate > 3x average."""
 
     def test_burst_detected(self):
-        qb = QueryBudget(window_seconds=300, max_calls=1000)
+        """Simulate slow calls then a fast burst using mocked time."""
+        _clock = [0.0]
 
-        # 10 slow calls spread across ~2s (5 calls/sec average)
-        for _ in range(10):
-            qb.record("ep")
-            time.sleep(0.2)
+        def _monotonic():
+            return _clock[0]
 
-        # 50 fast calls in a tight burst (>>15 calls/sec)
-        for _ in range(50):
-            qb.record("ep")
+        with patch("gradata.security.query_budget.time") as mock_time:
+            mock_time.monotonic = _monotonic
+            qb = QueryBudget(window_seconds=300, max_calls=1000)
 
-        result = qb.detect_anomalies("ep")
-        assert result["burst"] is True
+            # 10 slow calls spread across 2s
+            for _ in range(10):
+                qb.record("ep")
+                _clock[0] += 0.2
+
+            # 50 fast calls in a tight burst
+            for _ in range(50):
+                qb.record("ep")
+                _clock[0] += 0.001
+
+            result = qb.detect_anomalies("ep")
+            assert result["burst"] is True
 
     def test_no_false_positive_on_normal_usage(self):
-        qb = QueryBudget(window_seconds=300, max_calls=1000)
-        # 20 calls at a steady pace
-        for _ in range(20):
-            qb.record("ep")
-            time.sleep(0.02)
-        result = qb.detect_anomalies("ep")
-        assert result["burst"] is False
+        """Steady-pace calls should not trigger burst detection."""
+        _clock = [0.0]
+
+        def _monotonic():
+            return _clock[0]
+
+        with patch("gradata.security.query_budget.time") as mock_time:
+            mock_time.monotonic = _monotonic
+            qb = QueryBudget(window_seconds=300, max_calls=1000)
+
+            for _ in range(20):
+                qb.record("ep")
+                _clock[0] += 0.02
+
+            result = qb.detect_anomalies("ep")
+            assert result["burst"] is False
 
     def test_below_minimum_calls_no_burst(self):
         qb = QueryBudget(window_seconds=300, max_calls=1000)
@@ -73,8 +91,37 @@ class TestWindowExpiry:
     """Expired timestamps are pruned and count drops to 0."""
 
     def test_window_expiry(self):
-        qb = QueryBudget(window_seconds=1, max_calls=100)
-        qb.record("ep")
-        assert qb.count("ep") == 1
-        time.sleep(1.1)
-        assert qb.count("ep") == 0
+        """Use mocked time to simulate window expiry without sleeping."""
+        _clock = [0.0]
+
+        def _monotonic():
+            return _clock[0]
+
+        with patch("gradata.security.query_budget.time") as mock_time:
+            mock_time.monotonic = _monotonic
+            qb = QueryBudget(window_seconds=1, max_calls=100)
+            qb.record("ep")
+            assert qb.count("ep") == 1
+
+            _clock[0] += 1.1  # Advance past the 1s window
+            assert qb.count("ep") == 0
+
+
+class TestInitValidation:
+    """Constructor rejects invalid parameters."""
+
+    def test_rejects_zero_window(self):
+        with pytest.raises(ValueError, match="positive"):
+            QueryBudget(window_seconds=0)
+
+    def test_rejects_negative_window(self):
+        with pytest.raises(ValueError, match="positive"):
+            QueryBudget(window_seconds=-1)
+
+    def test_rejects_negative_max_calls(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            QueryBudget(max_calls=-1)
+
+    def test_accepts_zero_max_calls(self):
+        qb = QueryBudget(max_calls=0)
+        assert qb.max_calls == 0

--- a/tests/test_query_budget.py
+++ b/tests/test_query_budget.py
@@ -1,0 +1,80 @@
+"""Tests for sliding-window query budgeting."""
+
+import time
+
+import pytest
+
+from gradata.security.query_budget import QueryBudget
+
+
+class TestRecordAndCount:
+    """record() stores timestamps, count() returns the window total."""
+
+    def test_count_after_records(self):
+        qb = QueryBudget(window_seconds=60, max_calls=100)
+        for _ in range(5):
+            qb.record("apply_rules")
+        assert qb.count("apply_rules") == 5
+
+    def test_count_zero_for_unknown_endpoint(self):
+        qb = QueryBudget()
+        assert qb.count("unknown") == 0
+
+
+class TestRateLimitExceeded:
+    """is_rate_exceeded returns True after max_calls+1."""
+
+    def test_exceeded_after_max_plus_one(self):
+        budget = 10
+        qb = QueryBudget(window_seconds=60, max_calls=budget)
+        for _ in range(budget):
+            qb.record("ep")
+        assert not qb.is_rate_exceeded("ep")
+        qb.record("ep")  # max_calls + 1
+        assert qb.is_rate_exceeded("ep")
+
+
+class TestBurstDetection:
+    """detect_anomalies flags bursts when recent rate > 3x average."""
+
+    def test_burst_detected(self):
+        qb = QueryBudget(window_seconds=300, max_calls=1000)
+
+        # 10 slow calls spread across ~2s (5 calls/sec average)
+        for _ in range(10):
+            qb.record("ep")
+            time.sleep(0.2)
+
+        # 50 fast calls in a tight burst (>>15 calls/sec)
+        for _ in range(50):
+            qb.record("ep")
+
+        result = qb.detect_anomalies("ep")
+        assert result["burst"] is True
+
+    def test_no_false_positive_on_normal_usage(self):
+        qb = QueryBudget(window_seconds=300, max_calls=1000)
+        # 20 calls at a steady pace
+        for _ in range(20):
+            qb.record("ep")
+            time.sleep(0.02)
+        result = qb.detect_anomalies("ep")
+        assert result["burst"] is False
+
+    def test_below_minimum_calls_no_burst(self):
+        qb = QueryBudget(window_seconds=300, max_calls=1000)
+        for _ in range(5):
+            qb.record("ep")
+        result = qb.detect_anomalies("ep")
+        assert result["burst"] is False
+
+
+class TestWindowExpiry:
+    """Expired timestamps are pruned and count drops to 0."""
+
+    def test_window_expiry(self):
+        qb = QueryBudget(window_seconds=1, max_calls=100)
+        qb.record("ep")
+        assert qb.count("ep") == 1
+        time.sleep(1.1)
+        assert qb.count("ep") == 0

--- a/tests/test_rule_engine_v2.py
+++ b/tests/test_rule_engine_v2.py
@@ -231,7 +231,7 @@ class TestMergeRelatedRules:
         assert "merged_" in result[0].rule_id
         assert "Rule A" in result[0].instruction
         assert "Rule B" in result[0].instruction
-        assert "0.95" in result[0].instruction  # highest confidence
+        assert "[RULE]" in result[0].instruction  # tier label, no raw float
 
     def test_different_categories_stay_separate(self):
         r1 = _make_applied(_make_lesson(category="DRAFTING", description="A"))

--- a/tests/test_rule_engine_v2.py
+++ b/tests/test_rule_engine_v2.py
@@ -387,7 +387,7 @@ class TestMakeRuleId:
         lesson = _make_lesson(category="DRAFTING", description="Test rule")
         rule_id = _make_rule_id(lesson)
         assert rule_id.startswith("DRAFTING:")
-        assert len(rule_id.split(":")[1]) == 4
+        assert len(rule_id.split(":")[1]) == 8
 
     def test_deterministic(self):
         lesson = _make_lesson(description="Same desc")

--- a/tests/test_rule_metadata.py
+++ b/tests/test_rule_metadata.py
@@ -1,0 +1,91 @@
+"""Tests for RuleMetadata dataclass and its integration with Lesson."""
+
+from gradata._types import Lesson, LessonState, RuleMetadata
+
+
+class TestRuleMetadataDefaults:
+    def test_defaults(self):
+        m = RuleMetadata()
+        assert m.what == ""
+        assert m.why == ""
+        assert m.who == ""
+        assert m.when_created == ""
+        assert m.when_validated == ""
+        assert m.where_scope == ""
+        assert m.how_enforced == "injected"
+        assert m.utility_score == 0.5
+        assert m.safety_score == 0.5
+
+
+class TestRuleMetadataCustom:
+    def test_custom_values(self):
+        m = RuleMetadata(
+            what="no em dashes",
+            why="user preference",
+            who="oliver",
+            when_created="2026-04-07",
+            when_validated="2026-04-08",
+            where_scope="email",
+            how_enforced="injected",
+            utility_score=0.8,
+            safety_score=0.3,
+        )
+        assert m.what == "no em dashes"
+        assert m.why == "user preference"
+        assert m.who == "oliver"
+        assert m.when_created == "2026-04-07"
+        assert m.when_validated == "2026-04-08"
+        assert m.where_scope == "email"
+        assert m.utility_score == 0.8
+        assert m.safety_score == 0.3
+
+
+class TestRuleMetadataClamping:
+    def test_clamp_high(self):
+        m = RuleMetadata(utility_score=1.5, safety_score=2.0)
+        assert m.utility_score == 1.0
+        assert m.safety_score == 1.0
+
+    def test_clamp_low(self):
+        m = RuleMetadata(utility_score=-0.2, safety_score=-5.0)
+        assert m.utility_score == 0.0
+        assert m.safety_score == 0.0
+
+    def test_clamp_edge(self):
+        m = RuleMetadata(utility_score=0.0, safety_score=1.0)
+        assert m.utility_score == 0.0
+        assert m.safety_score == 1.0
+
+
+class TestRuleMetadataToDict:
+    def test_to_dict_all_fields(self):
+        m = RuleMetadata(what="test", utility_score=0.7)
+        d = m.to_dict()
+        assert isinstance(d, dict)
+        assert d["what"] == "test"
+        assert d["utility_score"] == 0.7
+        assert d["safety_score"] == 0.5
+        assert set(d.keys()) == {
+            "what", "why", "who", "when_created", "when_validated",
+            "where_scope", "how_enforced", "utility_score", "safety_score",
+        }
+
+
+class TestLessonMetadataField:
+    def test_lesson_has_metadata(self):
+        lesson = Lesson(
+            date="2026-04-07", state=LessonState.INSTINCT,
+            confidence=0.4, category="TEST", description="test lesson",
+        )
+        assert isinstance(lesson.metadata, RuleMetadata)
+        assert lesson.metadata.utility_score == 0.5
+
+    def test_lesson_metadata_independent(self):
+        """Each Lesson gets its own RuleMetadata (not shared)."""
+        a = Lesson(date="2026-01-01", state=LessonState.INSTINCT,
+                   confidence=0.4, category="A", description="a")
+        b = Lesson(date="2026-01-01", state=LessonState.INSTINCT,
+                   confidence=0.4, category="B", description="b")
+        a.metadata.utility_score = 0.9
+        assert b.metadata.utility_score == 0.5
+        assert a.metadata is not b.metadata

--- a/tests/test_safety_assertion.py
+++ b/tests/test_safety_assertion.py
@@ -116,16 +116,24 @@ class TestDocstring:
     def test_docstring_mentions_min_applications(self) -> None:
         doc = graduate.__doc__
         assert doc is not None, "graduate() has no docstring"
-        # Must mention the 3-fire requirement
-        assert "3" in doc or "MIN_APPLICATIONS" in doc, (
-            "Docstring does not document the 3-fire requirement"
+        # Must mention the exact fire-count thresholds
+        assert "fire_count >= 3" in doc or "MIN_APPLICATIONS_FOR_PATTERN" in doc, (
+            "Docstring does not document the 3-fire requirement for PATTERN"
+        )
+        assert "fire_count >= 5" in doc or "MIN_APPLICATIONS_FOR_RULE" in doc, (
+            "Docstring does not document the 5-fire requirement for RULE"
         )
 
     def test_docstring_mentions_pattern_and_rule_thresholds(self) -> None:
         doc = graduate.__doc__
         assert doc is not None
-        assert "PATTERN" in doc
-        assert "RULE" in doc
+        # Must mention the specific transitions
+        assert "INSTINCT -> PATTERN" in doc or "INSTINCT → PATTERN" in doc, (
+            "Docstring must document INSTINCT -> PATTERN transition"
+        )
+        assert "PATTERN -> RULE" in doc or "PATTERN → RULE" in doc, (
+            "Docstring must document PATTERN -> RULE transition"
+        )
 
 
 class TestConfidenceJumpWarning:

--- a/tests/test_safety_assertion.py
+++ b/tests/test_safety_assertion.py
@@ -1,0 +1,160 @@
+"""Tests for graduate() safety assertions and fire-count guards.
+
+Validates that:
+- INSTINCT cannot promote to PATTERN without 3+ fires
+- PATTERN cannot promote to RULE without 5+ fires
+- Zero confidence never promotes regardless of fires
+- graduate() docstring documents the fire-count requirements
+- Confidence jump warning fires when _pre_session_confidence is set
+"""
+
+from __future__ import annotations
+
+import logging
+
+from gradata._types import Lesson, LessonState
+from gradata.enhancements.self_improvement import (
+    MIN_APPLICATIONS_FOR_PATTERN,
+    MIN_APPLICATIONS_FOR_RULE,
+    PATTERN_THRESHOLD,
+    RULE_THRESHOLD,
+    graduate,
+)
+
+
+def _make_lesson(
+    *,
+    state: LessonState = LessonState.INSTINCT,
+    confidence: float = 0.50,
+    fire_count: int = 0,
+    category: str = "TEST",
+    description: str = "test lesson",
+) -> Lesson:
+    return Lesson(
+        date="2026-04-07",
+        state=state,
+        confidence=confidence,
+        category=category,
+        description=description,
+        fire_count=fire_count,
+    )
+
+
+class TestFireCountGuards:
+    """INSTINCT->PATTERN requires 3+ fires, PATTERN->RULE requires 5+ fires."""
+
+    def test_no_pattern_without_3_fires(self) -> None:
+        """High confidence alone cannot promote INSTINCT -> PATTERN."""
+        lesson = _make_lesson(
+            state=LessonState.INSTINCT,
+            confidence=PATTERN_THRESHOLD + 0.05,
+            fire_count=MIN_APPLICATIONS_FOR_PATTERN - 1,  # 2 fires, need 3
+        )
+        active, graduated = graduate([lesson])
+        assert lesson.state == LessonState.INSTINCT, (
+            f"Promoted to {lesson.state} with only {lesson.fire_count} fires"
+        )
+
+    def test_pattern_with_3_fires(self) -> None:
+        """INSTINCT -> PATTERN succeeds with 3+ fires and sufficient confidence."""
+        lesson = _make_lesson(
+            state=LessonState.INSTINCT,
+            confidence=PATTERN_THRESHOLD + 0.05,
+            fire_count=MIN_APPLICATIONS_FOR_PATTERN,
+        )
+        active, graduated = graduate([lesson])
+        assert lesson.state == LessonState.PATTERN
+
+    def test_no_rule_without_5_fires(self) -> None:
+        """High confidence alone cannot promote PATTERN -> RULE."""
+        lesson = _make_lesson(
+            state=LessonState.PATTERN,
+            confidence=RULE_THRESHOLD + 0.01,
+            fire_count=MIN_APPLICATIONS_FOR_RULE - 1,  # 4 fires, need 5
+        )
+        active, graduated = graduate([lesson])
+        assert lesson.state == LessonState.PATTERN, (
+            f"Promoted to {lesson.state} with only {lesson.fire_count} fires"
+        )
+
+    def test_rule_with_5_fires(self) -> None:
+        """PATTERN -> RULE succeeds with 5+ fires and sufficient confidence."""
+        lesson = _make_lesson(
+            state=LessonState.PATTERN,
+            confidence=RULE_THRESHOLD + 0.01,
+            fire_count=MIN_APPLICATIONS_FOR_RULE,
+        )
+        active, graduated = graduate([lesson])
+        assert lesson.state == LessonState.RULE
+
+
+class TestZeroConfidenceNeverPromotes:
+    """Zero confidence lessons get killed, never promoted."""
+
+    def test_zero_confidence_instinct_killed(self) -> None:
+        lesson = _make_lesson(
+            state=LessonState.INSTINCT,
+            confidence=0.0,
+            fire_count=100,  # Lots of fires, but zero confidence
+        )
+        graduate([lesson])
+        assert lesson.state == LessonState.KILLED
+
+    def test_zero_confidence_pattern_killed(self) -> None:
+        lesson = _make_lesson(
+            state=LessonState.PATTERN,
+            confidence=0.0,
+            fire_count=100,
+        )
+        graduate([lesson])
+        assert lesson.state == LessonState.KILLED
+
+
+class TestDocstring:
+    """graduate() docstring must document fire-count requirements."""
+
+    def test_docstring_mentions_min_applications(self) -> None:
+        doc = graduate.__doc__
+        assert doc is not None, "graduate() has no docstring"
+        # Must mention the 3-fire requirement
+        assert "3" in doc or "MIN_APPLICATIONS" in doc, (
+            "Docstring does not document the 3-fire requirement"
+        )
+
+    def test_docstring_mentions_pattern_and_rule_thresholds(self) -> None:
+        doc = graduate.__doc__
+        assert doc is not None
+        assert "PATTERN" in doc
+        assert "RULE" in doc
+
+
+class TestConfidenceJumpWarning:
+    """Safety assertion logs warning on excessive single-session confidence jump."""
+
+    def test_large_jump_logs_warning(self, caplog) -> None:
+        """Confidence jump > PATTERN_THRESHOLD triggers warning log."""
+        lesson = _make_lesson(
+            state=LessonState.INSTINCT,
+            confidence=0.80,
+            fire_count=MIN_APPLICATIONS_FOR_PATTERN,
+        )
+        lesson._pre_session_confidence = 0.10  # type: ignore[attr-defined]
+        # jump = 0.80 - 0.10 = 0.70 > PATTERN_THRESHOLD (0.60)
+        with caplog.at_level(logging.WARNING, logger="gradata.enhancements.self_improvement"):
+            graduate([lesson])
+        assert any("Safety assertion" in r.message for r in caplog.records), (
+            "Expected warning about confidence jump"
+        )
+
+    def test_small_jump_no_warning(self, caplog) -> None:  # type: ignore[override]
+        """Small confidence jump does not trigger warning."""
+        lesson = _make_lesson(
+            state=LessonState.INSTINCT,
+            confidence=0.65,
+            fire_count=MIN_APPLICATIONS_FOR_PATTERN,
+        )
+        lesson._pre_session_confidence = 0.55  # type: ignore[attr-defined]
+        # jump = 0.65 - 0.55 = 0.10 < PATTERN_THRESHOLD (0.60)
+        with caplog.at_level(logging.WARNING, logger="gradata.enhancements.self_improvement"):
+            graduate([lesson])
+        assert not any("Safety assertion" in r.message for r in caplog.records)

--- a/tests/test_scope_tagging.py
+++ b/tests/test_scope_tagging.py
@@ -1,0 +1,162 @@
+"""Tests for Correction Scope Tagging (Task 2: SDK P0 hardening).
+
+Verifies:
+- CorrectionScope enum exists with 4 values
+- Default correction gets domain scope
+- Explicit scope override works
+- Scope flows into lesson's scope_json
+- ONE_OFF lessons never graduate past INSTINCT
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gradata._types import CorrectionScope, Lesson, LessonState
+
+
+# ---------------------------------------------------------------------------
+# CorrectionScope enum
+# ---------------------------------------------------------------------------
+
+def test_correction_scope_enum_has_four_values():
+    """CorrectionScope has exactly UNIVERSAL, DOMAIN, PROJECT, ONE_OFF."""
+    assert CorrectionScope.UNIVERSAL.value == "universal"
+    assert CorrectionScope.DOMAIN.value == "domain"
+    assert CorrectionScope.PROJECT.value == "project"
+    assert CorrectionScope.ONE_OFF.value == "one_off"
+    assert len(CorrectionScope) == 4
+
+
+# ---------------------------------------------------------------------------
+# Default scope = domain
+# ---------------------------------------------------------------------------
+
+def test_default_scope_is_domain(tmp_path: Path):
+    """brain.correct() without scope param defaults to 'domain'."""
+    from tests.conftest import init_brain
+
+    brain = init_brain(tmp_path)
+    result = brain.correct("Use em dash — here", "Use colon: here")
+    # The correction data should have correction_scope = "domain"
+    assert result.get("correction_scope") == "domain"
+
+
+# ---------------------------------------------------------------------------
+# Explicit scope override
+# ---------------------------------------------------------------------------
+
+def test_explicit_scope_universal(tmp_path: Path):
+    """brain.correct(scope='universal') sets correction_scope to universal."""
+    from tests.conftest import init_brain
+
+    brain = init_brain(tmp_path)
+    result = brain.correct("bad output", "good output", scope="universal")
+    assert result.get("correction_scope") == "universal"
+
+
+def test_explicit_scope_one_off(tmp_path: Path):
+    """brain.correct(scope='one_off') sets correction_scope to one_off."""
+    from tests.conftest import init_brain
+
+    brain = init_brain(tmp_path)
+    result = brain.correct("wrong thing", "right thing", scope="one_off")
+    assert result.get("correction_scope") == "one_off"
+
+
+# ---------------------------------------------------------------------------
+# Scope flows into lesson scope_json
+# ---------------------------------------------------------------------------
+
+def test_scope_in_lesson_scope_json(tmp_path: Path):
+    """correction_scope appears in the new lesson's scope_json."""
+    from tests.conftest import init_brain
+    from gradata.enhancements.self_improvement import parse_lessons
+
+    brain = init_brain(tmp_path)
+    # Use a major edit to ensure severity threshold is met and lesson is created
+    brain.correct(
+        "This is a completely wrong paragraph that needs total rewriting with different content.",
+        "Here is the corrected version with entirely new accurate information and proper formatting.",
+        scope="project",
+    )
+
+    lessons_path = brain._find_lessons_path()
+    assert lessons_path and lessons_path.is_file(), "lessons.md not created"
+    text = lessons_path.read_text(encoding="utf-8")
+    lessons = parse_lessons(text)
+    assert len(lessons) >= 1, f"No lessons created. File content:\n{text[:500]}"
+    # Find the newly created lesson with correction_scope
+    new_lessons = [l for l in lessons if l.scope_json and "correction_scope" in l.scope_json]
+    assert len(new_lessons) >= 1, f"No lesson with correction_scope found. scope_jsons: {[l.scope_json for l in lessons]}"
+    scope_data = json.loads(new_lessons[0].scope_json)
+    assert scope_data.get("correction_scope") == "project"
+
+
+# ---------------------------------------------------------------------------
+# ONE_OFF never graduates past INSTINCT
+# ---------------------------------------------------------------------------
+
+def test_one_off_never_graduates_past_instinct():
+    """A one_off lesson with high confidence stays at INSTINCT."""
+    from gradata.enhancements.self_improvement import graduate
+
+    scope = json.dumps({"correction_scope": "one_off"})
+    lesson = Lesson(
+        date="2026-04-07",
+        state=LessonState.INSTINCT,
+        confidence=0.95,  # Way above PATTERN threshold
+        category="DRAFTING",
+        description="Fix this one specific typo",
+        fire_count=10,  # Meets all fire count thresholds
+        scope_json=scope,
+    )
+
+    active, graduated = graduate([lesson])
+    # Should still be INSTINCT — blocked from promotion
+    assert lesson.state == LessonState.INSTINCT
+    assert lesson in active
+
+
+def test_one_off_at_pattern_does_not_promote_to_rule():
+    """Even if a one_off lesson somehow reaches PATTERN, it shouldn't promote to RULE."""
+    from gradata.enhancements.self_improvement import graduate
+
+    scope = json.dumps({"correction_scope": "one_off"})
+    lesson = Lesson(
+        date="2026-04-07",
+        state=LessonState.PATTERN,
+        confidence=0.95,
+        category="DRAFTING",
+        description="Fix this one specific formatting issue",
+        fire_count=10,
+        scope_json=scope,
+    )
+
+    active, graduated = graduate([lesson])
+    # Should stay at PATTERN — blocked from RULE promotion
+    assert lesson.state == LessonState.PATTERN
+    assert lesson in active
+
+
+def test_non_one_off_can_graduate():
+    """A domain-scoped lesson with high confidence DOES graduate normally."""
+    from gradata.enhancements.self_improvement import graduate
+
+    scope = json.dumps({"correction_scope": "domain"})
+    lesson = Lesson(
+        date="2026-04-07",
+        state=LessonState.INSTINCT,
+        confidence=0.65,  # Above PATTERN threshold
+        category="DRAFTING",
+        description="Never use em dashes in prose",
+        fire_count=5,
+        scope_json=scope,
+    )
+
+    active, graduated = graduate([lesson])
+    # Should promote to PATTERN
+    assert lesson.state == LessonState.PATTERN

--- a/tests/test_score_obfuscation.py
+++ b/tests/test_score_obfuscation.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import pytest
 
+import time
+
 from gradata.security.score_obfuscation import (
     _SCORE_PATTERN,
+    constant_time_pad,
     obfuscate_instruction,
     truncate_score,
 )
@@ -140,3 +143,44 @@ class TestFormatRulesNoRawFloats:
         )
         # Should contain the tier label without float
         assert "[RULE]" in prompt
+
+
+# ---------------------------------------------------------------------------
+# constant_time_pad
+# ---------------------------------------------------------------------------
+
+
+class TestConstantTimePad:
+    """Verify timing-attack defense via constant_time_pad."""
+
+    def test_padded_takes_at_least_min_ms(self) -> None:
+        """Padded function should take at least min_ms milliseconds."""
+        min_ms = 30.0
+        start = time.perf_counter()
+        constant_time_pad(lambda: 42, min_ms=min_ms, jitter_ms=0.0)
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        assert elapsed_ms >= min_ms * 0.95, (
+            f"Expected >= {min_ms * 0.95:.1f}ms, got {elapsed_ms:.1f}ms"
+        )
+
+    def test_returns_function_result(self) -> None:
+        """Should return whatever fn() returns."""
+        result = constant_time_pad(lambda: "hello", min_ms=5.0, jitter_ms=0.0)
+        assert result == "hello"
+
+    def test_returns_none_from_void_fn(self) -> None:
+        result = constant_time_pad(lambda: None, min_ms=5.0, jitter_ms=0.0)
+        assert result is None
+
+    def test_jitter_adds_variance(self) -> None:
+        """With jitter, not all durations should be identical."""
+        durations: list[float] = []
+        for _ in range(10):
+            start = time.perf_counter()
+            constant_time_pad(lambda: 1, min_ms=5.0, jitter_ms=10.0)
+            durations.append((time.perf_counter() - start) * 1000)
+        # With 10ms jitter range over 10 runs, we expect some variance
+        assert max(durations) - min(durations) > 0.5, (
+            f"Expected timing variance from jitter, got spread "
+            f"{max(durations) - min(durations):.2f}ms"
+        )

--- a/tests/test_score_obfuscation.py
+++ b/tests/test_score_obfuscation.py
@@ -1,0 +1,142 @@
+"""Tests for score obfuscation — Security Task 1."""
+
+from __future__ import annotations
+
+import pytest
+
+from gradata.security.score_obfuscation import (
+    _SCORE_PATTERN,
+    obfuscate_instruction,
+    truncate_score,
+)
+
+
+# ---------------------------------------------------------------------------
+# truncate_score
+# ---------------------------------------------------------------------------
+
+
+class TestTruncateScore:
+    """Verify tier label mapping for all confidence ranges."""
+
+    def test_rule_tier_above_threshold(self) -> None:
+        assert truncate_score(0.95) == "RULE"
+
+    def test_rule_tier_at_boundary(self) -> None:
+        assert truncate_score(0.90) == "RULE"
+
+    def test_rule_tier_at_1(self) -> None:
+        assert truncate_score(1.0) == "RULE"
+
+    def test_pattern_tier_mid_range(self) -> None:
+        assert truncate_score(0.75) == "PATTERN"
+
+    def test_pattern_tier_at_boundary(self) -> None:
+        assert truncate_score(0.60) == "PATTERN"
+
+    def test_pattern_tier_just_below_rule(self) -> None:
+        assert truncate_score(0.89) == "PATTERN"
+
+    def test_instinct_tier_below_pattern(self) -> None:
+        assert truncate_score(0.59) == "INSTINCT"
+
+    def test_instinct_tier_at_zero(self) -> None:
+        assert truncate_score(0.0) == "INSTINCT"
+
+    def test_instinct_tier_low(self) -> None:
+        assert truncate_score(0.40) == "INSTINCT"
+
+
+# ---------------------------------------------------------------------------
+# obfuscate_instruction
+# ---------------------------------------------------------------------------
+
+
+class TestObfuscateInstruction:
+    """Verify float stripping from instruction strings."""
+
+    def test_strips_rule_float(self) -> None:
+        assert obfuscate_instruction("[RULE:0.95] DRAFTING: foo") == "[RULE] DRAFTING: foo"
+
+    def test_strips_pattern_float(self) -> None:
+        assert obfuscate_instruction("[PATTERN:0.72] CODE: bar") == "[PATTERN] CODE: bar"
+
+    def test_strips_instinct_float(self) -> None:
+        assert obfuscate_instruction("[INSTINCT:0.40] MISC: baz") == "[INSTINCT] MISC: baz"
+
+    def test_passthrough_no_brackets(self) -> None:
+        text = "Just a plain instruction with no brackets"
+        assert obfuscate_instruction(text) == text
+
+    def test_passthrough_empty_string(self) -> None:
+        assert obfuscate_instruction("") == ""
+
+    def test_multiple_scores_in_one_string(self) -> None:
+        text = "[RULE:0.95] foo [PATTERN:0.60] bar"
+        assert obfuscate_instruction(text) == "[RULE] foo [PATTERN] bar"
+
+    def test_preserves_surrounding_text(self) -> None:
+        text = "prefix [RULE:0.91] middle [PATTERN:0.65] suffix"
+        assert obfuscate_instruction(text) == "prefix [RULE] middle [PATTERN] suffix"
+
+    def test_does_not_strip_unknown_labels(self) -> None:
+        text = "[UNKNOWN:0.50] something"
+        assert obfuscate_instruction(text) == "[UNKNOWN:0.50] something"
+
+
+# ---------------------------------------------------------------------------
+# _SCORE_PATTERN regex
+# ---------------------------------------------------------------------------
+
+
+class TestScorePattern:
+    """Verify the regex matches expected formats."""
+
+    def test_matches_rule(self) -> None:
+        assert _SCORE_PATTERN.search("[RULE:0.95]") is not None
+
+    def test_matches_pattern(self) -> None:
+        assert _SCORE_PATTERN.search("[PATTERN:0.60]") is not None
+
+    def test_matches_instinct(self) -> None:
+        assert _SCORE_PATTERN.search("[INSTINCT:0.40]") is not None
+
+    def test_no_match_without_float(self) -> None:
+        assert _SCORE_PATTERN.search("[RULE]") is None
+
+    def test_no_match_lowercase(self) -> None:
+        assert _SCORE_PATTERN.search("[rule:0.95]") is None
+
+
+# ---------------------------------------------------------------------------
+# Integration: format_rules_for_prompt output
+# ---------------------------------------------------------------------------
+
+
+class TestFormatRulesNoRawFloats:
+    """Verify that format_rules_for_prompt output contains no raw floats."""
+
+    def test_no_raw_floats_in_prompt(self) -> None:
+        """After the rule_engine change, format_rules_for_prompt should
+        emit tier labels without confidence floats in the instruction field."""
+        from gradata._types import Lesson, LessonState
+        from gradata.rules.rule_engine import apply_rules, format_rules_for_prompt
+        from gradata._scope import RuleScope
+
+        lesson = Lesson(
+            date="2026-04-07",
+            category="DRAFTING",
+            description="Always include pricing",
+            state=LessonState.RULE,
+            confidence=0.95,
+        )
+        scope = RuleScope()
+        applied = apply_rules([lesson], scope)
+        prompt = format_rules_for_prompt(applied)
+
+        # Should NOT contain patterns like :0.95] — raw floats after colon
+        assert _SCORE_PATTERN.search(prompt) is None, (
+            f"Raw float leaked into prompt: {prompt}"
+        )
+        # Should contain the tier label without float
+        assert "[RULE]" in prompt


### PR DESCRIPTION
## Summary

SDK P0 hardening (Plan A) + security hardening (Plan C) from OASIS simulation findings.

**Driven by**: 6 OASIS sims (360 agents, 1,565 comments), 4 academic research documents, 5 Kenoodl bottomlines, exhaustive gap audit.

### Plan A — SDK P0 Hardening (6 features)
- `brain.rules()`, `brain.explain()`, `brain.export_data()` — rule inspection API
- Correction scope tagging — default narrow, CorrectionScope enum, ONE_OFF blocking
- PII/credential redaction — extraction-before-redaction pipeline, regex-only
- Batch approval at session end — `pending_promotions()`, `approve/reject_promotion()`
- Audit trail + SQLite provenance — `brain.trace()`, rule_provenance table
- Safety assertion — graduation guard documenting 3-fire requirement

### Plan C — Security Hardening (8 features)
- Score truncation — tier labels in prompts, raw floats in local dev tools only
- Per-brain salts — +/- 5% graduation jitter, non-deterministic timing
- Constant-time padding — timing attack defense
- Bucketed shuffle injection — within-tier shuffle, RULE > PATTERN > INSTINCT order
- Query budgeting — sliding-window rate limiter with burst anomaly detection
- Manifest signing — HMAC-SHA256 with brain-specific salt
- Rule metadata schema — 5W1H + dual utility/safety scores (Safe RLHF)
- Correction provenance — HMAC-signed records linking corrections to users

### Stats
- 17 commits, 3,387 lines added
- 8 new source files, 14 new test files
- 1438 → 1608 tests (170 new), 0 failures
- Meta-rules algorithm: confirmed stubbed, not in repo

## Test plan
- [x] All 1608 tests pass locally
- [x] No regressions from baseline (1438)
- [x] Simplify review: 6 issues found and fixed
- [x] Meta-rules algo verified absent from source
- [ ] CI green on 3.11, 3.12, 3.13

Generated with Gradata

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers a large hardening milestone across two parallel tracks: **Plan A** (SDK P0 — rule inspection API, correction scope tagging, PII redaction, batch approval, SQLite audit trail, safety assertions) and **Plan C** (security — score obfuscation, per-brain salts, timing-attack defenses, bucketed injection shuffle, query budgeting, manifest signing, rule metadata, and correction provenance). At 3,700+ lines and 170 new tests, the scope is ambitious and the implementation is largely sound — the security primitives in particular are well-designed and correctly wired.

**Key findings:**

- **Breaking API change in `brain.forget()`** — the parameter signature changed from `forget(description, category) -> int` to `forget(what) -> dict | list[dict]`. Keyword callers (`brain.forget(description="...")`) will get a `TypeError` at runtime, and callers that test the integer return value will silently mis-branch. No deprecation shim is provided.
- **`pending_promotions()` is invisible to `approval_required=True` lessons** — these lessons are frozen at INSTINCT with `pending_approval=True` and can never appear in `pending_promotions()` (which only returns PATTERN/RULE state). The batch-approval workflow is inaccessible for the exact use case it was designed for.
- **Home-grown YAML serializer doesn't escape newlines** — `_yaml_val` in `inspection.py` will produce malformed YAML if any rule description contains a literal newline or carriage return, which is plausible for multi-line AI-generated descriptions on Windows.
- **`.brain_salt` not in `.gitignore`** — the new per-brain salt file could be accidentally committed if a user's brain directory overlaps a git repo.

The security module (`brain_salt`, `query_budget`, `score_obfuscation`, `manifest_signing`, `correction_provenance`) is well-implemented and correctly integrated. Prior review concerns (`constant_time_pad` export, credit card regex, safety assertion dead code, `truncate_score` label mismatch) were addressed or are tracked.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until the `brain.forget()` API break and the `pending_promotions()` approval-workflow bug are resolved — both affect publicly callable methods.

The security primitives and pipeline integrations are well-executed. But two P1 logic issues remain in the public API: `brain.forget()` silently breaks all keyword callers (signature changed without deprecation), and `pending_promotions()` never surfaces `approval_required=True` lessons, making the batch approval feature non-functional for its primary use case. These are concrete, reproducible bugs — not hypotheticals — and they touch the surface area being advertised in the PR description.

`src/gradata/brain.py` (forget API break), `src/gradata/brain_inspection.py` (pending_promotions filter), `src/gradata/inspection.py` (YAML newline escaping)

<details open><summary><h3>Vulnerabilities</h3></summary>

- **PII redaction ordering is correct** — extraction runs on raw text before redaction, and redacted text is written to storage. No raw PII leaks into `events.jsonl` or the lessons file.
- **HMAC key material is never logged or exposed** — `_brain_salt` is used as HMAC key in both provenance signing and manifest signing; no log lines emit the salt value.
- **`hmac.compare_digest` used everywhere** — `verify_manifest` and `verify_provenance` both use constant-time comparison, preventing timing oracle attacks on signature verification.
- **Query budget enforces hard cutoff** — `apply_brain_rules` blocks rule injection (returns `""`) when the sliding-window limit is exceeded, preventing prompt-injection amplification.
- **Salt file exposure risk** — if `brain_dir` is inside a tracked git repo, `.brain_salt` could be committed, exposing the HMAC key used for manifest and provenance signing. Impact is limited (attacker would need DB access too), but the fix is trivial (add to `.gitignore`).
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/gradata/brain.py | Integrates BrainInspectionMixin, query budget, per-brain salt, and extended `forget()` — but `forget()` is a breaking API change (parameter names and return type both changed). |
| src/gradata/brain_inspection.py | New mixin providing `rules()`, `explain()`, `trace()`, `export_data()`, `pending_promotions()`, `approve_promotion()`, `reject_promotion()` — `pending_promotions()` is broken for `approval_required=True` lessons that stay at INSTINCT. |
| src/gradata/inspection.py | New inspection layer for listing/explaining/exporting rules; home-grown YAML serializer has newline-escaping bug that would produce malformed YAML output for multi-line descriptions. |
| src/gradata/_core.py | Adds PII redaction pipeline (extraction-before-storage), correction scope tagging, salted threshold propagation, provenance HMAC signing, and rule provenance writing on graduation. All new code wrapped in try/except to avoid blocking corrections. |
| src/gradata/enhancements/self_improvement.py | Adds salted thresholds to `graduate()` and `update_confidence()`, ONE_OFF scope blocking, scope_json round-trip serialization, and RuleMetadata parse/format. Logic is correct. |
| src/gradata/rules/rule_engine.py | Rule ID format improved to 8-char hex (much lower collision probability), raw confidence scores stripped from prompt injection, bucketed shuffle added for injection order security. |
| src/gradata/security/brain_salt.py | Per-brain salt generation and atomic write to `.brain_salt`; HMAC-derived threshold jitter is sound. Well-implemented with atomic rename fallback. |
| src/gradata/security/query_budget.py | Correct sliding-window rate limiter with burst detection; `_prune` correctly removes stale entries; burst anomaly sub-window edge cases handled cleanly. |
| src/gradata/security/score_obfuscation.py | Correct score truncation and instruction obfuscation; `constant_time_pad` properly uses `secrets.randbelow` for non-deterministic jitter; all exported from `__init__.py`. |
| src/gradata/security/manifest_signing.py | Canonical-JSON HMAC-SHA256 signing correctly excludes `signature` and `signed_at` from the signed payload; `hmac.compare_digest` used correctly. |
| src/gradata/security/correction_provenance.py | HMAC-signed provenance records with solid input validation; `verify_provenance` uses `hmac.compare_digest` for constant-time comparison. |
| src/gradata/safety.py | PII/credential redaction with extraction-before-storage ordering; credit card regex tightened to 4-4-4-4 format (previous concern addressed). |
| src/gradata/audit.py | SQLite-backed provenance trail with full correction lineage; safe exception handling ensures audit failures never block the correction pipeline. |
| src/gradata/_types.py | Adds `CorrectionScope` enum and `RuleMetadata` dataclass with 5W1H fields and dual utility/safety scores; `__post_init__` clamps scores to [0,1]. |
| src/gradata/_migrations.py | Adds `rule_provenance` table and its index via `CREATE IF NOT EXISTS` — safe for existing DBs. |
| src/gradata/security/__init__.py | All security symbols correctly exported including `constant_time_pad` (prior review concern resolved). |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant B as Brain
    participant C as _core.py
    participant S as safety.py
    participant P as correction_provenance
    participant A as audit.py
    participant G as graduate()
    participant RE as rule_engine

    U->>B: brain.correct(draft, final, scope="domain")
    B->>C: brain_correct(...)
    C->>C: extract behavioral instruction (full text)
    C->>S: redact_pii_with_report(draft/final)
    S-->>C: redacted texts
    C->>C: tag correction_scope → scope_data
    C->>C: emit CORRECTION event (redacted)
    C->>P: create_provenance_record(user_id, hash, session, salt)
    P-->>C: HMAC-signed provenance
    C-->>B: event dict

    U->>B: brain.end_session()
    B->>C: brain_end_session(salt=_brain_salt)
    C->>G: graduate(lessons, salt=_brain_salt)
    G->>G: salt_threshold(PATTERN_THRESHOLD, salt)
    G->>G: check ONE_OFF scope → block_promotion
    G->>G: promote/demote lessons
    G-->>C: active, graduated, transitions
    C->>A: write_provenance(rule_id, correction_event_id, session)
    C->>RE: format_rules_for_prompt(rules, bucketed_shuffle)
    C-->>B: session result

    U->>B: brain.rules() / brain.explain(rule_id) / brain.trace(rule_id)
    B->>RE: list_rules / explain_rule / trace_rule
    RE-->>B: rule dicts (tier label, not raw float)
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/gradata/brain.py`, line 474-476 ([link](https://github.com/gradata/gradata/blob/8ec1409670913be838ae41e147efca2081e04807/src/gradata/brain.py#L474-L476)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Rate limiter never actually enforces the limit**

   `is_rate_exceeded` returns `True` but execution falls straight through to the normal call path — only a `logger.warning` is emitted. The rate limiter currently has zero effect on real traffic; it is monitoring-only, not enforcement.

   If the intent is non-blocking (alerting only), the method name and surrounding comment are misleading. If the intent is to actually throttle, the method should either raise or return an empty string:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/gradata/brain.py
   Line: 474-476

   Comment:
   **Rate limiter never actually enforces the limit**

   `is_rate_exceeded` returns `True` but execution falls straight through to the normal call path — only a `logger.warning` is emitted. The rate limiter currently has zero effect on real traffic; it is monitoring-only, not enforcement.

   If the intent is non-blocking (alerting only), the method name and surrounding comment are misleading. If the intent is to actually throttle, the method should either raise or return an empty string:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fgradata%2Fbrain.py%0ALine%3A%20474-476%0A%0AComment%3A%0A**Rate%20limiter%20never%20actually%20enforces%20the%20limit**%0A%0A%60is_rate_exceeded%60%20returns%20%60True%60%20but%20execution%20falls%20straight%20through%20to%20the%20normal%20call%20path%20%E2%80%94%20only%20a%20%60logger.warning%60%20is%20emitted.%20The%20rate%20limiter%20currently%20has%20zero%20effect%20on%20real%20traffic%3B%20it%20is%20monitoring-only%2C%20not%20enforcement.%0A%0AIf%20the%20intent%20is%20non-blocking%20%28alerting%20only%29%2C%20the%20method%20name%20and%20surrounding%20comment%20are%20misleading.%20If%20the%20intent%20is%20to%20actually%20throttle%2C%20the%20method%20should%20either%20raise%20or%20return%20an%20empty%20string%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20self._query_budget.record%28%22apply_rules%22%29%0A%20%20%20%20%20%20%20%20if%20self._query_budget.is_rate_exceeded%28%22apply_rules%22%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20logger.warning%28%22Query%20budget%20exceeded%20for%20apply_rules%22%29%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20%22%22%20%20%23%20enforce%3A%20block%20further%20injection%20when%20budget%20exhausted%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=gradata%2Fgradata"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=1" height="20"></a>

2. `src/gradata/_core.py`, line 107-116 ([link](https://github.com/gradata/gradata/blob/8ec1409670913be838ae41e147efca2081e04807/src/gradata/_core.py#L107-L116)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Silent HMAC degradation when brain salt is empty**

   `getattr(brain, "_brain_salt", "")` returns `""` if the attribute doesn't exist (unlikely post-`__init__`, but still possible in test mocks or subclasses). `create_provenance_record` accepts this silently, producing an HMAC keyed with an empty byte string — which is technically valid HMAC but provides no security guarantee whatsoever, and the caller has no way to detect the degraded state.

   At minimum, log a warning when the salt is empty:

   ```python
           _salt = getattr(brain, "_brain_salt", "")
           if not _salt:
               _log.warning("brain._brain_salt is empty; provenance HMAC will use empty key")
           provenance = create_provenance_record(
               user_id=user_id, correction_hash=correction_hash,
               session=session or 0,
               salt=_salt,
           )
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/gradata/_core.py
   Line: 107-116

   Comment:
   **Silent HMAC degradation when brain salt is empty**

   `getattr(brain, "_brain_salt", "")` returns `""` if the attribute doesn't exist (unlikely post-`__init__`, but still possible in test mocks or subclasses). `create_provenance_record` accepts this silently, producing an HMAC keyed with an empty byte string — which is technically valid HMAC but provides no security guarantee whatsoever, and the caller has no way to detect the degraded state.

   At minimum, log a warning when the salt is empty:

   ```python
           _salt = getattr(brain, "_brain_salt", "")
           if not _salt:
               _log.warning("brain._brain_salt is empty; provenance HMAC will use empty key")
           provenance = create_provenance_record(
               user_id=user_id, correction_hash=correction_hash,
               session=session or 0,
               salt=_salt,
           )
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fgradata%2F_core.py%0ALine%3A%20107-116%0A%0AComment%3A%0A**Silent%20HMAC%20degradation%20when%20brain%20salt%20is%20empty**%0A%0A%60getattr%28brain%2C%20%22_brain_salt%22%2C%20%22%22%29%60%20returns%20%60%22%22%60%20if%20the%20attribute%20doesn't%20exist%20%28unlikely%20post-%60__init__%60%2C%20but%20still%20possible%20in%20test%20mocks%20or%20subclasses%29.%20%60create_provenance_record%60%20accepts%20this%20silently%2C%20producing%20an%20HMAC%20keyed%20with%20an%20empty%20byte%20string%20%E2%80%94%20which%20is%20technically%20valid%20HMAC%20but%20provides%20no%20security%20guarantee%20whatsoever%2C%20and%20the%20caller%20has%20no%20way%20to%20detect%20the%20degraded%20state.%0A%0AAt%20minimum%2C%20log%20a%20warning%20when%20the%20salt%20is%20empty%3A%0A%0A%60%60%60python%0A%20%20%20%20%20%20%20%20_salt%20%3D%20getattr%28brain%2C%20%22_brain_salt%22%2C%20%22%22%29%0A%20%20%20%20%20%20%20%20if%20not%20_salt%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20_log.warning%28%22brain._brain_salt%20is%20empty%3B%20provenance%20HMAC%20will%20use%20empty%20key%22%29%0A%20%20%20%20%20%20%20%20provenance%20%3D%20create_provenance_record%28%0A%20%20%20%20%20%20%20%20%20%20%20%20user_id%3Duser_id%2C%20correction_hash%3Dcorrection_hash%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20session%3Dsession%20or%200%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20salt%3D_salt%2C%0A%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=gradata%2Fgradata"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=1" height="20"></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Asrc%2Fgradata%2Fbrain.py%3A469-490%0A**Breaking%20API%20change%20in%20%60brain.forget%28%29%60%20%E2%80%94%20parameter%20names%20and%20return%20type%20changed**%0A%0AThe%20old%20signature%20was%20%60forget%28description%3A%20str%20%7C%20None%20%3D%20None%2C%20category%3A%20str%20%7C%20None%20%3D%20None%29%20-%3E%20int%60.%20This%20PR%20changes%20it%20to%20%60forget%28what%3A%20str%20%3D%20%22last%22%29%20-%3E%20dict%20%7C%20list%5Bdict%5D%60.%0A%0AAny%20caller%20using%20keyword%20arguments%20is%20broken%3A%0A%60%60%60python%0Abrain.forget%28description%3D%22casual%20tone%22%29%20%20%23%20TypeError%3A%20unexpected%20keyword%20argument%0Abrain.forget%28category%3D%22TONE%22%29%20%20%20%20%20%20%20%20%20%20%20%20%23%20TypeError%3A%20unexpected%20keyword%20argument%0A%60%60%60%0A%0AThe%20return%20type%20also%20changed%20from%20%60int%60%20%28count%20of%20removed%20lessons%29%20to%20%60dict%20%7C%20list%5Bdict%5D%60%2C%20breaking%20callers%20that%20do%20arithmetic%20on%20the%20result%20%28e.g.%20%60if%20brain.forget%28...%29%20%3E%200%60%29.%0A%0AThis%20needs%20either%20a%20deprecation%20shim%20or%20a%20major-version%20bump%20in%20the%20changelog.%20At%20minimum%2C%20a%20%60**kwargs%60%20guard%20with%20a%20helpful%20error%20message%20would%20prevent%20silent%20breakage%3A%0A%60%60%60python%0Adef%20forget%28self%2C%20what%3A%20str%20%3D%20%22last%22%2C%20**_legacy_kwargs%29%20-%3E%20dict%20%7C%20list%5Bdict%5D%3A%0A%20%20%20%20if%20_legacy_kwargs%3A%0A%20%20%20%20%20%20%20%20raise%20TypeError%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%22brain.forget%28%29%20API%20changed.%20Use%20forget%28'casual%20tone'%29%20or%20%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%22forget%28'all%20TONE'%29%20instead%20of%20description%3D%2Fcategory%3D%20kwargs.%22%0A%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Asrc%2Fgradata%2Fbrain_inspection.py%3A70-80%0A**%60pending_promotions%28%29%60%20is%20invisible%20to%20%60approval_required%3DTrue%60%20lessons**%0A%0AWhen%20%60brain.correct%28...%2C%20approval_required%3DTrue%29%60%20is%20called%2C%20the%20lesson%20is%20created%20with%20%60pending_approval%3DTrue%60%20and%20%60init_conf%3D0.0%60%2C%20which%20means%20%60graduate%28%29%60%20will%20always%20skip%20it%20%28%60if%20lesson.pending_approval%3A%20continue%60%29.%20The%20lesson%20stays%20at%20%60INSTINCT%60%20state%20indefinitely.%0A%0A%60pending_promotions%28%29%60%20delegates%20to%20%60list_rules%28%29%60%20which%20only%20returns%20%60ELIGIBLE_STATES%60%20%28PATTERN%20%2B%20RULE%29.%20An%20%60approval_required%60%20lesson%20stuck%20at%20INSTINCT%20will%20**never%20appear**%20in%20%60pending_promotions%28%29%60%2C%20making%20the%20approval%20workflow%20inaccessible.%0A%0AThe%20method%20needs%20to%20also%20include%20INSTINCT-state%20lessons%20where%20%60pending_approval%3DTrue%60%3A%0A%60%60%60python%0Adef%20pending_promotions%28self%29%20-%3E%20list%5Bdict%5D%3A%0A%20%20%20%20from%20gradata.inspection%20import%20list_rules%2C%20_load_lessons_from_path%2C%20_lesson_to_dict%0A%20%20%20%20lessons_path%20%3D%20self._find_lessons_path%28%29%20or%20self.dir%20%2F%20%22lessons.md%22%0A%20%20%20%20graduated%20%3D%20list_rules%28db_path%3Dself.db_path%2C%20lessons_path%3Dlessons_path%29%0A%20%20%20%20all_lessons%20%3D%20_load_lessons_from_path%28lessons_path%29%0A%20%20%20%20from%20gradata._types%20import%20LessonState%0A%20%20%20%20pending%20%3D%20%5B%0A%20%20%20%20%20%20%20%20_lesson_to_dict%28l%29%20for%20l%20in%20all_lessons%0A%20%20%20%20%20%20%20%20if%20l.state%20%3D%3D%20LessonState.INSTINCT%20and%20l.pending_approval%0A%20%20%20%20%5D%0A%20%20%20%20return%20pending%20%2B%20graduated%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Asrc%2Fgradata%2Finspection.py%3A186-200%0A**%60_yaml_val%60%20doesn't%20escape%20newlines%20%E2%80%94%20produces%20malformed%20YAML**%0A%0AIf%20a%20rule%20description%20or%20root%20cause%20contains%20a%20newline%20character%20%28possible%20on%20Windows%20with%20CRLF%2C%20or%20from%20multi-line%20AI%20output%29%2C%20%60_yaml_val%60%20emits%20the%20raw%20character%20without%20proper%20YAML%20escaping.%20A%20description%20like%20%60%22Use%20active%20voice.%5CnAvoid%20passive%20constructions.%22%60%20would%20break%20the%20YAML%20structure%20regardless%20of%20whether%20it%20gets%20double-quoted.%0A%0AAdd%20newline%20escaping%20before%20the%20quoting%20logic%3A%0A%60%60%60python%0Adef%20_yaml_val%28v%3A%20object%29%20-%3E%20str%3A%0A%20%20%20%20...%0A%20%20%20%20s%20%3D%20str%28v%29%0A%20%20%20%20s%20%3D%20s.replace%28'%5C%5C'%2C%20'%5C%5C%5C%5C'%29%0A%20%20%20%20s%20%3D%20s.replace%28'%22'%2C%20'%5C%5C%22'%29%0A%20%20%20%20has_special%20%3D%20%22%5Cn%22%20in%20s%20or%20%22%5Cr%22%20in%20s%20or%20%22%5Ct%22%20in%20s%0A%20%20%20%20s%20%3D%20s.replace%28'%5Cn'%2C%20'%5C%5Cn'%29.replace%28'%5Cr'%2C%20'%5C%5Cr'%29.replace%28'%5Ct'%2C%20'%5C%5Ct'%29%0A%20%20%20%20if%20s%20%3D%3D%20%22%22%20or%20%22%3A%22%20in%20s%20or%20%22%23%22%20in%20s%20or%20s.startswith%28%28%22-%22%2C%20%22%5B%22%2C%20%22%7B%22%29%29%20or%20has_special%3A%0A%20%20%20%20%20%20%20%20return%20f'%22%7Bs%7D%22'%0A%20%20%20%20return%20s%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0A.gitignore%3A144%0A**%60.brain_salt%60%20not%20added%20to%20%60.gitignore%60**%0A%0A%60load_or_create_salt%28%29%60%20writes%20a%20%60.brain_salt%60%20file%20into%20the%20brain%20directory.%20If%20any%20user's%20%60brain_dir%60%20overlaps%20a%20git%20repo%2C%20the%20salt%20file%20could%20be%20accidentally%20committed%2C%20exposing%20the%20HMAC%20key%20used%20for%20manifest%20and%20provenance%20signing.%0A%0A%60%60%60suggestion%0A.gstack%2F%0A.brain_salt%0A%60%60%60%0A%0A&repo=gradata%2Fgradata"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/gradata/brain.py
Line: 469-490

Comment:
**Breaking API change in `brain.forget()` — parameter names and return type changed**

The old signature was `forget(description: str | None = None, category: str | None = None) -> int`. This PR changes it to `forget(what: str = "last") -> dict | list[dict]`.

Any caller using keyword arguments is broken:
```python
brain.forget(description="casual tone")  # TypeError: unexpected keyword argument
brain.forget(category="TONE")            # TypeError: unexpected keyword argument
```

The return type also changed from `int` (count of removed lessons) to `dict | list[dict]`, breaking callers that do arithmetic on the result (e.g. `if brain.forget(...) > 0`).

This needs either a deprecation shim or a major-version bump in the changelog. At minimum, a `**kwargs` guard with a helpful error message would prevent silent breakage:
```python
def forget(self, what: str = "last", **_legacy_kwargs) -> dict | list[dict]:
    if _legacy_kwargs:
        raise TypeError(
            "brain.forget() API changed. Use forget('casual tone') or "
            "forget('all TONE') instead of description=/category= kwargs."
        )
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/gradata/brain_inspection.py
Line: 70-80

Comment:
**`pending_promotions()` is invisible to `approval_required=True` lessons**

When `brain.correct(..., approval_required=True)` is called, the lesson is created with `pending_approval=True` and `init_conf=0.0`, which means `graduate()` will always skip it (`if lesson.pending_approval: continue`). The lesson stays at `INSTINCT` state indefinitely.

`pending_promotions()` delegates to `list_rules()` which only returns `ELIGIBLE_STATES` (PATTERN + RULE). An `approval_required` lesson stuck at INSTINCT will **never appear** in `pending_promotions()`, making the approval workflow inaccessible.

The method needs to also include INSTINCT-state lessons where `pending_approval=True`:
```python
def pending_promotions(self) -> list[dict]:
    from gradata.inspection import list_rules, _load_lessons_from_path, _lesson_to_dict
    lessons_path = self._find_lessons_path() or self.dir / "lessons.md"
    graduated = list_rules(db_path=self.db_path, lessons_path=lessons_path)
    all_lessons = _load_lessons_from_path(lessons_path)
    from gradata._types import LessonState
    pending = [
        _lesson_to_dict(l) for l in all_lessons
        if l.state == LessonState.INSTINCT and l.pending_approval
    ]
    return pending + graduated
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/gradata/inspection.py
Line: 186-200

Comment:
**`_yaml_val` doesn't escape newlines — produces malformed YAML**

If a rule description or root cause contains a newline character (possible on Windows with CRLF, or from multi-line AI output), `_yaml_val` emits the raw character without proper YAML escaping. A description like `"Use active voice.\nAvoid passive constructions."` would break the YAML structure regardless of whether it gets double-quoted.

Add newline escaping before the quoting logic:
```python
def _yaml_val(v: object) -> str:
    ...
    s = str(v)
    s = s.replace('\\', '\\\\')
    s = s.replace('"', '\\"')
    has_special = "\n" in s or "\r" in s or "\t" in s
    s = s.replace('\n', '\\n').replace('\r', '\\r').replace('\t', '\\t')
    if s == "" or ":" in s or "#" in s or s.startswith(("-", "[", "{")) or has_special:
        return f'"{s}"'
    return s
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .gitignore
Line: 144

Comment:
**`.brain_salt` not added to `.gitignore`**

`load_or_create_salt()` writes a `.brain_salt` file into the brain directory. If any user's `brain_dir` overlaps a git repo, the salt file could be accidentally committed, exposing the HMAC key used for manifest and provenance signing.

```suggestion
.gstack/
.brain_salt
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: resolve all CodeRabbit review findi..."](https://github.com/gradata/gradata/commit/abeb84f371c0aaf69ce736b1788969adf14f3e1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27664723)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->