### PR TITLE
feat: daemon + detection layer + plugin tests

### DIFF
--- a/src/gradata/__init__.py
+++ b/src/gradata/__init__.py
@@ -32,17 +32,18 @@ if _log_level in ("DEBUG", "INFO", "WARNING", "ERROR"):
     )
     _logging.getLogger("gradata").setLevel(getattr(_logging, _log_level))
 
-from gradata._paths import BrainContext
-from gradata.enhancements.self_improvement import (
+from gradata._paths import BrainContext  # noqa: E402
+from gradata._types import Lesson, LessonState, RuleTransferScope  # noqa: E402
+from gradata.brain import Brain  # noqa: E402
+from gradata.context_wrapper import brain_context  # noqa: E402
+from gradata.enhancements.self_improvement import (  # noqa: E402
     compute_learning_velocity,
     format_lessons,
     graduate,
     parse_lessons,
     update_confidence,
 )
-from gradata._types import Lesson, LessonState, RuleTransferScope
-from gradata.brain import Brain
-from gradata.exceptions import (
+from gradata.exceptions import (  # noqa: E402
     BrainError,
     BrainNotFoundError,
     EmbeddingError,
@@ -51,20 +52,24 @@ from gradata.exceptions import (
     TaxonomyError,
     ValidationError,
 )
-from gradata.context_wrapper import brain_context
-from gradata.onboard import onboard
+from gradata.onboard import onboard  # noqa: E402
 
 __all__ = [
     # Core API
     "Brain",
     "BrainContext",
+    "BrainError",
+    "BrainNotFoundError",
+    "EmbeddingError",
+    "EventPersistenceError",
+    "ExportError",
     "Lesson",
     "LessonState",
     "RuleTransferScope",
+    "TaxonomyError",
+    "ValidationError",
     "__version__",
-    # One-line wrapper
     "brain_context",
-    # Graduation pipeline
     "compute_learning_velocity",
     "format_lessons",
     "graduate",

--- a/src/gradata/_brain_manifest.py
+++ b/src/gradata/_brain_manifest.py
@@ -21,10 +21,10 @@ Split into 4 files for maintainability (<500 lines each):
 
 import json
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
 import gradata._paths as _p
 from gradata._db import get_connection
-from gradata._paths import BrainContext
 
 # Re-export helpers so existing imports from _brain_manifest still work
 from gradata._manifest_helpers import (
@@ -34,13 +34,15 @@ from gradata._manifest_helpers import (
     _sdk_capabilities,
     _tag_taxonomy,
 )
-from gradata._manifest_quality import _compound_score
 from gradata._manifest_metrics import (
     _behavioral_contract,
     _memory_composition,
     _quality_metrics,
     _rag_status,
 )
+
+if TYPE_CHECKING:
+    from gradata._paths import BrainContext
 
 
 def generate_manifest(*, domain: str = "General", ctx: "BrainContext | None" = None) -> dict:

--- a/src/gradata/_context_compile.py
+++ b/src/gradata/_context_compile.py
@@ -6,9 +6,12 @@ returns formatted context injection.
 """
 
 import re
+from typing import TYPE_CHECKING
 
 import gradata._paths as _p
-from gradata._paths import BrainContext
+
+if TYPE_CHECKING:
+    from gradata._paths import BrainContext
 
 # Task detection keywords
 TASK_KEYWORDS = {

--- a/src/gradata/_context_packet.py
+++ b/src/gradata/_context_packet.py
@@ -4,13 +4,17 @@ Context Packet Builder.
 Generates structured context briefs before agent spawn.
 """
 
+import contextlib
 import json
 import sqlite3
 from datetime import date, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import gradata._paths as _p
-from gradata._paths import BrainContext
+
+if TYPE_CHECKING:
+    from gradata._paths import BrainContext
 
 
 # Lazy imports
@@ -223,10 +227,8 @@ def _load_audit_context(session: int, ctx: "BrainContext | None" = None) -> dict
         ]
     except Exception:
         pass
-    try:
+    with contextlib.suppress(Exception):
         result["correction_rate"] = _correction_rate(last_n_sessions=5)
-    except Exception:
-        pass
     return result
 
 

--- a/src/gradata/_core.py
+++ b/src/gradata/_core.py
@@ -7,13 +7,16 @@ Brain.py delegates to these to stay under 500 lines.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import re  # used by export functions for slug sanitization
-from collections.abc import Callable
+from datetime import UTC
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
+
     from gradata._types import Lesson
     from gradata.brain import Brain
 
@@ -43,7 +46,7 @@ def _filter_lessons_by_state(lessons, min_state: str = "PATTERN"):
 
 
 def _attribute_domain_fires(
-    brain: "Brain",
+    brain: Brain,
     correction_category: str,
     correction_desc: str,
 ) -> None:
@@ -192,9 +195,14 @@ def brain_correct(
     desc = ""  # Will be set if severity threshold is met
     try:
         from datetime import date as _date
+
         from gradata._types import Lesson, LessonState
         from gradata.enhancements.self_improvement import (
-            parse_lessons, format_lessons, update_confidence, INITIAL_CONFIDENCE)
+            INITIAL_CONFIDENCE,
+            format_lessons,
+            parse_lessons,
+            update_confidence,
+        )
 
         if _SEV_RANK.get(diff.severity, 0) >= _SEV_RANK.get(min_severity, 0):
             lessons_path = brain._find_lessons_path(create=True)
@@ -219,7 +227,9 @@ def brain_correct(
                     else:
                         # Try behavioral extraction (LLM + cache + templates)
                         try:
-                            from gradata.enhancements.edit_classifier import extract_behavioral_instruction
+                            from gradata.enhancements.edit_classifier import (
+                                extract_behavioral_instruction,
+                            )
                             from gradata.enhancements.instruction_cache import InstructionCache
                             if not isinstance(brain._instruction_cache, InstructionCache):
                                 brain._instruction_cache = InstructionCache(
@@ -358,15 +368,14 @@ def brain_correct(
 
     # Persist rule graph
     if hasattr(brain, '_rule_graph') and brain._rule_graph:
-        try:
+        with contextlib.suppress(Exception):
             brain._rule_graph.save()
-        except Exception:
-            pass
 
     # Index into FTS5
     try:
-        from gradata._query import fts_index
         from datetime import date as _fts_date
+
+        from gradata._query import fts_index
         fts_index(source="corrections", file_type="correction",
                   text=f"{category or 'UNKNOWN'}: {summary or diff.severity} - {final_redacted[:500]}",
                   embed_date=_fts_date.today().isoformat(), ctx=brain.ctx)
@@ -415,6 +424,7 @@ def brain_correct(
     try:
         import hashlib as _hashlib
         import json
+
         from gradata.security.correction_provenance import create_provenance_record
         correction_hash = _hashlib.sha256(
             json.dumps([draft, final], separators=(",", ":")).encode()
@@ -439,7 +449,7 @@ def brain_correct(
 # ── end_session() ──────────────────────────────────────────────────────
 
 
-def _graduation_message(old_state: str, lesson: "Lesson") -> str:
+def _graduation_message(old_state: str, lesson: Lesson) -> str:
     """Generate a user-facing graduation notification message."""
     if lesson.state.value == "PATTERN":
         return (f"You've corrected this {lesson.fire_count} times — "
@@ -458,7 +468,11 @@ def brain_end_session(
     """Run full graduation sweep at end of session."""
     try:
         from gradata.enhancements.self_improvement import (
-            parse_lessons, format_lessons, update_confidence, graduate)
+            format_lessons,
+            graduate,
+            parse_lessons,
+            update_confidence,
+        )
 
         lessons_path = brain._find_lessons_path()
         if not lessons_path or not lessons_path.is_file():
@@ -527,7 +541,8 @@ def brain_end_session(
         # Persist lineage (table created by _migrations.py)
         if transitions and brain.db_path.is_file():
             try:
-                from datetime import datetime, UTC
+                from datetime import UTC, datetime
+
                 from gradata._db import get_connection
                 now = datetime.now(UTC).isoformat()
                 with get_connection(brain.db_path) as conn:
@@ -543,9 +558,10 @@ def brain_end_session(
 
             # Write rule provenance for promotions to PATTERN or RULE
             try:
+                from datetime import UTC, datetime
+
                 from gradata.audit import write_provenance
                 from gradata.inspection import _make_rule_id
-                from datetime import datetime, UTC
                 now_prov = datetime.now(UTC).isoformat()
                 for l, old_s, new_s in transitions:
                     if new_s in ("PATTERN", "RULE"):
@@ -696,7 +712,7 @@ def brain_auto_evolve(
     threshold: float = 7.0,
 ) -> dict:
     """Evaluate output and auto-generate corrections for failed dimensions."""
-    from gradata.contrib.patterns.evaluator import evaluate, QUALITY_DIMENSIONS, default_evaluator
+    from gradata.contrib.patterns.evaluator import QUALITY_DIMENSIONS, default_evaluator, evaluate
 
     dims = dimensions or QUALITY_DIMENSIONS
     eval_fn = evaluator or default_evaluator
@@ -746,9 +762,7 @@ def brain_detect_implicit_feedback(
             return False
         # Check right boundary (end of string or non-alpha)
         end = idx + len(phrase)
-        if end < len(text) and text[end].isalpha():
-            return False
-        return True
+        return not (end < len(text) and text[end].isalpha())
 
     for marker in ["are you sure", "that's wrong", "that's not right", "not accurate",
                     "no, not that", "no don't", "stop doing", "why did you", "why didn't you"]:
@@ -856,7 +870,7 @@ def brain_export_rules(brain: Brain, *, min_state: str = "PATTERN", skill_name: 
         lines.append("")
 
     lines.extend(["## Provenance", "",
-                   f"- Source: Gradata correction-based procedural memory",
+                   "- Source: Gradata correction-based procedural memory",
                    f"- Domain: {domain}", f"- Rules exported: {len(qualified)}",
                    f"- Categories: {len(by_category)}", f"- Min graduation tier: {min_state}", ""])
     return "\n".join(lines)
@@ -880,12 +894,12 @@ def brain_export_rules_json(brain: Brain, *, min_state: str = "PATTERN") -> list
 
 
 def brain_export_skill(brain: Brain, *, output_dir: str | None = None,
-                       min_state: str = "PATTERN", skill_name: str = "") -> "Path":
+                       min_state: str = "PATTERN", skill_name: str = "") -> Path:
     """Export graduated rules as a full skill directory."""
-    from pathlib import Path
-    import json
     import hashlib
-    from datetime import datetime, UTC
+    import json
+    from datetime import UTC, datetime
+    from pathlib import Path
 
     content = brain_export_rules(brain, min_state=min_state, skill_name=skill_name)
     if not content:
@@ -923,8 +937,8 @@ def brain_export_skill(brain: Brain, *, output_dir: str | None = None,
 def brain_export_skills(brain: Brain, *, output_dir: str | None = None,
                         min_state: str = "PATTERN") -> list[str]:
     """Export graduated rules as per-category SKILL.md files."""
-    from pathlib import Path
     from collections import defaultdict
+    from pathlib import Path
 
     rules = brain_export_rules_json(brain, min_state=min_state)
     if not rules:
@@ -965,7 +979,7 @@ def brain_export_skills(brain: Brain, *, output_dir: str | None = None,
 
 # ── convergence() ─────────────────────────────────────────────────────
 
-def _mann_kendall(data: "list[int] | list[float]") -> tuple[str, float]:
+def _mann_kendall(data: list[int] | list[float]) -> tuple[str, float]:
     """Mann-Kendall trend test — delegates to _stats.trend_analysis().
 
     Returns (trend, p_value) where trend is "decreasing", "increasing", or "no_trend".
@@ -976,15 +990,12 @@ def _mann_kendall(data: "list[int] | list[float]") -> tuple[str, float]:
     from gradata._stats import trend_analysis
     slope, p_value = trend_analysis([float(x) for x in data])
 
-    if p_value < 0.05:
-        trend = "decreasing" if slope < 0 else "increasing"
-    else:
-        trend = "no_trend"
+    trend = ("decreasing" if slope < 0 else "increasing") if p_value < 0.05 else "no_trend"
 
     return trend, round(p_value, 4)
 
 
-def brain_convergence(brain: "Brain") -> dict:
+def brain_convergence(brain: Brain) -> dict:
     """Compute corrections-per-session convergence data.
 
     Uses Mann-Kendall trend test for statistical rigor.
@@ -1114,7 +1125,7 @@ def brain_convergence(brain: "Brain") -> dict:
 _AVG_SECONDS_PER_CORRECTION = 45
 
 
-def brain_efficiency(brain: "Brain", *, estimate_time: bool = False) -> dict:
+def brain_efficiency(brain: Brain, *, estimate_time: bool = False) -> dict:
     """Quantify effort saved by brain learning.
 
     Returns effort_ratio (current vs initial correction rate).
@@ -1161,7 +1172,7 @@ def brain_efficiency(brain: "Brain", *, estimate_time: bool = False) -> dict:
     return result
 
 
-def brain_prove(brain: "Brain") -> dict:
+def brain_prove(brain: Brain) -> dict:
     """Generate statistical proof that this brain improves output quality."""
     convergence = brain._get_convergence()
     efficiency = brain_efficiency(brain)
@@ -1171,8 +1182,8 @@ def brain_prove(brain: "Brain") -> dict:
     try:
         lessons_path = brain._find_lessons_path()
         if lessons_path and lessons_path.is_file():
-            from gradata.enhancements.self_improvement import parse_lessons
             from gradata._types import LessonState
+            from gradata.enhancements.self_improvement import parse_lessons
             lessons = parse_lessons(lessons_path.read_text(encoding="utf-8"))
             rule_count = sum(1 for l in lessons if l.state in (LessonState.PATTERN, LessonState.RULE))
     except Exception:
@@ -1244,13 +1255,14 @@ def brain_prove(brain: "Brain") -> dict:
 # ── Sharing ──────────────────────────────────────────────────────────
 
 
-def brain_share(brain: "Brain") -> dict:
+def brain_share(brain: Brain) -> dict:
     """Export graduated rules as a shareable package for team distribution.
 
     Only exports PATTERN and RULE state lessons — proven behavioral rules
     that have survived the graduation pipeline.
     """
-    from datetime import datetime, timezone
+    from datetime import datetime
+
     from gradata._types import LessonState
 
     lessons_path = brain._find_lessons_path()
@@ -1274,21 +1286,19 @@ def brain_share(brain: "Brain") -> dict:
                 })
 
     proof: dict = {}
-    try:
+    with contextlib.suppress(Exception):
         proof = brain_prove(brain)
-    except Exception:
-        pass
 
     return {
         "brain_id": str(brain.dir),
-        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "exported_at": datetime.now(UTC).isoformat(),
         "rules": rules,
         "rule_count": len(rules),
         "proof": proof,
     }
 
 
-def brain_absorb(brain: "Brain", package: dict) -> dict:
+def brain_absorb(brain: Brain, package: dict) -> dict:
     """Import shared rules into this brain.
 
     Imported rules enter as INSTINCT with initial confidence (0.40),
@@ -1298,6 +1308,7 @@ def brain_absorb(brain: "Brain", package: dict) -> dict:
     Skips rules that are >0.6 similar to existing lessons (duplicates).
     """
     from datetime import date as _date
+
     from gradata._types import CorrectionType, Lesson, LessonState
     from gradata.enhancements.self_improvement import format_lessons, parse_lessons
     from gradata.enhancements.similarity import best_similarity

--- a/src/gradata/_db.py
+++ b/src/gradata/_db.py
@@ -91,7 +91,7 @@ def lessons_lock(lessons_path: str | Path, timeout: float = 10.0):
                 try:
                     msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
                     break
-                except (OSError, IOError):
+                except OSError:
                     if time.monotonic() > deadline:
                         raise TimeoutError(
                             f"Could not acquire lessons lock after {timeout}s"
@@ -103,7 +103,7 @@ def lessons_lock(lessons_path: str | Path, timeout: float = 10.0):
                 try:
                     fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
                     break
-                except (OSError, IOError):
+                except OSError:
                     if time.monotonic() > deadline:
                         raise TimeoutError(
                             f"Could not acquire lessons lock after {timeout}s"
@@ -119,13 +119,13 @@ def lessons_lock(lessons_path: str | Path, timeout: float = 10.0):
                 try:
                     import msvcrt
                     msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
-                except (OSError, IOError):
+                except OSError:
                     pass
             else:
                 try:
                     import fcntl
                     fcntl.flock(fd, fcntl.LOCK_UN)
-                except (OSError, IOError):
+                except OSError:
                     pass
             os.close(fd)
 

--- a/src/gradata/_doctor.py
+++ b/src/gradata/_doctor.py
@@ -11,7 +11,6 @@ Usage:
 """
 from __future__ import annotations
 
-
 import json
 import os
 import shutil
@@ -207,10 +206,7 @@ def diagnose(brain_dir: str | Path | None = None) -> dict:
         }
     """
     # Resolve brain path
-    if brain_dir:
-        brain_path = Path(brain_dir).resolve()
-    else:
-        brain_path = _resolve_brain_path()
+    brain_path = Path(brain_dir).resolve() if brain_dir else _resolve_brain_path()
 
     checks = [
         _check_python_version(),

--- a/src/gradata/_embed.py
+++ b/src/gradata/_embed.py
@@ -7,14 +7,14 @@ FTS5 is the primary search engine. sqlite-vec planned for vector similarity.
 
 from __future__ import annotations
 
-import logging
-
 import hashlib
 import json
+import logging
 import os
 import re
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import gradata._paths as _p
 from gradata._config import (
@@ -29,7 +29,9 @@ from gradata._config import (
     SKIP_DIRS,
     SKIP_FILES,
 )
-from gradata._paths import BrainContext
+
+if TYPE_CHECKING:
+    from gradata._paths import BrainContext
 
 
 def get_file_hash(path: Path) -> str:

--- a/src/gradata/_encryption.py
+++ b/src/gradata/_encryption.py
@@ -43,6 +43,7 @@ def _get_fernet(key_bytes: bytes):
     """Create a Fernet instance from raw 32-byte key. Requires cryptography."""
     try:
         import base64
+
         from cryptography.fernet import Fernet
     except ImportError:
         raise ImportError(

--- a/src/gradata/_events.py
+++ b/src/gradata/_events.py
@@ -10,14 +10,15 @@ import contextlib
 import json
 import logging
 import sqlite3
-import sys
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
 # IMPORTANT: Use module reference (not value import) so set_brain_dir() updates propagate.
 # `from X import Y` copies the value at import time — subsequent set_brain_dir() won't update it.
 import gradata._paths as _p
-from gradata._paths import BrainContext
-from gradata._stats import brier_score
+
+if TYPE_CHECKING:
+    from gradata._paths import BrainContext
 
 _log = logging.getLogger("gradata.events")
 
@@ -42,24 +43,18 @@ def _ensure_table(conn: sqlite3.Connection):
     conn.execute("CREATE INDEX IF NOT EXISTS idx_events_session ON events(session)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_events_type ON events(type)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_events_session_type ON events(session, type)")
-    try:
+    with contextlib.suppress(sqlite3.OperationalError):
         conn.execute("ALTER TABLE events ADD COLUMN valid_from TEXT")
-    except sqlite3.OperationalError:
-        pass
-    try:
+    with contextlib.suppress(sqlite3.OperationalError):
         conn.execute("ALTER TABLE events ADD COLUMN valid_until TEXT")
-    except sqlite3.OperationalError:
-        pass
-    try:
+    with contextlib.suppress(sqlite3.OperationalError):
         conn.execute("ALTER TABLE events ADD COLUMN scope TEXT DEFAULT 'local'")
-    except sqlite3.OperationalError:
-        pass
     conn.commit()
 
 
 def emit(event_type: str, source: str, data: dict | None = None, tags: list | None = None,
          session: int | None = None, valid_from: str | None = None, valid_until: str | None = None,
-         ctx: "BrainContext | None" = None):
+         ctx: BrainContext | None = None):
     """Emit an event to the brain's event log.
 
     Args:
@@ -152,7 +147,7 @@ def emit_gate_override(gate_name: str, reason: str, steps_skipped: list | None =
 
 def query(event_type: str | None = None, session: int | None = None, last_n_sessions: int | None = None,
           limit: int = 100, as_of: str | None = None, active_only: bool = False,
-          ctx: "BrainContext | None" = None) -> list:
+          ctx: BrainContext | None = None) -> list:
     db_path = ctx.db_path if ctx else _p.DB_PATH
     with contextlib.closing(sqlite3.connect(str(db_path))) as conn:
         conn.row_factory = sqlite3.Row
@@ -199,7 +194,7 @@ def query(event_type: str | None = None, session: int | None = None, last_n_sess
 
 def supersede(event_id: int, new_data: dict | None = None, new_tags: list | None = None,
               source: str = "supersede", new_valid_from: str | None = None,
-              ctx: "BrainContext | None" = None):
+              ctx: BrainContext | None = None):
     now = datetime.now(UTC).isoformat()
     db = ctx.db_path if ctx else _p.DB_PATH
     with contextlib.closing(sqlite3.connect(str(db))) as conn:
@@ -221,7 +216,7 @@ def supersede(event_id: int, new_data: dict | None = None, new_tags: list | None
     return replacement
 
 
-def correction_rate(last_n_sessions: int = 5, ctx: "BrainContext | None" = None) -> dict:
+def correction_rate(last_n_sessions: int = 5, ctx: BrainContext | None = None) -> dict:
     db = ctx.db_path if ctx else _p.DB_PATH
     with contextlib.closing(sqlite3.connect(str(db))) as conn:
         _ensure_table(conn)
@@ -233,7 +228,7 @@ def correction_rate(last_n_sessions: int = 5, ctx: "BrainContext | None" = None)
     return {r[0]: r[1] for r in rows}
 
 
-def compute_leading_indicators(session: int, ctx: "BrainContext | None" = None) -> dict:
+def compute_leading_indicators(session: int, ctx: BrainContext | None = None) -> dict:
     db = ctx.db_path if ctx else _p.DB_PATH
     with contextlib.closing(sqlite3.connect(str(db))) as conn:
         _ensure_table(conn)
@@ -300,7 +295,7 @@ def get_current_session() -> int:
     return _detect_session()
 
 
-def _detect_session(ctx: "BrainContext | None" = None) -> int:
+def _detect_session(ctx: BrainContext | None = None) -> int:
     """Detect current session number from event data.
 
     Args:
@@ -378,7 +373,7 @@ def find_contradictions(event_type: str | None = None, tag_prefix: str | None = 
     return conflicts
 
 
-def audit_trend(last_n_sessions: int = 5, ctx: "BrainContext | None" = None) -> list:
+def audit_trend(last_n_sessions: int = 5, ctx: BrainContext | None = None) -> list:
     """Get audit scores for trend analysis."""
     db = ctx.db_path if ctx else _p.DB_PATH
     with contextlib.closing(sqlite3.connect(str(db))) as conn:
@@ -390,4 +385,3 @@ def audit_trend(last_n_sessions: int = 5, ctx: "BrainContext | None" = None) -> 
             ORDER BY session
         """, (last_n_sessions - 1,)).fetchall()
     return [{"session": r[0], "data": json.loads(r[1])} for r in rows]
-

--- a/src/gradata/_fact_extractor.py
+++ b/src/gradata/_fact_extractor.py
@@ -113,9 +113,7 @@ _get_prospect_names = _get_entity_names
 def _quality_gate(fact_type, fact_value):
     if not fact_value or len(fact_value.strip()) < MIN_FACT_LENGTH:
         return False
-    if fact_type not in VALID_FACT_TYPES:
-        return False
-    return True
+    return fact_type in VALID_FACT_TYPES
 
 
 def _clean_value(val):

--- a/src/gradata/_installer.py
+++ b/src/gradata/_installer.py
@@ -20,7 +20,6 @@ Flow:
 """
 from __future__ import annotations
 
-
 import json
 import subprocess
 import sys

--- a/src/gradata/_manifest_helpers.py
+++ b/src/gradata/_manifest_helpers.py
@@ -6,10 +6,13 @@ Split from _brain_manifest.py for file size compliance (<500 lines).
 """
 
 import re
+from typing import TYPE_CHECKING
 
 import gradata._paths as _p
 from gradata._db import get_connection
-from gradata._paths import BrainContext
+
+if TYPE_CHECKING:
+    from gradata._paths import BrainContext
 
 # ── Severity constants (single source of truth) ───────────────────────
 LOW_SEVERITY = frozenset({"as-is", "minor"})

--- a/src/gradata/_manifest_metrics.py
+++ b/src/gradata/_manifest_metrics.py
@@ -8,12 +8,10 @@ Split from _brain_manifest.py for file size compliance (<500 lines).
 import re
 import statistics
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import gradata._paths as _p
 from gradata._db import get_connection
-from gradata._paths import BrainContext
-from gradata._stats import trend_analysis as _trend_analysis
-
 from gradata._manifest_helpers import _session_window
 from gradata._manifest_quality import (
     _categories_extinct,
@@ -26,6 +24,10 @@ from gradata._manifest_quality import (
     _severity_ratio,
     _transfer_score,
 )
+from gradata._stats import trend_analysis as _trend_analysis
+
+if TYPE_CHECKING:
+    from gradata._paths import BrainContext
 
 
 def _lesson_distribution(ctx: "BrainContext | None" = None) -> dict[str, int]:
@@ -216,7 +218,7 @@ def _outcome_correlation(ctx: "BrainContext | None" = None, window: int = 20) ->
         if len(rows) < 5:
             return None
 
-        sessions = [r[0] for r in rows]
+        [r[0] for r in rows]
         values = [float(r[1]) for r in rows]
 
         # Compute trend direction for outcomes
@@ -232,7 +234,7 @@ def _outcome_correlation(ctx: "BrainContext | None" = None, window: int = 20) ->
         if sx == 0 or sy == 0:
             r = 0.0
         else:
-            r = sum((xi - mx) * (vi - my) for xi, vi in zip(x, values)) / ((n - 1) * sx * sy)
+            r = sum((xi - mx) * (vi - my) for xi, vi in zip(x, values, strict=False)) / ((n - 1) * sx * sy)
 
         return {
             "outcome_trend_slope": round(slope, 4),
@@ -450,4 +452,3 @@ def _rag_status(ctx: "BrainContext | None" = None) -> dict:
     except Exception:
         pass
     return result
-

--- a/src/gradata/_manifest_quality.py
+++ b/src/gradata/_manifest_quality.py
@@ -8,13 +8,15 @@ Split from _brain_manifest.py for file size compliance (<500 lines).
 import math
 import re
 import statistics
+from typing import TYPE_CHECKING
 
 import gradata._paths as _p
 from gradata._db import get_connection
-from gradata._paths import BrainContext
+from gradata._manifest_helpers import LOW_SEVERITY, _session_window
 from gradata._stats import trend_analysis as _trend_analysis
 
-from gradata._manifest_helpers import LOW_SEVERITY, _session_window
+if TYPE_CHECKING:
+    from gradata._paths import BrainContext
 
 
 def _compute_fda(ctx: "BrainContext | None" = None, window: int = 20) -> float | None:

--- a/src/gradata/_math.py
+++ b/src/gradata/_math.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import math
-from typing import Sequence
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
     """Cosine similarity between two vectors. Returns 0.0 for zero or mismatched vectors."""
     if len(a) != len(b):
         return 0.0
-    dot = sum(x * y for x, y in zip(a, b))
+    dot = sum(x * y for x, y in zip(a, b, strict=False))
     norm_a = math.sqrt(sum(x * x for x in a))
     norm_b = math.sqrt(sum(x * x for x in b))
     if norm_a == 0.0 or norm_b == 0.0:

--- a/src/gradata/_migrations.py
+++ b/src/gradata/_migrations.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import contextlib
 import sqlite3
 from pathlib import Path
-from gradata._db import get_connection
 
+from gradata._db import get_connection
 
 _BASE_TABLES: list[str] = [
     """CREATE TABLE IF NOT EXISTS events (
@@ -79,10 +80,8 @@ def run_migrations(db_path: str | Path) -> int:
     conn = get_connection(db_path)
     applied = 0
     for sql in _BASE_TABLES:
-        try:
+        with contextlib.suppress(sqlite3.OperationalError):
             conn.execute(sql)
-        except sqlite3.OperationalError:
-            pass
     for sql in _MIGRATIONS:
         try:
             conn.execute(sql)

--- a/src/gradata/_paths.py
+++ b/src/gradata/_paths.py
@@ -9,7 +9,6 @@ This file is the SDK-portable equivalent.
 """
 from __future__ import annotations
 
-
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -41,7 +40,7 @@ class BrainContext:
     gates_dir: Path
 
     @classmethod
-    def from_brain_dir(cls, brain_dir: str | Path, working_dir: str | Path | None = None) -> "BrainContext":
+    def from_brain_dir(cls, brain_dir: str | Path, working_dir: str | Path | None = None) -> BrainContext:
         """Build a BrainContext from a brain directory path.
 
         Args:

--- a/src/gradata/_query.py
+++ b/src/gradata/_query.py
@@ -5,9 +5,11 @@ Primary search: SQLite FTS5 (keyword matching).
 sqlite-vec planned for vector similarity.
 """
 
+import contextlib
 import sqlite3
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import gradata._paths as _p
 from gradata._config import (
@@ -27,7 +29,9 @@ from gradata._config import (
     SKIP_DIRS,
     SKIP_FILES,
 )
-from gradata._paths import BrainContext
+
+if TYPE_CHECKING:
+    from gradata._paths import BrainContext
 
 # ── FTS5 Full-Text Search ────────────────────────────────────────────────
 
@@ -87,14 +91,10 @@ def fts_index_batch(docs: list[dict], ctx: "BrainContext | None" = None):
 def fts_rebuild(ctx: "BrainContext | None" = None):
     db = ctx.db_path if ctx else _p.DB_PATH
     conn = sqlite3.connect(str(db))
-    try:
+    with contextlib.suppress(Exception):
         conn.execute("DROP TABLE IF EXISTS brain_fts")
-    except Exception:
-        pass
-    try:
+    with contextlib.suppress(Exception):
         conn.execute("DROP TABLE IF EXISTS brain_fts_content")
-    except Exception:
-        pass
     conn.commit()
     _ensure_fts_table(conn)
 

--- a/src/gradata/_stats.py
+++ b/src/gradata/_stats.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import math
 from collections import Counter, defaultdict
 
-
 # ============================================================================
 # 0. TREND ANALYSIS (Theil-Sen + Mann-Kendall)
 # ============================================================================

--- a/src/gradata/_tag_taxonomy.py
+++ b/src/gradata/_tag_taxonomy.py
@@ -225,9 +225,8 @@ def validate_tag(tag: str, strict: bool = False) -> tuple[bool, str]:
             return False, f"Unknown tag prefix: {prefix}"
         return True, f"Unknown prefix (allowed in non-strict): {prefix}"
     spec = TAXONOMY[prefix]
-    if spec["mode"] == "closed":
-        if value not in spec["values"]:
-            return False, f"Invalid {prefix} value: {value}. Valid: {sorted(spec['values'])}"
+    if spec["mode"] == "closed" and value not in spec["values"]:
+        return False, f"Invalid {prefix} value: {value}. Valid: {sorted(spec['values'])}"
     if spec["mode"] == "dynamic" and prefix in ("prospect", "entity", "candidate", "customer"):
         known = _get_entity_names()
         if known and value not in known:

--- a/src/gradata/_validator.py
+++ b/src/gradata/_validator.py
@@ -12,16 +12,18 @@ Trust Dimensions:
 """
 from __future__ import annotations
 
-
 import json
 import re
 import sqlite3
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import gradata._paths as _p
-from gradata._paths import BrainContext
+
+if TYPE_CHECKING:
+    from gradata._paths import BrainContext
 
 __all__ = [
     "main",
@@ -589,7 +591,7 @@ def validate_brain(manifest_path: Path | None = None, ctx: BrainContext | None =
     return report
 
 
-def save_validation(report: dict, ctx: "BrainContext | None" = None):
+def save_validation(report: dict, ctx: BrainContext | None = None):
     """Save validation report to brain/validations/."""
     brain_dir = ctx.brain_dir if ctx else _p.BRAIN_DIR
     validations_dir = brain_dir / "validations"

--- a/src/gradata/audit.py
+++ b/src/gradata/audit.py
@@ -167,7 +167,7 @@ def trace_rule(
         Dict with keys: rule_id, rule, provenance, corrections, transitions.
         Returns {"error": "..."} if rule_id not found in lessons.
     """
-    from gradata.inspection import _load_lessons_from_path, _make_rule_id, _lesson_to_dict
+    from gradata.inspection import _lesson_to_dict, _load_lessons_from_path, _make_rule_id
 
     lessons = _load_lessons_from_path(lessons_path)
 

--- a/src/gradata/benchmarks/swe_bench.py
+++ b/src/gradata/benchmarks/swe_bench.py
@@ -34,21 +34,22 @@ from __future__ import annotations
 import json
 import logging
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 _log = logging.getLogger(__name__)
 
 __all__ = [
-    "SWEInstance",
     "PatchResult",
     "RunConfig",
     "RunResults",
     "SWEBenchHarness",
+    "SWEInstance",
+    "compare_patches",
     "load_swe_bench_lite",
     "load_swe_bench_verified",
-    "compare_patches",
 ]
 
 
@@ -490,7 +491,7 @@ class SWEBenchHarness:
 
         # Per-batch learning curve comparison
         curve = []
-        for i, (b, e) in enumerate(zip(baseline.batch_stats, enhanced.batch_stats)):
+        for i, (b, e) in enumerate(zip(baseline.batch_stats, enhanced.batch_stats, strict=False)):
             curve.append({
                 "batch": i + 1,
                 "baseline_rate": b.resolve_rate,

--- a/src/gradata/brain.py
+++ b/src/gradata/brain.py
@@ -37,15 +37,18 @@ from __future__ import annotations
 
 import logging
 import sys
-from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from gradata._types import Lesson
 
 logger = logging.getLogger("gradata")
 
+
+import contextlib
 
 from gradata.brain_inspection import BrainInspectionMixin
 
@@ -68,13 +71,13 @@ class Brain(BrainInspectionMixin):
         import os as _os
         self._encryption_key = None
         if encryption_key or _os.environ.get("GRADATA_ENCRYPTION_KEY"):
-            from gradata._encryption import resolve_encryption_key, open_encrypted_db
+            from gradata._encryption import open_encrypted_db, resolve_encryption_key
             self._encryption_key = resolve_encryption_key(encryption_key)
             if self._encryption_key:
                 open_encrypted_db(self.dir, self._encryption_key)
 
         self._instruction_cache: object | None = None  # lazy: InstructionCache
-        self._fired_rules: list["Lesson"] = []  # Rules injected this session (for misfire attribution)
+        self._fired_rules: list[Lesson] = []  # Rules injected this session (for misfire attribution)
         self._convergence_cache: dict | None = None
         self._convergence_session: int | None = None
 
@@ -197,7 +200,7 @@ class Brain(BrainInspectionMixin):
         company: str | None = None,
         embedding: str | None = None,
         interactive: bool | None = None,
-    ) -> "Brain":
+    ) -> Brain:
         """Bootstrap a new brain directory with the onboarding wizard.
 
         Args:
@@ -479,11 +482,11 @@ class Brain(BrainInspectionMixin):
             brain.forget("all tone")       # everything in TONE category
         """
         try:
-            from gradata.enhancements.self_improvement import parse_lessons, format_lessons
+            from gradata.enhancements.self_improvement import format_lessons, parse_lessons
         except ImportError:
             return {"rolled_back": False, "error": "enhancements not installed"}
-        from gradata._types import LessonState
         from gradata._db import write_lessons_safe
+        from gradata._types import LessonState
 
         lessons_path = self._find_lessons_path()
         if not lessons_path or not lessons_path.is_file():
@@ -527,7 +530,7 @@ class Brain(BrainInspectionMixin):
         write_lessons_safe(lessons_path, format_lessons(lessons))
 
         for r in results:
-            try:
+            with contextlib.suppress(Exception):
                 self.emit("LESSON_CHANGE", "brain.forget", {
                     "action": "rolled_back", "lesson_index": r["lesson_index"],
                     "lesson_category": r["category"],
@@ -536,8 +539,6 @@ class Brain(BrainInspectionMixin):
                     "previous_confidence": r["previous_confidence"],
                     "kill_reason": "manual_forget",
                 }, [f"category:{r['category']}", "rollback"], 0)
-            except Exception:
-                pass
 
         return results[0] if len(results) == 1 else results
 
@@ -545,7 +546,7 @@ class Brain(BrainInspectionMixin):
                  category: str | None = None) -> dict:
         """Disable a specific lesson by setting its state to KILLED."""
         try:
-            from gradata.enhancements.self_improvement import parse_lessons, format_lessons
+            from gradata.enhancements.self_improvement import format_lessons, parse_lessons
         except ImportError:
             return {"rolled_back": False, "error": "enhancements not installed"}
         from gradata._types import LessonState
@@ -612,7 +613,7 @@ class Brain(BrainInspectionMixin):
     def _resolve_pending(self, approval_id: int, resolution: str, mutator) -> dict:
         """Shared logic for approve/reject: look up pending, mutate lesson, resolve."""
         from gradata._db import get_connection, lessons_lock
-        from gradata.enhancements.self_improvement import parse_lessons, format_lessons
+        from gradata.enhancements.self_improvement import format_lessons, parse_lessons
 
         conn = get_connection(self.db_path)
         import sqlite3; conn.row_factory = sqlite3.Row
@@ -984,8 +985,9 @@ class Brain(BrainInspectionMixin):
     def health(self) -> dict:
         """Generate brain health report."""
         try:
-            from gradata.enhancements.reporting import generate_health_report
             import dataclasses
+
+            from gradata.enhancements.reporting import generate_health_report
             return dataclasses.asdict(generate_health_report(self.db_path))
         except ImportError:
             return {"healthy": True, "issues": []}
@@ -1026,8 +1028,13 @@ class Brain(BrainInspectionMixin):
     def guard(self, text: str, direction: str = "input") -> dict:
         """Run guardrail checks on text. See gradata.contrib.patterns.guardrails."""
         from gradata.contrib.patterns.guardrails import (
-            InputGuard, OutputGuard, banned_phrases,
-            destructive_action, injection_detector, pii_detector)
+            InputGuard,
+            OutputGuard,
+            banned_phrases,
+            destructive_action,
+            injection_detector,
+            pii_detector,
+        )
         if direction == "input":
             checks = InputGuard(pii_detector, injection_detector).check(text)
         else:
@@ -1041,7 +1048,8 @@ class Brain(BrainInspectionMixin):
     def reflect(self, draft: str, checklist=None, evaluator=None,
                 refiner=None, max_cycles: int = 3) -> dict:
         """Run reflection loop. See gradata.contrib.patterns.reflection."""
-        from gradata.contrib.patterns.reflection import EMAIL_CHECKLIST, default_evaluator, reflect as _reflect
+        from gradata.contrib.patterns.reflection import EMAIL_CHECKLIST, default_evaluator
+        from gradata.contrib.patterns.reflection import reflect as _reflect
         result = _reflect(output=draft, checklist=checklist or EMAIL_CHECKLIST,
                           evaluator=evaluator or default_evaluator,
                           refiner=refiner or (lambda o, f: o), max_cycles=max_cycles)
@@ -1055,7 +1063,7 @@ class Brain(BrainInspectionMixin):
         from gradata.contrib.patterns.pipeline import Pipeline
         return Pipeline(*stages)
 
-    def run(self, tasks: list[str] | str, worker: "Callable", *,
+    def run(self, tasks: list[str] | str, worker: Callable, *,
             max_concurrent: int = 3) -> dict:
         """Execute task(s) through orchestrator. See gradata.contrib.patterns.orchestrator."""
         from gradata.contrib.patterns.orchestrator import execute_orchestrated
@@ -1063,9 +1071,9 @@ class Brain(BrainInspectionMixin):
             tasks = [tasks]
         return execute_orchestrated(tasks, worker, brain=self, max_concurrent=max_concurrent)
 
-    def spawn_queue(self, tasks: list[str], worker: "Callable", *,
+    def spawn_queue(self, tasks: list[str], worker: Callable, *,
                     max_concurrent: int = 3, timeout_seconds: int = 1800,
-                    on_complete: "Callable | None" = None) -> dict:
+                    on_complete: Callable | None = None) -> dict:
         """Execute tasks through a pull-based queue with N concurrent workers."""
         import concurrent.futures
         results, failed = [], []
@@ -1095,7 +1103,5 @@ class Brain(BrainInspectionMixin):
 
 
 # Re-export Pipeline type
-try:
-    from gradata.contrib.patterns.pipeline import Pipeline
-except ImportError:
+with contextlib.suppress(ImportError):
     pass

--- a/src/gradata/brain_inspection.py
+++ b/src/gradata/brain_inspection.py
@@ -8,8 +8,10 @@ self._find_lessons_path) so they work transparently via multiple inheritance.
 from __future__ import annotations
 
 import logging
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -88,9 +90,9 @@ class BrainInspectionMixin:
         Returns:
             {"approved": True} on success, {"error": "..."} if not found.
         """
-        from gradata.inspection import _make_rule_id, _load_lessons_from_path
-        from gradata.enhancements.self_improvement import format_lessons
         from gradata._db import write_lessons_safe
+        from gradata.enhancements.self_improvement import format_lessons
+        from gradata.inspection import _load_lessons_from_path, _make_rule_id
 
         lessons_path = self._find_lessons_path() or self.dir / "lessons.md"
         lessons = _load_lessons_from_path(lessons_path)
@@ -130,10 +132,10 @@ class BrainInspectionMixin:
             {"rejected": True, "demoted_from": old_state} on success,
             {"error": "..."} if not found.
         """
-        from gradata.inspection import _make_rule_id, _load_lessons_from_path
-        from gradata.enhancements.self_improvement import format_lessons
         from gradata._db import write_lessons_safe
         from gradata._types import LessonState
+        from gradata.enhancements.self_improvement import format_lessons
+        from gradata.inspection import _load_lessons_from_path, _make_rule_id
 
         lessons_path = self._find_lessons_path() or self.dir / "lessons.md"
         lessons = _load_lessons_from_path(lessons_path)

--- a/src/gradata/cli.py
+++ b/src/gradata/cli.py
@@ -19,7 +19,6 @@ Usage:
 """
 from __future__ import annotations
 
-
 import argparse
 import json
 import sys
@@ -318,7 +317,7 @@ def cmd_diagnose(args):
     else:
         print("No lessons yet — need more corrections to start building procedural memory.")
 
-    print(f"\nRun 'gradata health' for a full brain health report.")
+    print("\nRun 'gradata health' for a full brain health report.")
 
 
 def cmd_correct(args):
@@ -400,7 +399,7 @@ def cmd_convergence(args):
     print(f"\n  Corrections per Session (trend: {trend})")
     print(f"  {'─' * (chart_width + 15)}")
 
-    for i, (s, c) in enumerate(zip(sessions, counts)):
+    for _i, (s, c) in enumerate(zip(sessions, counts, strict=False)):
         bar_len = int((c / max_count) * chart_width) if max_count > 0 else 0
         bar = "█" * bar_len
         print(f"  S{s:<4} │{bar} {c}")
@@ -412,7 +411,7 @@ def cmd_convergence(args):
     # Category breakdown
     by_cat = data.get("by_category", {})
     if by_cat:
-        print(f"\n  By category:")
+        print("\n  By category:")
         for cat, info in sorted(by_cat.items()):
             cat_trend = info.get("trend", "?")
             cat_total = sum(info.get("corrections_per_session", []))
@@ -537,7 +536,7 @@ def main():
                          help="Poll interval in seconds (default: 5)")
 
     # diagnose — free correction pattern diagnostic (no graduation needed)
-    p_diagnose = sub.add_parser("diagnose", help="Analyze correction patterns (free diagnostic)")
+    sub.add_parser("diagnose", help="Analyze correction patterns (free diagnostic)")
 
     # review — human-in-the-loop approval
     p_review = sub.add_parser("review", help="Review pending lessons for approval")

--- a/src/gradata/context_wrapper.py
+++ b/src/gradata/context_wrapper.py
@@ -26,10 +26,12 @@ with OpenAI, Anthropic, or any chat completions API.
 from __future__ import annotations
 
 import logging
-from collections.abc import Generator
-from contextlib import contextmanager
-from pathlib import Path
-from typing import Any
+from contextlib import contextmanager, suppress
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
 
 logger = logging.getLogger("gradata.context_wrapper")
 
@@ -110,10 +112,8 @@ class BrainContextState:
 
         # Pre-load rules if brain available
         if brain and inject_rules:
-            try:
+            with suppress(Exception):
                 self._rules_text = brain.apply_brain_rules("general")
-            except Exception:
-                pass
 
     @property
     def rules(self) -> str:
@@ -171,10 +171,8 @@ class BrainContextState:
 
         # Log the output
         if self._brain:
-            try:
+            with suppress(Exception):
                 self._brain.log_output(response, output_type="general")
-            except Exception:
-                pass
 
     def correct(self, draft: str | None = None, final: str = "") -> dict | None:
         """Record a correction (user edited the AI's output).

--- a/src/gradata/contrib/enhancements/eval_benchmark.py
+++ b/src/gradata/contrib/enhancements/eval_benchmark.py
@@ -34,11 +34,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 __all__ = [
-    "BenchmarkCase",
-    "CaseResult",
-    "BenchmarkResult",
-    "LearningBenchmark",
     "STANDARD_BENCHMARK",
+    "BenchmarkCase",
+    "BenchmarkResult",
+    "CaseResult",
+    "LearningBenchmark",
     "run_standard_benchmark",
 ]
 
@@ -166,8 +166,8 @@ class LearningBenchmark:
 
         # Import edit classifier for category detection
         try:
-            from gradata.enhancements.edit_classifier import classify_edits
             from gradata.enhancements.diff_engine import compute_diff
+            from gradata.enhancements.edit_classifier import classify_edits
             has_classifier = True
         except ImportError:
             has_classifier = False

--- a/src/gradata/contrib/enhancements/install_manifest.py
+++ b/src/gradata/contrib/enhancements/install_manifest.py
@@ -34,15 +34,15 @@ from pathlib import Path
 from typing import Any
 
 __all__ = [
-    "ModuleCost",
-    "ModuleStability",
-    "Module",
-    "Profile",
-    "InstallPlan",
-    "InstallState",
     "DEFAULT_MODULES",
     "DEFAULT_PROFILES",
     "InstallManifest",
+    "InstallPlan",
+    "InstallState",
+    "Module",
+    "ModuleCost",
+    "ModuleStability",
+    "Profile",
 ]
 
 
@@ -145,7 +145,7 @@ class InstallState:
         filepath = Path(filepath)
         if not filepath.exists():
             return cls()
-        with open(filepath, "r", encoding="utf-8") as f:
+        with open(filepath, encoding="utf-8") as f:
             data = json.load(f)
         return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
 

--- a/src/gradata/contrib/enhancements/quality_gates.py
+++ b/src/gradata/contrib/enhancements/quality_gates.py
@@ -18,9 +18,11 @@ Design decisions
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 # ---------------------------------------------------------------------------
 # Data structures

--- a/src/gradata/contrib/patterns/context_brackets.py
+++ b/src/gradata/contrib/patterns/context_brackets.py
@@ -27,15 +27,15 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 __all__ = [
-    "ContextBracket",
-    "BracketConfig",
     "BRACKET_CONFIGS",
+    "BracketConfig",
+    "ContextBracket",
+    "ContextTracker",
+    "estimate_remaining_capacity",
+    "format_bracket_prompt",
     "get_bracket",
     "get_bracket_guidance",
-    "estimate_remaining_capacity",
     "is_action_allowed",
-    "format_bracket_prompt",
-    "ContextTracker",
 ]
 
 
@@ -232,9 +232,7 @@ def is_action_allowed(bracket: ContextBracket, action: str) -> bool:
         True if the action is permitted.
     """
     config = BRACKET_CONFIGS[bracket]
-    if action in config.prohibited_actions:
-        return False
-    return True
+    return action not in config.prohibited_actions
 
 
 def format_bracket_prompt(bracket: ContextBracket) -> str:

--- a/src/gradata/contrib/patterns/evaluator.py
+++ b/src/gradata/contrib/patterns/evaluator.py
@@ -55,9 +55,11 @@ Example
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 

--- a/src/gradata/contrib/patterns/execute_qualify.py
+++ b/src/gradata/contrib/patterns/execute_qualify.py
@@ -33,17 +33,18 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
+
 from gradata.contrib.patterns.task_escalation import TaskOutcome, TaskStatus
 
 __all__ = [
-    "QualifyScore",
-    "FailureClassification",
-    "QualifyResult",
+    "ExecuteQualifyLoop",
     "ExecuteQualifyResult",
     "ExecutorFn",
-    "QualifierFn",
+    "FailureClassification",
     "FixerFn",
-    "ExecuteQualifyLoop",
+    "QualifierFn",
+    "QualifyResult",
+    "QualifyScore",
 ]
 
 

--- a/src/gradata/contrib/patterns/guardrails.py
+++ b/src/gradata/contrib/patterns/guardrails.py
@@ -24,9 +24,11 @@ Usage::
 from __future__ import annotations
 
 import re
-from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 # ---------------------------------------------------------------------------
 # Data types
@@ -579,28 +581,28 @@ def validate_agent_spawn(
 # ---------------------------------------------------------------------------
 
 __all__ = [
+    # Classes
+    "Guard",
     # Data types
     "GuardCheck",
     "GuardedResult",
-    "ManifestCheckResult",
-    # Classes
-    "Guard",
     "InputGuard",
+    "ManifestCheckResult",
     "OutputGuard",
-    # Wrapper
-    "guarded",
-    # Built-in guards
-    "pii_detector",
-    "injection_detector",
-    "scope_validator",
     "banned_phrases",
-    "destructive_action",
+    "check_exec_command",
     # Manifest-based agent security
     "check_write_path",
-    "check_exec_command",
-    "scan_for_secrets",
-    "validate_agent_spawn",
+    "destructive_action",
+    # Wrapper
+    "guarded",
     "guards_from_graduated_rules",
+    "injection_detector",
+    # Built-in guards
+    "pii_detector",
+    "scan_for_secrets",
+    "scope_validator",
+    "validate_agent_spawn",
 ]
 
 
@@ -628,12 +630,12 @@ def guards_from_graduated_rules() -> list[Guard]:
 
     guards = []
     for rule in rules:
-        principle = rule.principle.lower()
+        rule.principle.lower()
 
         def _make_check(rule_text: str, rule_cat: str) -> Callable[[Any], GuardCheck]:
             """Create a check function that scans output for rule violations."""
             def check_fn(data: Any) -> GuardCheck:
-                text = str(data).lower() if data else ""
+                str(data).lower() if data else ""
                 # Simple keyword check — does the output violate the rule?
                 # Rules are phrased as "never X" or "always Y"
                 # This is a heuristic; real guardrails need LLM-backed checks

--- a/src/gradata/contrib/patterns/human_loop.py
+++ b/src/gradata/contrib/patterns/human_loop.py
@@ -35,9 +35,11 @@ Design principles
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 # ---------------------------------------------------------------------------
 # Risk keyword tables

--- a/src/gradata/contrib/patterns/loop_detection.py
+++ b/src/gradata/contrib/patterns/loop_detection.py
@@ -43,9 +43,9 @@ from typing import Any
 
 __all__ = [
     "LoopAction",
-    "LoopEvent",
-    "LoopDetectorConfig",
     "LoopDetector",
+    "LoopDetectorConfig",
+    "LoopEvent",
 ]
 
 

--- a/src/gradata/contrib/patterns/middleware.py
+++ b/src/gradata/contrib/patterns/middleware.py
@@ -42,8 +42,8 @@ from typing import Any
 
 __all__ = [
     "Middleware",
-    "MiddlewareContext",
     "MiddlewareChain",
+    "MiddlewareContext",
     "MiddlewareError",
 ]
 

--- a/src/gradata/contrib/patterns/orchestrator.py
+++ b/src/gradata/contrib/patterns/orchestrator.py
@@ -453,10 +453,7 @@ def register_route_rules(
     global _ROUTE_RULES, _ROUTE_DEFAULT
 
     new_rules = [RouteRule(keywords=kw, agent=agent) for kw, agent in rules]
-    if replace:
-        _ROUTE_RULES = new_rules
-    else:
-        _ROUTE_RULES = new_rules + _ROUTE_RULES
+    _ROUTE_RULES = new_rules if replace else new_rules + _ROUTE_RULES
 
     if default_agent is not None:
         _ROUTE_DEFAULT = default_agent
@@ -527,7 +524,7 @@ def execute_orchestrated(
 
     # If brain has spawn_queue, use it for parallel execution
     if brain and hasattr(brain, "spawn_queue"):
-        _sq = getattr(brain, "spawn_queue")
+        _sq = brain.spawn_queue
         result = _sq(tasks=tasks, worker=worker, max_concurrent=max_concurrent)
         result["strategy"] = "queue"
         result["patterns_detected"] = sorted(patterns)

--- a/src/gradata/contrib/patterns/parallel.py
+++ b/src/gradata/contrib/patterns/parallel.py
@@ -34,9 +34,11 @@ from __future__ import annotations
 
 import time
 from collections import defaultdict
-from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 # ---------------------------------------------------------------------------
 # Data structures

--- a/src/gradata/contrib/patterns/pipeline.py
+++ b/src/gradata/contrib/patterns/pipeline.py
@@ -33,9 +33,11 @@ Usage::
 from __future__ import annotations
 
 import time
-from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 # ---------------------------------------------------------------------------
 # Data classes
@@ -57,11 +59,10 @@ class GateResult:
     score: float | None = None
 
     def __post_init__(self) -> None:
-        if self.score is not None:
-            if not (0.0 <= self.score <= 1.0):
-                raise ValueError(
-                    f"GateResult.score must be in [0.0, 1.0], got {self.score!r}"
-                )
+        if self.score is not None and not (0.0 <= self.score <= 1.0):
+            raise ValueError(
+                f"GateResult.score must be in [0.0, 1.0], got {self.score!r}"
+            )
 
 
 @dataclass

--- a/src/gradata/contrib/patterns/q_learning_router.py
+++ b/src/gradata/contrib/patterns/q_learning_router.py
@@ -39,10 +39,10 @@ from pathlib import Path
 from typing import Any
 
 __all__ = [
-    "RouterConfig",
-    "RouteDecision",
     "Experience",
     "QLearningRouter",
+    "RouteDecision",
+    "RouterConfig",
 ]
 
 
@@ -253,7 +253,7 @@ class QLearningRouter:
                 return RouteDecision(
                     agent=cached_agent,
                     state_hash=state_hash,
-                    q_values=dict(zip(self.config.agents, q_vals)),
+                    q_values=dict(zip(self.config.agents, q_vals, strict=False)),
                     confidence=self._compute_confidence(q_vals),
                     exploiting=True,
                 )
@@ -283,7 +283,7 @@ class QLearningRouter:
         return RouteDecision(
             agent=agent,
             state_hash=state_hash,
-            q_values=dict(zip(self.config.agents, q_values)),
+            q_values=dict(zip(self.config.agents, q_values, strict=False)),
             confidence=self._compute_confidence(q_values),
             exploiting=exploiting,
         )
@@ -371,6 +371,7 @@ class QLearningRouter:
     def _compute_hmac(data_bytes: bytes) -> str:
         """Compute HMAC-SHA256 for integrity verification."""
         import hmac as _hmac
+
         # Key derived from machine identity (not secret, just tamper detection)
         import platform
         key = f"gradata-router-{platform.node()}".encode()
@@ -416,7 +417,7 @@ class QLearningRouter:
         if not filepath.exists():
             return False
 
-        with open(filepath, "r", encoding="utf-8") as f:
+        with open(filepath, encoding="utf-8") as f:
             state = json.load(f)
 
         # Verify HMAC if present (backward compat: files without HMAC still load)

--- a/src/gradata/contrib/patterns/reconciliation.py
+++ b/src/gradata/contrib/patterns/reconciliation.py
@@ -32,12 +32,12 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 __all__ = [
-    "DeviationScore",
-    "PlanItem",
     "ActualResult",
     "DeviationDetail",
-    "ReconciliationSummary",
+    "DeviationScore",
+    "PlanItem",
     "Reconciler",
+    "ReconciliationSummary",
     "format_summary",
 ]
 
@@ -271,7 +271,7 @@ class Reconciler:
 
     def _classify_root_cause(
         self,
-        plan: PlanItem,  # noqa: ARG002
+        plan: PlanItem,
         actual: ActualResult,
     ) -> str:
         """Classify the root cause of a deviation.
@@ -308,7 +308,7 @@ def format_summary(summary: ReconciliationSummary) -> str:
         Multi-line formatted string.
     """
     lines = [
-        f"## Reconciliation Summary (UNIFY)",
+        "## Reconciliation Summary (UNIFY)",
         f"Overall: **{summary.overall_score.value.upper()}** "
         f"({summary.pass_count}P / {summary.gap_count}G / {summary.drift_count}D)",
         f"Completion: {summary.completion_ratio:.0%}",

--- a/src/gradata/contrib/patterns/reflection.py
+++ b/src/gradata/contrib/patterns/reflection.py
@@ -32,9 +32,11 @@ Typical usage::
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 # ---------------------------------------------------------------------------
 # Data classes

--- a/src/gradata/contrib/patterns/task_escalation.py
+++ b/src/gradata/contrib/patterns/task_escalation.py
@@ -31,12 +31,12 @@ from enum import Enum
 from typing import Any
 
 __all__ = [
-    "TaskStatus",
     "TaskOutcome",
-    "report_outcome",
-    "is_actionable",
-    "requires_human",
+    "TaskStatus",
     "format_outcome",
+    "is_actionable",
+    "report_outcome",
+    "requires_human",
 ]
 
 

--- a/src/gradata/contrib/patterns/tree_of_thoughts.py
+++ b/src/gradata/contrib/patterns/tree_of_thoughts.py
@@ -5,8 +5,11 @@ Evaluates multiple candidate rule wordings before committing to one.
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 @dataclass

--- a/src/gradata/correction_detector.py
+++ b/src/gradata/correction_detector.py
@@ -225,7 +225,7 @@ def _extract_implied_changes(text: str) -> list[str]:
         text,
         re.IGNORECASE,
     )
-    for action, target in dont_match:
+    for _action, target in dont_match:
         changes.append(f"remove: {target.strip()}")
 
     # "change X to Y" -> "replace X with Y"

--- a/src/gradata/daemon.py
+++ b/src/gradata/daemon.py
@@ -24,6 +24,8 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import contextlib
+import hashlib
 import json
 import logging
 import os
@@ -31,13 +33,11 @@ import signal
 import sqlite3
 import threading
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from socketserver import ThreadingMixIn
-
-import hashlib
 
 import gradata
 from gradata._scope import RuleScope
@@ -88,18 +88,18 @@ class _Handler(BaseHTTPRequestHandler):
     """Routes requests to the parent GradataDaemon instance."""
 
     # Suppress default stderr logging — we use our own logger
-    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+    def log_message(self, format: str, *args: object) -> None:
         logger.debug(format, *args)
 
     # ── Routing ─────────────────────────────────────────────────────────
 
-    def do_GET(self) -> None:  # noqa: N802
+    def do_GET(self) -> None:
         if self.path == "/health":
             self._handle_health()
         else:
             self._not_found()
 
-    def do_POST(self) -> None:  # noqa: N802
+    def do_POST(self) -> None:
         routes: dict[str, object] = {
             "/apply-rules": self._handle_apply_rules,
             "/correct": self._handle_correct,
@@ -121,7 +121,7 @@ class _Handler(BaseHTTPRequestHandler):
     # ── Helpers ─────────────────────────────────────────────────────────
 
     @property
-    def daemon(self) -> "GradataDaemon":
+    def daemon(self) -> GradataDaemon:
         return self.server._daemon  # type: ignore[attr-defined]
 
     def _read_json(self) -> dict:
@@ -410,8 +410,8 @@ class _Handler(BaseHTTPRequestHandler):
                     )
                     if isinstance(results, list):
                         context_parts = [str(r) for r in results[:5]]
-            except Exception:
-                pass
+            except Exception as e:
+                logger.exception("brain-recall search failed: %s", e)
 
         self._send_json({
             "context": "\n".join(context_parts),
@@ -516,6 +516,7 @@ class _Handler(BaseHTTPRequestHandler):
 
         d = self.daemon
         pending = 0
+        checkpointed = True
         try:
             with d._brain_lock:
                 lessons = d._brain._load_lessons()
@@ -524,11 +525,12 @@ class _Handler(BaseHTTPRequestHandler):
                 d._brain.emit("CHECKPOINT", "plugin.pre_compact", {
                     "session_id": session_id, "reason": reason, "pending_lessons": pending,
                 })
-        except Exception:
-            pass
+        except Exception as e:
+            logger.exception("checkpoint failed for session_id=%s, reason=%s: %s", session_id, reason, e)
+            checkpointed = False
 
         self._send_json({
-            "checkpointed": True,
+            "checkpointed": checkpointed,
             "pending_lessons": pending,
             "unsaved_corrections": 0,
         })
@@ -602,7 +604,7 @@ class GradataDaemon:
         self._pid_file = Path(pid_file) if pid_file else None
         self._server: _ThreadingHTTPServer | None = None
         self._started_mono = time.monotonic()
-        self._started_at = datetime.now(timezone.utc).isoformat()
+        self._started_at = datetime.now(UTC).isoformat()
 
         # Session counter: pick up from DB
         self._session_counter = self._init_session_counter()
@@ -715,10 +717,8 @@ class GradataDaemon:
         if self._idle_timer:
             self._idle_timer.cancel()
         if self._pid_file and self._pid_file.exists():
-            try:
+            with contextlib.suppress(OSError):
                 self._pid_file.unlink()
-            except OSError:
-                pass
 
     def _maybe_send_telemetry(self) -> None:
         """Send anonymous daily heartbeat if telemetry is opted in."""
@@ -729,19 +729,19 @@ class GradataDaemon:
         except FileNotFoundError:
             return
 
-        if "telemetry = true" not in config_text.lower():
+        if not _re.search(r"^\s*telemetry\s*=\s*true\s*$", config_text, _re.IGNORECASE | _re.MULTILINE):
             return
 
         match = _re.search(r'telemetry_last_sent\s*=\s*"([^"]+)"', config_text)
         if match:
             try:
                 last_sent = datetime.fromisoformat(match.group(1))
-                if (datetime.now(timezone.utc) - last_sent).total_seconds() < 86400:
+                if (datetime.now(UTC) - last_sent).total_seconds() < 86400:
                     return
             except ValueError:
                 pass
 
-        def _send():
+        def _send() -> None:
             import platform
             import urllib.request
             rules_count = 0
@@ -750,9 +750,9 @@ class GradataDaemon:
                 with self._brain_lock:
                     lessons = self._brain._load_lessons()
                     lessons_count = len(lessons)
-                    rules_count = sum(1 for l in lessons if l.state.name == "RULE")
-            except Exception:
-                pass
+                    rules_count = sum(1 for lesson in lessons if lesson.state.name == "RULE")
+            except Exception as e:
+                logger.exception("telemetry: failed to load lessons: %s", e)
             payload = json.dumps({
                 "sdk_version": gradata.__version__,
                 "rules_count": rules_count,
@@ -772,7 +772,7 @@ class GradataDaemon:
                 pass
             try:
                 import re as _re2
-                now = datetime.now(timezone.utc).isoformat()
+                now = datetime.now(UTC).isoformat()
                 if "telemetry_last_sent" in config_text:
                     new_config = _re2.sub(
                         r'telemetry_last_sent\s*=\s*"[^"]*"',

--- a/src/gradata/daemon.py
+++ b/src/gradata/daemon.py
@@ -10,6 +10,12 @@ Endpoints:
     POST /correct      — record a correction
     POST /detect       — detect implicit feedback / mode
     POST /end-session  — close the current session
+    POST /brain-recall — search brain for context relevant to a file
+    POST /enforce-rules — check content against graduated rules
+    POST /log-event    — log structured events for pattern analysis
+    POST /tag-delta    — semantic tagging of file changes
+    POST /checkpoint   — save learning state before context compaction
+    POST /maintain     — brain maintenance tasks
 
 Usage:
     python -m gradata.daemon --brain-dir ./my-brain
@@ -31,7 +37,16 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from socketserver import ThreadingMixIn
 
+import hashlib
+
 import gradata
+from gradata._scope import RuleScope
+from gradata._types import LessonState
+from gradata.detection.addition_pattern import AdditionTracker, classify_addition, is_addition
+from gradata.detection.correction_conflict import ConflictTracker, extract_diff_tokens
+from gradata.detection.mode_classifier import classify_mode
+from gradata.enhancements.self_improvement import parse_lessons
+from gradata.rules.rule_engine import apply_rules, format_rules_for_prompt
 
 logger = logging.getLogger("gradata.daemon")
 
@@ -90,6 +105,12 @@ class _Handler(BaseHTTPRequestHandler):
             "/correct": self._handle_correct,
             "/detect": self._handle_detect,
             "/end-session": self._handle_end_session,
+            "/brain-recall": self._handle_brain_recall,
+            "/enforce-rules": self._handle_enforce_rules,
+            "/log-event": self._handle_log_event,
+            "/tag-delta": self._handle_tag_delta,
+            "/checkpoint": self._handle_checkpoint,
+            "/maintain": self._handle_maintain,
         }
         handler = routes.get(self.path)
         if handler:
@@ -154,18 +175,12 @@ class _Handler(BaseHTTPRequestHandler):
 
         d = self.daemon
         with d._brain_lock:
-            # Load and parse lessons
             lessons_path = d._brain_dir / "lessons.md"
             if lessons_path.exists():
-                from gradata.enhancements.self_improvement import parse_lessons
                 lessons_text = lessons_path.read_text(encoding="utf-8")
                 lessons = parse_lessons(lessons_text)
             else:
                 lessons = []
-
-            # Build scope and apply rules
-            from gradata._scope import RuleScope
-            from gradata.rules.rule_engine import apply_rules, format_rules_for_prompt
 
             scope = RuleScope(
                 task_type=context.get("task_type", ""),
@@ -193,10 +208,13 @@ class _Handler(BaseHTTPRequestHandler):
         if session_id:
             d._fired_rules[session_id] = fired_ids
 
+        mode, mode_conf = classify_mode(prompt)
+
         self._send_json({
             "rules": rules_out,
             "injection_text": injection_text,
-            "mode_detected": "chat",
+            "mode_detected": mode,
+            "mode_confidence": mode_conf,
             "fired_rule_ids": fired_ids,
         })
 
@@ -249,6 +267,31 @@ class _Handler(BaseHTTPRequestHandler):
         if session_id:
             d._fired_rules[session_id] = untested
 
+        # Addition pattern detection (Signal 4)
+
+        addition_detected = False
+        addition_lesson = None
+        if is_addition(old_string, new_string):
+            ext = Path(file_path).suffix if file_path else ""
+            fingerprint = classify_addition(old_string, new_string, ext)
+            addition_lesson = d._addition_tracker.record(fingerprint, session_id)
+            addition_detected = True
+
+        # Correction-of-correction detection (Signal 6)
+
+        correction_conflict = None
+        _, new_removed = extract_diff_tokens(old_string, new_string)
+        if new_removed and misfired:
+            for rule_id in misfired:
+                action = d._conflict_tracker.record_conflict(rule_id)
+                if action:
+                    correction_conflict = {
+                        "rule_id": rule_id,
+                        "action": action,
+                        "conflict_count": d._conflict_tracker.get_count(rule_id),
+                    }
+                    break
+
         # Build response
         self._send_json({
             "captured": True,
@@ -258,8 +301,9 @@ class _Handler(BaseHTTPRequestHandler):
             "lesson_state": result.get("lesson_state", "INSTINCT"),
             "misfired_rules": misfired,
             "accepted_rules": [],
-            "addition_detected": False,
-            "correction_conflict": None,
+            "addition_detected": addition_detected,
+            "addition_lesson": addition_lesson,
+            "correction_conflict": correction_conflict,
         })
 
     def _handle_detect(self) -> None:
@@ -288,6 +332,8 @@ class _Handler(BaseHTTPRequestHandler):
         recent_fired = body.get("recent_fired_rules", [])
         related_rules = recent_fired if detected else []
 
+        mode, mode_conf = classify_mode(user_message)
+
         self._send_json({
             "implicit_feedback": {
                 "detected": detected,
@@ -295,8 +341,8 @@ class _Handler(BaseHTTPRequestHandler):
                 "related_rules": related_rules,
                 "action_taken": "logged" if detected else None,
             },
-            "mode": "chat",
-            "mode_confidence": 0.0,
+            "mode": mode,
+            "mode_confidence": mode_conf,
         })
 
     def _handle_end_session(self) -> None:
@@ -337,6 +383,192 @@ class _Handler(BaseHTTPRequestHandler):
             "cross_project_candidates": [],
         })
 
+    # ── Extended endpoint handlers ─────────────────────────────────────
+
+    def _handle_brain_recall(self) -> None:
+        self.daemon._reset_idle_timer()
+        body = self._read_json()
+        file_path = body.get("file_path", "")
+        content_preview = body.get("content_preview", "")
+
+        d = self.daemon
+        context_parts: list[str] = []
+        relevant_rules: list[dict] = []
+
+        query = (
+            f"{Path(file_path).stem} {content_preview[:200]}"
+            if file_path
+            else content_preview[:200]
+        )
+        if query.strip():
+            try:
+                with d._brain_lock:
+                    results = (
+                        d._brain.search(query)
+                        if hasattr(d._brain, "search")
+                        else []
+                    )
+                    if isinstance(results, list):
+                        context_parts = [str(r) for r in results[:5]]
+            except Exception:
+                pass
+
+        self._send_json({
+            "context": "\n".join(context_parts),
+            "relevant_rules": relevant_rules,
+            "relevant_corrections": [],
+        })
+
+    def _handle_enforce_rules(self) -> None:
+        self.daemon._reset_idle_timer()
+        body = self._read_json()
+        content = body.get("content", "")
+
+        d = self.daemon
+        violations: list[dict] = []
+
+        if content:
+            with d._brain_lock:
+                lessons = d._brain._load_lessons()
+
+                rules = [le for le in lessons if le.state == LessonState.RULE]
+
+                content_lower = content.lower()
+                for rule in rules:
+                    desc_lower = rule.description.lower()
+                    if "never" in desc_lower:
+                        never_what = desc_lower.split("never", 1)[1].strip()[:50]
+                        keywords = [w for w in never_what.split() if len(w) > 3]
+                        if any(kw in content_lower for kw in keywords):
+                            desc_hash = hashlib.sha256(rule.description.encode()).hexdigest()[:8]
+                            violations.append({
+                                "rule_id": f"{rule.category}:{desc_hash}",
+                                "description": rule.description,
+                                "severity": "warn",
+                            })
+
+        self._send_json({
+            "violations": violations,
+            "pass": len(violations) == 0,
+        })
+
+    def _handle_log_event(self) -> None:
+        self.daemon._reset_idle_timer()
+        body = self._read_json()
+        event_type = body.get("event_type", "unknown")
+        data = body.get("data", {})
+
+        d = self.daemon
+        try:
+            with d._brain_lock:
+                d._brain.emit(event_type.upper(), "plugin.hook", data)
+        except Exception as exc:
+            logger.debug("log-event failed: %s", exc)
+
+        self._send_json({"logged": True})
+
+    def _handle_tag_delta(self) -> None:
+        self.daemon._reset_idle_timer()
+        body = self._read_json()
+        file_path = body.get("file_path", "")
+        old_content = body.get("old_content", "")
+        new_content = body.get("new_content", "")
+
+        ext = Path(file_path).suffix.lower() if file_path else ""
+        category = _EXT_CATEGORY.get(ext, "GENERAL")
+
+        tags: list[str] = []
+        if not old_content and new_content:
+            tags.append("new_file")
+        elif old_content and not new_content:
+            tags.append("deleted")
+        else:
+            old_lines = set(old_content.splitlines())
+            new_lines = set(new_content.splitlines())
+            added = new_lines - old_lines
+            removed = old_lines - new_lines
+
+            if len(added) > len(removed) * 3:
+                tags.append("feature_addition")
+            elif len(removed) > len(added) * 3:
+                tags.append("cleanup")
+            elif added and removed:
+                tags.append("refactor")
+
+            added_text = "\n".join(added)
+            if "import " in added_text or "require(" in added_text:
+                tags.append("dependency_change")
+            if "test" in added_text.lower() or "assert" in added_text.lower():
+                tags.append("test_change")
+            if "fix" in added_text.lower() or "bug" in added_text.lower():
+                tags.append("bug_fix")
+
+        if not tags:
+            tags.append("edit")
+
+        self._send_json({"tags": tags, "category": category})
+
+    def _handle_checkpoint(self) -> None:
+        self.daemon._reset_idle_timer()
+        body = self._read_json()
+        session_id = body.get("session_id", "")
+        reason = body.get("reason", "manual")
+
+        d = self.daemon
+        pending = 0
+        try:
+            with d._brain_lock:
+                lessons = d._brain._load_lessons()
+                pending = sum(1 for le in lessons
+                              if le.state in (LessonState.INSTINCT, LessonState.PATTERN))
+                d._brain.emit("CHECKPOINT", "plugin.pre_compact", {
+                    "session_id": session_id, "reason": reason, "pending_lessons": pending,
+                })
+        except Exception:
+            pass
+
+        self._send_json({
+            "checkpointed": True,
+            "pending_lessons": pending,
+            "unsaved_corrections": 0,
+        })
+
+    def _handle_maintain(self) -> None:
+        self.daemon._reset_idle_timer()
+        body = self._read_json()
+        tasks_requested = body.get("tasks", ["manifest"])
+
+        d = self.daemon
+        completed: list[str] = []
+        failed: list[str] = []
+        start = time.monotonic()
+
+        for task_name in tasks_requested:
+            try:
+                with d._brain_lock:
+                    if task_name == "manifest":
+                        d._brain.manifest()
+                        completed.append("manifest")
+                    elif task_name == "fts_rebuild":
+                        if hasattr(d._brain, "search"):
+                            d._brain.search("")
+                        completed.append("fts_rebuild")
+                    elif task_name == "patterns":
+                        d._brain.export_rules(min_state="PATTERN")
+                        completed.append("patterns")
+                    else:
+                        failed.append(task_name)
+            except Exception as exc:
+                logger.debug("maintain task %s failed: %s", task_name, exc)
+                failed.append(task_name)
+
+        duration_ms = round((time.monotonic() - start) * 1000)
+        self._send_json({
+            "completed": completed,
+            "failed": failed,
+            "duration_ms": duration_ms,
+        })
+
 
 # ── Main daemon class ──────────────────────────────────────────────────
 
@@ -363,6 +595,8 @@ class GradataDaemon:
 
         self._sessions: dict[str, int] = {}
         self._fired_rules: dict[str, list[str]] = {}
+        self._addition_tracker = AdditionTracker()
+        self._conflict_tracker = ConflictTracker()
 
         self._port = port
         self._pid_file = Path(pid_file) if pid_file else None
@@ -446,6 +680,9 @@ class GradataDaemon:
         # Start idle timer
         self._reset_idle_timer()
 
+        # Opt-in anonymous telemetry
+        self._maybe_send_telemetry()
+
         assert self._server is not None
         try:
             self._server.serve_forever()
@@ -482,6 +719,74 @@ class GradataDaemon:
                 self._pid_file.unlink()
             except OSError:
                 pass
+
+    def _maybe_send_telemetry(self) -> None:
+        """Send anonymous daily heartbeat if telemetry is opted in."""
+        import re as _re
+        config_path = Path.home() / ".gradata" / "config.toml"
+        try:
+            config_text = config_path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return
+
+        if "telemetry = true" not in config_text.lower():
+            return
+
+        match = _re.search(r'telemetry_last_sent\s*=\s*"([^"]+)"', config_text)
+        if match:
+            try:
+                last_sent = datetime.fromisoformat(match.group(1))
+                if (datetime.now(timezone.utc) - last_sent).total_seconds() < 86400:
+                    return
+            except ValueError:
+                pass
+
+        def _send():
+            import platform
+            import urllib.request
+            rules_count = 0
+            lessons_count = 0
+            try:
+                with self._brain_lock:
+                    lessons = self._brain._load_lessons()
+                    lessons_count = len(lessons)
+                    rules_count = sum(1 for l in lessons if l.state.name == "RULE")
+            except Exception:
+                pass
+            payload = json.dumps({
+                "sdk_version": gradata.__version__,
+                "rules_count": rules_count,
+                "lessons_count": lessons_count,
+                "os": platform.system().lower(),
+                "python_version": platform.python_version(),
+            }).encode()
+            try:
+                req = urllib.request.Request(
+                    "https://api.gradata.com/telemetry",
+                    data=payload,
+                    headers={"Content-Type": "application/json"},
+                    method="POST",
+                )
+                urllib.request.urlopen(req, timeout=5)
+            except Exception:
+                pass
+            try:
+                import re as _re2
+                now = datetime.now(timezone.utc).isoformat()
+                if "telemetry_last_sent" in config_text:
+                    new_config = _re2.sub(
+                        r'telemetry_last_sent\s*=\s*"[^"]*"',
+                        f'telemetry_last_sent = "{now}"',
+                        config_text,
+                    )
+                else:
+                    new_config = config_text.rstrip() + f'\ntelemetry_last_sent = "{now}"\n'
+                config_path.write_text(new_config, encoding="utf-8")
+            except Exception:
+                pass
+
+        thread = threading.Thread(target=_send, daemon=True)
+        thread.start()
 
     @property
     def port(self) -> int:

--- a/src/gradata/detection/__init__.py
+++ b/src/gradata/detection/__init__.py
@@ -1,24 +1,26 @@
 """Detection layer — behavioral signal extraction."""
 
-from gradata.detection.mode_classifier import classify_mode, MODE_CATEGORY_MAP
+from __future__ import annotations
+
 from gradata.detection.addition_pattern import (
-    is_addition,
-    classify_addition,
     AdditionTracker,
+    classify_addition,
+    is_addition,
 )
 from gradata.detection.correction_conflict import (
+    ConflictTracker,
     detect_conflict,
     extract_diff_tokens,
-    ConflictTracker,
 )
+from gradata.detection.mode_classifier import MODE_CATEGORY_MAP, classify_mode
 
 __all__ = [
-    "classify_mode",
     "MODE_CATEGORY_MAP",
-    "is_addition",
-    "classify_addition",
     "AdditionTracker",
+    "ConflictTracker",
+    "classify_addition",
+    "classify_mode",
     "detect_conflict",
     "extract_diff_tokens",
-    "ConflictTracker",
+    "is_addition",
 ]

--- a/src/gradata/detection/__init__.py
+++ b/src/gradata/detection/__init__.py
@@ -1,0 +1,24 @@
+"""Detection layer — behavioral signal extraction."""
+
+from gradata.detection.mode_classifier import classify_mode, MODE_CATEGORY_MAP
+from gradata.detection.addition_pattern import (
+    is_addition,
+    classify_addition,
+    AdditionTracker,
+)
+from gradata.detection.correction_conflict import (
+    detect_conflict,
+    extract_diff_tokens,
+    ConflictTracker,
+)
+
+__all__ = [
+    "classify_mode",
+    "MODE_CATEGORY_MAP",
+    "is_addition",
+    "classify_addition",
+    "AdditionTracker",
+    "detect_conflict",
+    "extract_diff_tokens",
+    "ConflictTracker",
+]

--- a/src/gradata/detection/addition_pattern.py
+++ b/src/gradata/detection/addition_pattern.py
@@ -1,0 +1,208 @@
+"""Signal 4 — Addition pattern detection.
+
+Detects when users repeatedly ADD the same type of content (type annotations,
+imports, comments, links) without changing existing text.  After N repetitions,
+creates a candidate lesson.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+# ── Pure addition check ───────────────────────────────────────────────────
+
+
+def is_addition(old: str, new: str, min_added_chars: int = 10) -> bool:
+    """True when *new* contains *old* plus added content (insertion, not replacement).
+
+    - Empty old + non-empty new (>= min_added_chars) counts as addition.
+    - Returns False if old changed significantly or added content is too short.
+    """
+    # Empty old, non-empty new = new file content
+    if not old and new and len(new) >= min_added_chars:
+        return True
+
+    if not old or not new:
+        return False
+
+    # old must appear verbatim inside new
+    if old not in new:
+        return False
+
+    added = len(new) - len(old)
+    return added >= min_added_chars
+
+
+# ── Structural classification ─────────────────────────────────────────────
+
+# Extension → high-level category
+_EXT_CATEGORY: dict[str, str] = {
+    ".py": "python", ".pyi": "python",
+    ".js": "javascript", ".jsx": "javascript", ".mjs": "javascript",
+    ".ts": "typescript", ".tsx": "typescript",
+    ".rs": "rust", ".go": "go", ".java": "java", ".rb": "ruby",
+    ".c": "c", ".cpp": "cpp", ".h": "c", ".cs": "csharp",
+    ".swift": "swift", ".kt": "kotlin",
+    ".md": "markdown", ".txt": "text", ".rst": "restructuredtext",
+}
+
+# Regex patterns for non-Python code files
+_CODE_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("import", re.compile(r"(?:^|\n)\s*(?:import |from .+ import |require\(|#include )")),
+    ("type_annotation", re.compile(r":\s*\w+[\w\[\], |]*(?:\s*[=;)]|\s*$)", re.MULTILINE)),
+    ("comment", re.compile(r"(?:^|\n)\s*(?://|/\*|#\s)")),
+    ("error_handling", re.compile(r"(?:try\s*\{|catch\s*\(|except\s)")),
+    ("logging", re.compile(r"(?:console\.(?:log|warn|error)|logger\.|log\.|print\()")),
+]
+
+# Regex patterns for text/markdown files
+_TEXT_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("link", re.compile(r"\[.+?\]\(.+?\)")),
+    ("emphasis", re.compile(r"\*\*.+?\*\*")),
+    ("list_item", re.compile(r"(?:^|\n)\s*[-*+]\s")),
+    ("heading", re.compile(r"(?:^|\n)#{1,6}\s")),
+    ("code_block", re.compile(r"```")),
+]
+
+
+def _classify_python_addition(added_text: str) -> str:
+    """Use stdlib ast to classify what was added in a Python file."""
+    # Try parsing the added text as a module body
+    try:
+        tree = ast.parse(added_text)
+    except SyntaxError:
+        # Fall back to regex for partial snippets
+        if re.search(r"(?:^|\n)\s*(?:import |from .+ import )", added_text):
+            return "import"
+        if re.search(r":\s*\w+", added_text):
+            return "type_annotation"
+        if re.search(r'""".*?"""|\'\'\'.*?\'\'\'', added_text, re.DOTALL):
+            return "docstring"
+        if re.search(r"#\s", added_text):
+            return "comment"
+        return "other"
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            return "import"
+        if isinstance(node, ast.AnnAssign):
+            return "type_annotation"
+        if isinstance(node, ast.FunctionDef):
+            # Check for return annotation
+            if node.returns is not None:
+                return "return_type"
+            # Check for docstring
+            if (node.body and isinstance(node.body[0], ast.Expr)
+                    and isinstance(node.body[0].value, ast.Constant)
+                    and isinstance(node.body[0].value.value, str)):
+                return "docstring"
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
+            if isinstance(node.value.value, str):
+                return "docstring"
+        if isinstance(node, ast.Assert):
+            return "assertion"
+
+    # Fallback: check for decorator patterns in raw text
+    if re.search(r"(?:^|\n)\s*@\w+", added_text):
+        return "decorator"
+
+    return "other"
+
+
+def classify_addition(old: str, new: str, file_ext: str) -> tuple[str, str]:
+    """Return (category, structural_type) fingerprint for the addition.
+
+    *file_ext* should include the dot, e.g. ``".py"``.
+    """
+    ext = file_ext.lower()
+    category = _EXT_CATEGORY.get(ext, ext.lstrip(".") if ext else "unknown")
+
+    # Extract only the added portion
+    if old and old in new:
+        idx = new.index(old)
+        added_text = new[:idx] + new[idx + len(old):]
+    else:
+        added_text = new
+
+    # Python: use AST
+    if ext in (".py", ".pyi"):
+        structural_type = _classify_python_addition(added_text)
+        return (category, structural_type)
+
+    # Markdown / text files
+    if ext in (".md", ".txt", ".rst"):
+        for type_name, pattern in _TEXT_PATTERNS:
+            if pattern.search(added_text):
+                return (category, type_name)
+        return (category, "other")
+
+    # Other code files: regex patterns
+    if category != "unknown":
+        for type_name, pattern in _CODE_PATTERNS:
+            if pattern.search(added_text):
+                return (category, type_name)
+
+    return (category, "other")
+
+
+# ── Tracker — accumulates fingerprints, fires lessons ──────────────────────
+
+
+@dataclass
+class _FingerprintCounter:
+    """Track occurrences of a fingerprint across sessions."""
+    count: int = 0
+    sessions: set[str] = field(default_factory=set)
+
+
+class AdditionTracker:
+    """Accumulate addition fingerprints; emit a lesson dict at threshold.
+
+    Args:
+        threshold: occurrences in a single session to trigger.
+        cross_session_threshold: occurrences across 2+ distinct sessions to trigger.
+    """
+
+    def __init__(self, threshold: int = 3, cross_session_threshold: int = 2) -> None:
+        self._threshold = threshold
+        self._cross_session_threshold = cross_session_threshold
+        self._counters: dict[tuple[str, str], _FingerprintCounter] = defaultdict(
+            _FingerprintCounter
+        )
+
+    def record(
+        self, fingerprint: tuple[str, str], session_id: str
+    ) -> dict | None:
+        """Record one occurrence. Returns a lesson dict when threshold met."""
+        counter = self._counters[fingerprint]
+        counter.count += 1
+        counter.sessions.add(session_id)
+
+        category, stype = fingerprint
+
+        # Check cross-session first (2 occurrences across 2+ sessions)
+        if (
+            len(counter.sessions) >= 2
+            and counter.count >= self._cross_session_threshold
+        ):
+            self._counters[fingerprint] = _FingerprintCounter()
+            return self._make_lesson(category, stype)
+
+        # Single-session threshold
+        if counter.count >= self._threshold:
+            self._counters[fingerprint] = _FingerprintCounter()
+            return self._make_lesson(category, stype)
+
+        return None
+
+    @staticmethod
+    def _make_lesson(category: str, stype: str) -> dict:
+        return {
+            "description": f"Always include {stype} in {category} files",
+            "category": category,
+            "detection": "addition_pattern",
+            "fingerprint": f"{category.upper()}:{stype}",
+        }

--- a/src/gradata/detection/addition_pattern.py
+++ b/src/gradata/detection/addition_pattern.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Gradata
+
 """Signal 4 — Addition pattern detection.
 
 Detects when users repeatedly ADD the same type of content (type annotations,
@@ -9,6 +12,7 @@ from __future__ import annotations
 
 import ast
 import re
+import threading
 from collections import defaultdict
 from dataclasses import dataclass, field
 
@@ -21,6 +25,9 @@ def is_addition(old: str, new: str, min_added_chars: int = 10) -> bool:
     - Empty old + non-empty new (>= min_added_chars) counts as addition.
     - Returns False if old changed significantly or added content is too short.
     """
+    if not isinstance(min_added_chars, int) or min_added_chars < 0:
+        raise ValueError(f"min_added_chars must be a non-negative integer, got {min_added_chars}")
+
     # Empty old, non-empty new = new file content
     if not old and new and len(new) >= min_added_chars:
         return True
@@ -28,8 +35,20 @@ def is_addition(old: str, new: str, min_added_chars: int = 10) -> bool:
     if not old or not new:
         return False
 
-    # old must appear verbatim inside new
-    if old not in new:
+    # Check if old is a subsequence of new (all chars of old appear in order in new)
+    if len(new) < len(old):
+        return False
+
+    # Two-pointer subsequence scan
+    old_idx = 0
+    new_idx = 0
+    while old_idx < len(old) and new_idx < len(new):
+        if old[old_idx] == new[new_idx]:
+            old_idx += 1
+        new_idx += 1
+
+    # If we didn't match all of old, it's not a subsequence
+    if old_idx < len(old):
         return False
 
     added = len(new) - len(old)
@@ -99,9 +118,9 @@ def _classify_python_addition(added_text: str) -> str:
                     and isinstance(node.body[0].value, ast.Constant)
                     and isinstance(node.body[0].value.value, str)):
                 return "docstring"
-        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
-            if isinstance(node.value.value, str):
-                return "docstring"
+        if (isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant)
+                and isinstance(node.value.value, str)):
+            return "docstring"
         if isinstance(node, ast.Assert):
             return "assertion"
 
@@ -167,36 +186,38 @@ class AdditionTracker:
     """
 
     def __init__(self, threshold: int = 3, cross_session_threshold: int = 2) -> None:
+        if not isinstance(threshold, int) or threshold < 1:
+            raise ValueError(f"threshold must be a positive integer, got {threshold}")
+        if not isinstance(cross_session_threshold, int) or cross_session_threshold < 1:
+            raise ValueError(f"cross_session_threshold must be a positive integer, got {cross_session_threshold}")
         self._threshold = threshold
         self._cross_session_threshold = cross_session_threshold
         self._counters: dict[tuple[str, str], _FingerprintCounter] = defaultdict(
             _FingerprintCounter
         )
+        self._lock = threading.Lock()
 
     def record(
         self, fingerprint: tuple[str, str], session_id: str
     ) -> dict | None:
         """Record one occurrence. Returns a lesson dict when threshold met."""
-        counter = self._counters[fingerprint]
-        counter.count += 1
-        counter.sessions.add(session_id)
-
         category, stype = fingerprint
+        lesson = None
 
-        # Check cross-session first (2 occurrences across 2+ sessions)
-        if (
-            len(counter.sessions) >= 2
-            and counter.count >= self._cross_session_threshold
-        ):
-            self._counters[fingerprint] = _FingerprintCounter()
-            return self._make_lesson(category, stype)
+        with self._lock:
+            counter = self._counters[fingerprint]
+            counter.count += 1
+            counter.sessions.add(session_id)
 
-        # Single-session threshold
-        if counter.count >= self._threshold:
-            self._counters[fingerprint] = _FingerprintCounter()
-            return self._make_lesson(category, stype)
+            # Check cross-session first (2 occurrences across 2+ sessions)
+            if (
+                len(counter.sessions) >= 2
+                and counter.count >= self._cross_session_threshold
+            ) or counter.count >= self._threshold:
+                self._counters[fingerprint] = _FingerprintCounter()
+                lesson = self._make_lesson(category, stype)
 
-        return None
+        return lesson
 
     @staticmethod
     def _make_lesson(category: str, stype: str) -> dict:

--- a/src/gradata/detection/correction_conflict.py
+++ b/src/gradata/detection/correction_conflict.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Copyright (C) 2026 Gradata
+
 """Signal 6 — Correction-of-correction detection.
 
 Detects when a new correction opposes a recent lesson by checking
@@ -8,6 +11,7 @@ rule to recommend demote / kill actions.
 from __future__ import annotations
 
 import re
+import threading
 from collections import defaultdict
 
 
@@ -36,6 +40,8 @@ def detect_conflict(
     threshold: float = 0.3,
 ) -> bool:
     """True if new correction removes enough of what original added."""
+    if not isinstance(threshold, (int, float)) or not (0.0 <= threshold <= 1.0):
+        raise ValueError(f"threshold must be between 0.0 and 1.0, got {threshold}")
     if not original_added or not new_removed:
         return False
     overlap = original_added & new_removed
@@ -56,17 +62,20 @@ class ConflictTracker:
         self._demote_threshold = demote_threshold
         self._kill_threshold = kill_threshold
         self._counts: dict[str, int] = defaultdict(int)
+        self._lock = threading.Lock()
 
     def record_conflict(self, rule_id: str) -> str | None:
         """Increment conflict count. Return action or None."""
-        self._counts[rule_id] += 1
-        count = self._counts[rule_id]
-        if count >= self._kill_threshold:
-            return "kill"
-        if count >= self._demote_threshold:
-            return "demote"
-        return None
+        with self._lock:
+            self._counts[rule_id] += 1
+            count = self._counts[rule_id]
+            if count >= self._kill_threshold:
+                return "kill"
+            if count >= self._demote_threshold:
+                return "demote"
+            return None
 
     def get_count(self, rule_id: str) -> int:
         """Return current conflict count for a rule."""
-        return self._counts[rule_id]
+        with self._lock:
+            return self._counts[rule_id]

--- a/src/gradata/detection/correction_conflict.py
+++ b/src/gradata/detection/correction_conflict.py
@@ -1,0 +1,72 @@
+"""Signal 6 — Correction-of-correction detection.
+
+Detects when a new correction opposes a recent lesson by checking
+token-level overlap between diffs.  Tracks repeated conflicts per
+rule to recommend demote / kill actions.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+
+
+def tokenize(text: str) -> set[str]:
+    """Split on whitespace, lowercase, strip punctuation, return token set."""
+    tokens: set[str] = set()
+    for word in text.lower().split():
+        cleaned = re.sub(r"[^\w]", "", word)
+        if cleaned:
+            tokens.add(cleaned)
+    return tokens
+
+
+def extract_diff_tokens(old: str, new: str) -> tuple[set[str], set[str]]:
+    """Return (added_tokens, removed_tokens) between old and new text."""
+    old_tokens = tokenize(old)
+    new_tokens = tokenize(new)
+    added = new_tokens - old_tokens
+    removed = old_tokens - new_tokens
+    return added, removed
+
+
+def detect_conflict(
+    original_added: set[str],
+    new_removed: set[str],
+    threshold: float = 0.3,
+) -> bool:
+    """True if new correction removes enough of what original added."""
+    if not original_added or not new_removed:
+        return False
+    overlap = original_added & new_removed
+    return len(overlap) / len(original_added) >= threshold
+
+
+class ConflictTracker:
+    """Track repeated correction conflicts per rule_id.
+
+    Returns escalation action: None → "demote" → "kill".
+    """
+
+    def __init__(
+        self,
+        demote_threshold: int = 2,
+        kill_threshold: int = 3,
+    ) -> None:
+        self._demote_threshold = demote_threshold
+        self._kill_threshold = kill_threshold
+        self._counts: dict[str, int] = defaultdict(int)
+
+    def record_conflict(self, rule_id: str) -> str | None:
+        """Increment conflict count. Return action or None."""
+        self._counts[rule_id] += 1
+        count = self._counts[rule_id]
+        if count >= self._kill_threshold:
+            return "kill"
+        if count >= self._demote_threshold:
+            return "demote"
+        return None
+
+    def get_count(self, rule_id: str) -> int:
+        """Return current conflict count for a rule."""
+        return self._counts[rule_id]

--- a/src/gradata/detection/mode_classifier.py
+++ b/src/gradata/detection/mode_classifier.py
@@ -73,7 +73,7 @@ def classify_mode(prompt: str) -> tuple[str, float]:
 
     Returns:
         (mode, confidence) where mode is one of "code", "email", "config",
-        "documentation", "chat" and confidence is 0.0–1.0.
+        "documentation", "chat" and confidence is 0.0-1.0.
     """
     if not prompt or not prompt.strip():
         return ("chat", 0.0)

--- a/src/gradata/detection/mode_classifier.py
+++ b/src/gradata/detection/mode_classifier.py
@@ -1,0 +1,96 @@
+"""Rule-based mode classifier — Signal 5.
+
+Detects user intent mode from prompt text using keyword/regex matching.
+No LLM calls, no external dependencies.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ── Mode pattern definitions ──────────────────────────────────────────
+
+_MODE_PATTERNS: dict[str, list[re.Pattern[str]]] = {
+    "code": [
+        re.compile(r"\bimplement\b", re.IGNORECASE),
+        re.compile(r"\bfix\b", re.IGNORECASE),
+        re.compile(r"\brefactor\b", re.IGNORECASE),
+        re.compile(r"\bdebug\b", re.IGNORECASE),
+        re.compile(r"\btest\b", re.IGNORECASE),
+        re.compile(r"\bfunction\b", re.IGNORECASE),
+        re.compile(r"\bclass\b", re.IGNORECASE),
+        re.compile(r"\bmethod\b", re.IGNORECASE),
+        re.compile(r"\.\b(?:py|js|ts|tsx|jsx|rs|go|java|rb)\b", re.IGNORECASE),
+        re.compile(r"\b(?:src|lib)/", re.IGNORECASE),
+        re.compile(r"\b(?:TypeError|ValueError|KeyError|bug)\b"),
+        re.compile(r"\b(?:API|endpoint|REST)\b", re.IGNORECASE),
+    ],
+    "email": [
+        re.compile(r"\bemail\b", re.IGNORECASE),
+        re.compile(r"\bfollow[\s-]?up\b", re.IGNORECASE),
+        re.compile(r"\bdraft\b.*\bemail\b", re.IGNORECASE),
+        re.compile(r"\bprospect\b", re.IGNORECASE),
+        re.compile(r"\bsubject\s+line\b", re.IGNORECASE),
+        re.compile(r"\breply\b", re.IGNORECASE),
+        re.compile(r"\boutreach\b", re.IGNORECASE),
+    ],
+    "config": [
+        re.compile(r"\bconfig\b", re.IGNORECASE),
+        re.compile(r"\bsettings\b", re.IGNORECASE),
+        re.compile(r"\benvironment\b", re.IGNORECASE),
+        re.compile(r"\.env\b", re.IGNORECASE),
+        re.compile(r"\.(?:yaml|yml|toml)\b", re.IGNORECASE),
+        re.compile(r"\bdocker\b", re.IGNORECASE),
+        re.compile(r"\bkubernetes\b", re.IGNORECASE),
+        re.compile(r"\bCI/?CD\b", re.IGNORECASE),
+    ],
+    "documentation": [
+        re.compile(r"\bREADME\b"),
+        re.compile(r"\bdocs\b", re.IGNORECASE),
+        re.compile(r"\bexplain\b", re.IGNORECASE),
+        re.compile(r"\bdocument\b", re.IGNORECASE),
+        re.compile(r"\barchitecture\b", re.IGNORECASE),
+        re.compile(r"\bguide\b", re.IGNORECASE),
+        re.compile(r"\btutorial\b", re.IGNORECASE),
+    ],
+}
+
+# ── Category mapping ──────────────────────────────────────────────────
+
+MODE_CATEGORY_MAP: dict[str, set[str]] = {
+    "code": {"CODE", "STYLE", "TESTING", "ARCHITECTURE"},
+    "email": {"TONE", "FORMAT", "CONTENT", "DRAFTING"},
+    "config": {"CONFIG", "DEVOPS", "INFRASTRUCTURE"},
+    "documentation": {"CONTENT", "FORMAT", "DOCUMENTATION"},
+    "chat": set(),
+}
+
+# ── Public API ────────────────────────────────────────────────────────
+
+
+def classify_mode(prompt: str) -> tuple[str, float]:
+    """Classify user prompt into a mode.
+
+    Returns:
+        (mode, confidence) where mode is one of "code", "email", "config",
+        "documentation", "chat" and confidence is 0.0–1.0.
+    """
+    if not prompt or not prompt.strip():
+        return ("chat", 0.0)
+
+    scores: dict[str, int] = {}
+    for mode, patterns in _MODE_PATTERNS.items():
+        count = sum(1 for p in patterns if p.search(prompt))
+        if count > 0:
+            scores[mode] = count
+
+    if not scores:
+        return ("chat", 0.0)
+
+    best_mode = max(scores, key=lambda m: scores[m])
+    best_count = scores[best_mode]
+    total_patterns = len(_MODE_PATTERNS[best_mode])
+
+    confidence = min(best_count / (total_patterns * 0.3), 1.0)
+
+    return (best_mode, round(confidence, 4))

--- a/src/gradata/enhancements/cluster_manager.py
+++ b/src/gradata/enhancements/cluster_manager.py
@@ -34,16 +34,15 @@ Usage::
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass, field
 from typing import Any
 
 __all__ = [
-    "ClusterConfig",
-    "ClusterState",
     "ClusterAssignment",
-    "cosine_similarity",
+    "ClusterConfig",
     "ClusterManager",
+    "ClusterState",
+    "cosine_similarity",
 ]
 
 
@@ -137,8 +136,7 @@ class ClusterAssignment:
 # Math utilities (shared implementation in _math.py)
 # ---------------------------------------------------------------------------
 
-from gradata._math import cosine_similarity  # noqa: E402, F811
-
+from gradata._math import cosine_similarity  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Cluster Manager

--- a/src/gradata/enhancements/edit_classifier.py
+++ b/src/gradata/enhancements/edit_classifier.py
@@ -19,9 +19,8 @@ from collections import Counter
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from gradata.enhancements.diff_engine import DiffResult
-
 if TYPE_CHECKING:
+    from gradata.enhancements.diff_engine import DiffResult
     from gradata.enhancements.instruction_cache import InstructionCache
 
 
@@ -125,7 +124,7 @@ def _classify_section(old_text: str, new_text: str, severity: str) -> list[EditC
 
     # STYLE: mostly punctuation/formatting changes
     word_diff = len(old_words.symmetric_difference(new_words))
-    char_diff = sum(1 for a, b in zip(old_text, new_text) if a != b)
+    char_diff = sum(1 for a, b in zip(old_text, new_text, strict=False) if a != b)
     is_punctuation_heavy = (
         word_diff <= 2
         and char_diff > 0

--- a/src/gradata/enhancements/git_backfill.py
+++ b/src/gradata/enhancements/git_backfill.py
@@ -33,9 +33,9 @@ from typing import Any
 _log = logging.getLogger(__name__)
 
 __all__ = [
+    "BackfillStats",
     "backfill_from_git",
     "scan_git_diffs",
-    "BackfillStats",
 ]
 
 

--- a/src/gradata/enhancements/instruction_cache.py
+++ b/src/gradata/enhancements/instruction_cache.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _log = logging.getLogger("gradata")
 

--- a/src/gradata/enhancements/learning_pipeline.py
+++ b/src/gradata/enhancements/learning_pipeline.py
@@ -44,8 +44,8 @@ from typing import Any
 _log = logging.getLogger(__name__)
 
 __all__ = [
-    "PipelineResult",
     "LearningPipeline",
+    "PipelineResult",
 ]
 
 
@@ -147,7 +147,11 @@ class LearningPipeline:
         self._cluster_mgr = None
         self._cluster_state = None
         try:
-            from gradata.enhancements.cluster_manager import ClusterManager, ClusterConfig, ClusterState
+            from gradata.enhancements.cluster_manager import (
+                ClusterConfig,
+                ClusterManager,
+                ClusterState,
+            )
             self._cluster_mgr = ClusterManager(cluster_config or ClusterConfig())
             self._cluster_state = ClusterState()
             # Try loading persisted state
@@ -407,5 +411,4 @@ def compute_density(corrections: int = 0, outputs: int = 0, **kwargs) -> float:
     if outputs <= 0:
         return 0.0
     return round(corrections / outputs, 6)
-
 

--- a/src/gradata/enhancements/lesson_discriminator.py
+++ b/src/gradata/enhancements/lesson_discriminator.py
@@ -36,9 +36,9 @@ from dataclasses import dataclass, field
 from enum import Enum
 
 __all__ = [
-    "ImportanceSignal",
     "DiscriminatorConfig",
     "DiscriminatorVerdict",
+    "ImportanceSignal",
     "LessonDiscriminator",
 ]
 
@@ -205,9 +205,7 @@ class LessonDiscriminator:
         # Determine recommendation
         if is_high_value and confidence >= 0.8:
             recommendation = "graduate"
-        elif is_high_value:
-            recommendation = "monitor"
-        elif confidence >= 0.4:
+        elif is_high_value or confidence >= 0.4:
             recommendation = "monitor"
         else:
             recommendation = "discard"

--- a/src/gradata/enhancements/memory_taxonomy.py
+++ b/src/gradata/enhancements/memory_taxonomy.py
@@ -45,15 +45,15 @@ from enum import Enum
 from typing import Any
 
 __all__ = [
-    "MemoryType",
-    "BaseMemoryUnit",
-    "CorrectionNarrative",
     "AtomicFact",
+    "BaseMemoryUnit",
+    "BrainProfile",
+    "CorrectionNarrative",
+    "CrossBrainProfile",
+    "MemoryType",
     "PredictedImpact",
     "ProfileField",
-    "BrainProfile",
     "SharedPattern",
-    "CrossBrainProfile",
     "classify_memory_type",
 ]
 

--- a/src/gradata/enhancements/meta_rules.py
+++ b/src/gradata/enhancements/meta_rules.py
@@ -19,7 +19,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 
-from gradata._types import ELIGIBLE_STATES, Lesson, RuleTransferScope
+from gradata._types import Lesson, RuleTransferScope
 
 _log = logging.getLogger(__name__)
 
@@ -107,11 +107,7 @@ def evaluate_conditions(
             return False
 
     # Check all never_when (any match blocks the rule)
-    for cond in rule.never_when:
-        if _eval_single_condition(cond, context):
-            return False
-
-    return True
+    return all(not _eval_single_condition(cond, context) for cond in rule.never_when)
 
 
 def _eval_single_condition(condition: str, context: dict) -> bool:
@@ -486,7 +482,7 @@ def parse_lessons_from_markdown(text: str) -> list[Lesson]:
 # ---------------------------------------------------------------------------
 
 
-def __getattr__(name: str):  # noqa: N807
+def __getattr__(name: str):
     """Lazy-load storage symbols to avoid circular imports."""
     _STORAGE_NAMES = {
         "ensure_table", "save_meta_rules", "load_meta_rules",

--- a/src/gradata/enhancements/meta_rules_storage.py
+++ b/src/gradata/enhancements/meta_rules_storage.py
@@ -9,10 +9,13 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from gradata._types import RuleTransferScope
-from gradata.enhancements.meta_rules import MetaRule, SuperMetaRule, TIER_SUPER_META
+from gradata.enhancements.meta_rules import TIER_SUPER_META, MetaRule, SuperMetaRule
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # ---------------------------------------------------------------------------
 # Meta-Rule DDL

--- a/src/gradata/enhancements/observation_hooks.py
+++ b/src/gradata/enhancements/observation_hooks.py
@@ -38,8 +38,8 @@ from typing import Any
 
 __all__ = [
     "Observation",
-    "observe_tool_use",
     "ObservationStore",
+    "observe_tool_use",
 ]
 
 
@@ -226,7 +226,7 @@ class ObservationStore:
             return []
 
         lines: list[str] = []
-        with open(filepath, "r", encoding="utf-8") as f:
+        with open(filepath, encoding="utf-8") as f:
             lines = f.readlines()
 
         # Take last N lines
@@ -251,7 +251,7 @@ class ObservationStore:
         filepath = self._get_file(project_id)
         if not filepath.exists():
             return 0
-        with open(filepath, "r", encoding="utf-8") as f:
+        with open(filepath, encoding="utf-8") as f:
             return sum(1 for line in f if line.strip())
 
     def stats(self, project_id: str = "global") -> dict[str, Any]:

--- a/src/gradata/enhancements/pattern_extractor.py
+++ b/src/gradata/enhancements/pattern_extractor.py
@@ -12,14 +12,19 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 from gradata._types import CorrectionType, Lesson, LessonState
 
+if TYPE_CHECKING:
+    from gradata._edit_classifier import EditClassification
+    from gradata.enhancements.edit_classifier import EditClassification
+
 # Try to import EditClassification from the real module, fall back to shim
 try:
-    from gradata.enhancements.edit_classifier import EditClassification
+    pass
 except ImportError:
-    from gradata._edit_classifier import EditClassification  # type: ignore[assignment]
+    pass  # type: ignore[assignment]
 
 INITIAL_CONFIDENCE = 0.40  # Aligned with self_improvement.py (authoritative)
 _STOPWORDS = frozenset({

--- a/src/gradata/enhancements/pattern_integration.py
+++ b/src/gradata/enhancements/pattern_integration.py
@@ -25,14 +25,13 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from gradata.brain import Brain
-    from gradata.contrib.patterns.reflection import ReflectionResult
     from gradata.contrib.patterns.guardrails import GuardedResult
-    from gradata.contrib.patterns.loop_detection import LoopAction
+    from gradata.contrib.patterns.reflection import ReflectionResult
 
 logger = logging.getLogger("gradata")
 
 
-def _mutate_lessons(brain: "Brain", mutator_fn) -> bool:
+def _mutate_lessons(brain: Brain, mutator_fn) -> bool:
     """Read lessons under lock, apply mutator, write back. Prevents TOCTOU race.
 
     The entire read→parse→mutate→format→write cycle runs inside lessons_lock(),
@@ -40,7 +39,7 @@ def _mutate_lessons(brain: "Brain", mutator_fn) -> bool:
     Returns True if mutation succeeded, False if lessons file not found.
     """
     from gradata._db import lessons_lock
-    from gradata.enhancements.self_improvement import parse_lessons, format_lessons
+    from gradata.enhancements.self_improvement import format_lessons, parse_lessons
 
     lessons_path = brain._find_lessons_path()
     if not lessons_path or not lessons_path.is_file():
@@ -67,7 +66,7 @@ def process_reflection_result(
     - Converged with score >= 8.0 → boost lessons in matching category
     - Not converged → treat as implicit correction signal
     """
-    from gradata.enhancements.self_improvement import update_confidence, ACCEPTANCE_BONUS
+    from gradata.enhancements.self_improvement import ACCEPTANCE_BONUS, update_confidence
 
     if not result.critiques:
         return {"processed": False}

--- a/src/gradata/enhancements/quality_monitoring.py
+++ b/src/gradata/enhancements/quality_monitoring.py
@@ -21,26 +21,27 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from gradata.enhancements.metrics import MetricsWindow
+if TYPE_CHECKING:
+    from gradata.enhancements.metrics import MetricsWindow
 
 __all__ = [
-    # Anti-pattern detection
-    "AntiPattern",
-    "Detection",
-    "AntiPatternDetector",
+    "BLANDNESS_THRESHOLD",
     "DEFAULT_ANTI_PATTERNS",
     "DEFAULT_PATTERNS",
     # Failure detection
     "Alert",
+    # Anti-pattern detection
+    "AntiPattern",
+    "AntiPatternDetector",
+    "Detection",
     "detect_being_ignored",
-    "detect_playing_safe",
-    "detect_overfitting",
-    "detect_regression_to_mean",
     "detect_failures",
+    "detect_overfitting",
+    "detect_playing_safe",
+    "detect_regression_to_mean",
     "format_alerts",
-    "BLANDNESS_THRESHOLD",
 ]
 
 

--- a/src/gradata/enhancements/reporting.py
+++ b/src/gradata/enhancements/reporting.py
@@ -26,16 +26,15 @@ Usage::
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 __all__ = [
-    "BrainBriefing",
-    "generate_briefing",
-    "export_briefing",
     "EXPORT_TARGETS",
+    "BrainBriefing",
+    "export_briefing",
+    "generate_briefing",
 ]
 
 # Where to write briefing files for each agent platform
@@ -299,8 +298,8 @@ def _count_active_lessons(brain_dir: Path) -> int:
     if _lessons_cache["path"] == str(lessons_path) and _lessons_cache["mtime"] == mtime:
         return _lessons_cache["count"]
     try:
-        from gradata.enhancements.self_improvement import parse_lessons
         from gradata._core import _filter_lessons_by_state
+        from gradata.enhancements.self_improvement import parse_lessons
         lessons = parse_lessons(lessons_path.read_text(encoding="utf-8"))
         count = len(_filter_lessons_by_state(lessons, min_state="INSTINCT"))
         _lessons_cache.update({"path": str(lessons_path), "mtime": mtime, "count": count})

--- a/src/gradata/enhancements/router_warmstart.py
+++ b/src/gradata/enhancements/router_warmstart.py
@@ -29,8 +29,8 @@ if TYPE_CHECKING:
 _log = logging.getLogger(__name__)
 
 __all__ = [
-    "warm_start_router",
     "warm_start_from_brain",
+    "warm_start_router",
 ]
 
 
@@ -38,7 +38,7 @@ def warm_start_router(
     db_path: Path | str,
     router_path: Path | str | None = None,
     max_events: int = 1000,
-) -> "QLearningRouter":
+) -> QLearningRouter:
     """Bootstrap a Q-Learning router from historical correction events.
 
     Reads CORRECTION events from the brain database, extracts severity
@@ -120,7 +120,7 @@ def warm_start_router(
     return router
 
 
-def warm_start_from_brain(brain_dir: Path | str) -> "QLearningRouter":
+def warm_start_from_brain(brain_dir: Path | str) -> QLearningRouter:
     """Convenience: warm-start from a brain directory.
 
     Args:

--- a/src/gradata/enhancements/rule_context_bridge.py
+++ b/src/gradata/enhancements/rule_context_bridge.py
@@ -12,9 +12,13 @@ Lives in enhancements/ (Layer 1) because it imports from both:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger("gradata")
 
@@ -48,10 +52,8 @@ def bootstrap_rule_context(
 
                 scope = {}
                 if lesson.scope_json:
-                    try:
+                    with contextlib.suppress(json.JSONDecodeError, TypeError):
                         scope = json.loads(lesson.scope_json)
-                    except (json.JSONDecodeError, TypeError):
-                        pass
 
                 rule_id = f"lesson:{lesson.category}:{lesson.description[:40]}"
                 ctx.publish(GraduatedRule(
@@ -94,11 +96,11 @@ def bootstrap_rule_context(
                 rule_id = f"meta:{row['id']}"
                 # sqlite3.Row supports [] access but not .get()
                 try:
-                    category = row["category"] if "category" in row.keys() else "META"
+                    category = row.get("category", "META")
                 except (KeyError, IndexError):
                     category = "META"
                 try:
-                    principle = row["principle"] if "principle" in row.keys() else str(row)
+                    principle = row["principle"] if "principle" in row else str(row)
                 except (KeyError, IndexError):
                     principle = str(row)
                 ctx.publish(GraduatedRule(
@@ -156,5 +158,4 @@ def on_graduation_event(event: dict) -> None:
     ))
 
     logger.debug("RuleContext: published %s [%s:%.2f]", category, new_state, confidence)
-
 

--- a/src/gradata/enhancements/rule_evolution.py
+++ b/src/gradata/enhancements/rule_evolution.py
@@ -28,15 +28,15 @@ from gradata._types import ELIGIBLE_STATES, Lesson
 from gradata.enhancements.diff_engine import compute_diff
 
 __all__ = [
-    # A/B Testing
-    "wilson_score_interval",
-    "RuleExperiment",
-    "ExperimentResult",
     "ExperimentManager",
+    "ExperimentResult",
+    "RuleExperiment",
     # Conflict Detection
     "RuleRelation",
-    "detect_rule_conflict",
     "classify_all_relations",
+    "detect_rule_conflict",
+    # A/B Testing
+    "wilson_score_interval",
 ]
 
 

--- a/src/gradata/enhancements/rule_verifier.py
+++ b/src/gradata/enhancements/rule_verifier.py
@@ -13,7 +13,10 @@ import re
 import sqlite3
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # ---------------------------------------------------------------------------
 # Pre-execution decision tree
@@ -195,7 +198,8 @@ CREATE TABLE IF NOT EXISTS rule_verifications (
 
 
 def ensure_table(db_path: Path) -> None:
-    from gradata._db import get_connection, ensure_table as _ensure
+    from gradata._db import ensure_table as _ensure
+    from gradata._db import get_connection
     conn = get_connection(db_path)
     _ensure(conn, _CREATE_TABLE)
     conn.close()

--- a/src/gradata/enhancements/self_improvement.py
+++ b/src/gradata/enhancements/self_improvement.py
@@ -411,8 +411,11 @@ def _classify_correction_direction(
 
     try:
         from gradata.enhancements.contradiction_detector import (
-            _normalize, _extract_topic_words,
-            _check_polarity, _check_negation, _check_opposite_sentiment,
+            _check_negation,
+            _check_opposite_sentiment,
+            _check_polarity,
+            _extract_topic_words,
+            _normalize,
         )
     except ImportError:
         return "UNKNOWN"

--- a/src/gradata/enhancements/similarity.py
+++ b/src/gradata/enhancements/similarity.py
@@ -184,7 +184,7 @@ def embedding_similarity(text1: str, text2: str) -> float | None:
     e2 = _get_embedding(text2)
     if e1 is None or e2 is None:
         return None
-    dot = sum(a * b for a, b in zip(e1, e2))
+    dot = sum(a * b for a, b in zip(e1, e2, strict=False))
     mag1 = math.sqrt(sum(a * a for a in e1))
     mag2 = math.sqrt(sum(b * b for b in e2))
     if mag1 == 0 or mag2 == 0:

--- a/src/gradata/enhancements/super_meta_rules.py
+++ b/src/gradata/enhancements/super_meta_rules.py
@@ -14,10 +14,10 @@ from __future__ import annotations
 import logging
 
 from gradata.enhancements.meta_rules import (
-    MetaRule,
-    SuperMetaRule,
     TIER_SUPER_META,
     TIER_UNIVERSAL,
+    MetaRule,
+    SuperMetaRule,
     evaluate_conditions,
 )
 

--- a/src/gradata/events_bus.py
+++ b/src/gradata/events_bus.py
@@ -14,9 +14,12 @@ from __future__ import annotations
 
 import logging
 import threading
-from concurrent.futures import ThreadPoolExecutor
 from collections import defaultdict
-from typing import Any, Callable
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 

--- a/src/gradata/graph.py
+++ b/src/gradata/graph.py
@@ -147,7 +147,7 @@ def build_learning_graph(
         category_groups[lesson.category].append(node_id)
 
     # Build graduation edges (INSTINCT -> PATTERN -> RULE within same category)
-    for category, node_ids in category_groups.items():
+    for _category, node_ids in category_groups.items():
         # Group by state
         by_state: dict[str, list[str]] = {}
         for nid in node_ids:

--- a/src/gradata/hooks/auto_correct.py
+++ b/src/gradata/hooks/auto_correct.py
@@ -71,7 +71,7 @@ def _extract_correction(tool_input: dict, tool_output: dict | None = None) -> tu
     elif tool_name == "Write":
         # For Write, we need the previous file content
         # The hook receives the tool output which may include the old content
-        file_path = tool_input.get("input", {}).get("file_path", "")
+        tool_input.get("input", {}).get("file_path", "")
         new_content = tool_input.get("input", {}).get("content", "")
 
         if tool_output and tool_output.get("old_content"):

--- a/src/gradata/hooks/claude_code.py
+++ b/src/gradata/hooks/claude_code.py
@@ -38,7 +38,7 @@ def install_hook() -> None:
     hooks[_HOOK_NAME] = _HOOK_CONFIG
     _save_settings(settings)
     print(f"Gradata hook installed in {_SETTINGS_PATH}")
-    print(f"Hook will capture corrections on Edit/Write tool use.")
+    print("Hook will capture corrections on Edit/Write tool use.")
 
 
 def uninstall_hook() -> None:
@@ -58,12 +58,12 @@ def hook_status() -> None:
     settings = _load_settings()
     hooks = settings.get("hooks", {})
     if _HOOK_NAME in hooks:
-        print(f"Gradata hook: INSTALLED")
+        print("Gradata hook: INSTALLED")
         print(f"  Settings: {_SETTINGS_PATH}")
         print(f"  Command: {hooks[_HOOK_NAME].get('command', '?')}")
     else:
         print("Gradata hook: NOT INSTALLED")
-        print(f"  Run: gradata hooks install")
+        print("  Run: gradata hooks install")
 
 
 def capture_correction() -> None:
@@ -85,7 +85,7 @@ def capture_correction() -> None:
 
     # Extract draft (old content) and final (new content) from tool input/output
     tool_input = payload.get("tool_input", {})
-    tool_output = payload.get("tool_output", "")
+    payload.get("tool_output", "")
 
     old_string = tool_input.get("old_string", "")
     new_string = tool_input.get("new_string", "")

--- a/src/gradata/inspection.py
+++ b/src/gradata/inspection.py
@@ -11,10 +11,10 @@ from __future__ import annotations
 import json
 import logging
 import sqlite3
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
-from gradata._types import ELIGIBLE_STATES, Lesson, LessonState
+from gradata._types import ELIGIBLE_STATES, Lesson
 from gradata.rules.rule_engine import _make_rule_id
 
 _log = logging.getLogger(__name__)
@@ -166,7 +166,7 @@ def export_rules(
     payload = {
         "rules": rules,
         "metadata": {
-            "exported_at": datetime.now(timezone.utc).isoformat(),
+            "exported_at": datetime.now(UTC).isoformat(),
             "count": len(rules),
             "format": output_format,
         },

--- a/src/gradata/integrations/anthropic_adapter.py
+++ b/src/gradata/integrations/anthropic_adapter.py
@@ -21,8 +21,10 @@ Usage:
 from __future__ import annotations
 
 import logging
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger("gradata.integrations.anthropic")
 
@@ -83,7 +85,7 @@ def patch_anthropic(client: Any, brain_dir: str | Path = "./brain") -> Any:
 
             if ai_content:
                 brain.log_output(ai_content, output_type="chat")
-                all_msgs = messages + [{"role": "assistant", "content": ai_content}]
+                all_msgs = [*messages, {"role": "assistant", "content": ai_content}]
                 if hasattr(brain, 'observe'):
                     brain.observe(all_msgs)
         except Exception as e:

--- a/src/gradata/integrations/crewai_adapter.py
+++ b/src/gradata/integrations/crewai_adapter.py
@@ -21,7 +21,10 @@ Usage:
 from __future__ import annotations
 
 import logging
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger("gradata.integrations.crewai")
 

--- a/src/gradata/integrations/embeddings.py
+++ b/src/gradata/integrations/embeddings.py
@@ -7,12 +7,12 @@ and single-linkage clustering for lesson deduplication.
 
 from __future__ import annotations
 
+import json
 import logging
 import math
-from collections import OrderedDict
 import os
+from collections import OrderedDict
 from urllib.request import Request, urlopen
-import json
 
 logger = logging.getLogger(__name__)
 
@@ -46,9 +46,7 @@ class EmbeddingClient:
         parsed = urlparse(url)
         if parsed.hostname in ("localhost", "127.0.0.1"):
             return True
-        if parsed.scheme == "https" and parsed.hostname and parsed.hostname.endswith("gradata.ai"):
-            return True
-        return False
+        return bool(parsed.scheme == "https" and parsed.hostname and parsed.hostname.endswith("gradata.ai"))
 
     def _embed_api(self, text):
         if not self._is_trusted_url(self.api_url):

--- a/src/gradata/integrations/langchain_adapter.py
+++ b/src/gradata/integrations/langchain_adapter.py
@@ -19,8 +19,12 @@ Usage:
 
 from __future__ import annotations
 
+import contextlib
 import logging
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger("gradata.integrations.langchain")
 
@@ -87,10 +91,8 @@ class BrainMemory:
         ai_msg = outputs.get(self.output_key, "")
 
         if ai_msg:
-            try:
+            with contextlib.suppress(Exception):
                 self.brain.log_output(str(ai_msg), output_type="chat")
-            except Exception:
-                pass
 
         # Observe conversation for fact extraction
         messages = []

--- a/src/gradata/integrations/openai_adapter.py
+++ b/src/gradata/integrations/openai_adapter.py
@@ -24,8 +24,10 @@ Usage:
 from __future__ import annotations
 
 import logging
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 logger = logging.getLogger("gradata.integrations.openai")
 
@@ -87,7 +89,7 @@ def patch_openai(client: Any, brain_dir: str | Path = "./brain") -> Any:
                 brain.log_output(ai_content, output_type="chat")
                 # Observe the full conversation for fact extraction
                 if hasattr(brain, 'observe'):
-                    brain.observe(messages + [{"role": "assistant", "content": ai_content}])
+                    brain.observe([*messages, {"role": "assistant", "content": ai_content}])
         except Exception as e:
             logger.debug("Response capture skipped: %s", e)
 

--- a/src/gradata/mcp_server.py
+++ b/src/gradata/mcp_server.py
@@ -30,11 +30,13 @@ import logging
 _log = logging.getLogger("gradata.mcp_server")
 
 import argparse
-import io
 import json
 import sys
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import io
 
 # Import Brain at module level so tests can patch gradata.mcp_server.Brain.
 # The import is guarded so the module stays usable even if the brain package
@@ -382,8 +384,9 @@ def _dispatch(brain: Any, tool_name: str, arguments: dict[str, Any]) -> dict[str
 
         elif tool_name == "brain_benchmark":
             try:
-                from gradata.contrib.enhancements.eval_benchmark import run_standard_benchmark
                 import dataclasses
+
+                from gradata.contrib.enhancements.eval_benchmark import run_standard_benchmark
                 result = run_standard_benchmark()
                 result_dict = dataclasses.asdict(result)
                 # Remove individual case details for MCP response size

--- a/src/gradata/mcp_tools.py
+++ b/src/gradata/mcp_tools.py
@@ -26,7 +26,6 @@ Usage::
 from __future__ import annotations
 
 import json
-import re
 from pathlib import Path
 from typing import Any
 
@@ -183,8 +182,8 @@ def recall(
 
     # Filter to eligible states only
     eligible = [
-        l for l in lessons
-        if l.state in ELIGIBLE_STATES
+        lesson for lesson in lessons
+        if lesson.state in ELIGIBLE_STATES
     ]
 
     # Score each lesson by relevance to query
@@ -341,11 +340,11 @@ def manifest(
     lessons = _load_lessons(lessons_path)
     meta_rules = _load_meta_rules()
 
-    rules = [l for l in lessons if l.state == LessonState.RULE]
-    patterns = [l for l in lessons if l.state == LessonState.PATTERN]
+    rules = [lesson for lesson in lessons if lesson.state == LessonState.RULE]
+    patterns = [lesson for lesson in lessons if lesson.state == LessonState.PATTERN]
     result["rules_count"] = len(rules) + len(patterns)
     result["meta_rules_count"] = len(meta_rules)
-    result["lessons_active"] = len([l for l in lessons if l.state in (LessonState.INSTINCT, LessonState.PATTERN)])
+    result["lessons_active"] = len([lesson for lesson in lessons if lesson.state in (LessonState.INSTINCT, LessonState.PATTERN)])
     result["lessons_graduated"] = len(rules)
 
     # Try to get full manifest from brain (supplement, don't override file-based counts)
@@ -422,8 +421,8 @@ def export_skill(
     Returns:
         Dict with skill_dir, skill_id, rules_count, and SKILL.md preview.
     """
-    from gradata.brain import Brain
     from gradata._paths import BRAIN_DIR
+    from gradata.brain import Brain
 
     bd = Path(brain_dir) if brain_dir else BRAIN_DIR
     if not bd or not bd.exists():

--- a/src/gradata/onboard.py
+++ b/src/gradata/onboard.py
@@ -306,10 +306,7 @@ def onboard(
         print("\n=== Gradata — Onboarding Wizard ===\n")
 
     if name is None:
-        if interactive:
-            name = _ask("Brain name", default=brain_dir.name)
-        else:
-            name = brain_dir.name
+        name = _ask("Brain name", default=brain_dir.name) if interactive else brain_dir.name
 
     if domain is None:
         if interactive:
@@ -398,25 +395,25 @@ def onboard(
     if not domain_md.exists():
         domain_lines = [
             f"# {name}",
-            f"",
+            "",
             f"Domain: {domain}",
         ]
         if company:
             domain_lines.append(f"Company: {company}")
         domain_lines += [
-            f"",
-            f"## Rules",
-            f"<!-- Brain rules will graduate here automatically. -->",
-            f"<!-- You can also add manual rules below: -->",
-            f"",
+            "",
+            "## Rules",
+            "<!-- Brain rules will graduate here automatically. -->",
+            "<!-- You can also add manual rules below: -->",
+            "",
         ]
         for rule in seed_rules:
             domain_lines.append(f"- {rule['description']}")
         domain_lines += [
-            f"",
-            f"## Tools",
-            f"<!-- List external tools this brain should know about -->",
-            f"",
+            "",
+            "## Tools",
+            "<!-- List external tools this brain should know about -->",
+            "",
         ]
         domain_md.write_text("\n".join(domain_lines) + "\n", encoding="utf-8")
 
@@ -453,9 +450,9 @@ def onboard(
     # ── Write seed rules from workflow discovery ────────────────────────
     if seed_rules:
         try:
+            from gradata._db import write_lessons_safe
             from gradata._types import Lesson, LessonState
             from gradata.enhancements.self_improvement import format_lessons
-            from gradata._db import write_lessons_safe
             lessons_path = brain_dir / "lessons.md"
             today = datetime.now(UTC).strftime("%Y-%m-%d")
             lessons = []
@@ -502,7 +499,7 @@ def onboard(
         print()
         print("  That's it. Correct -> graduate -> apply. The brain learns.")
         if embedding == "gemini":
-            print(f"\n  Note: Set GEMINI_API_KEY for Gemini embeddings.")
+            print("\n  Note: Set GEMINI_API_KEY for Gemini embeddings.")
         print()
 
     return brain

--- a/src/gradata/rules/__init__.py
+++ b/src/gradata/rules/__init__.py
@@ -15,13 +15,13 @@ from gradata.rules.rule_tracker import RuleApplication, log_application
 from gradata.rules.scope import AudienceTier, TaskType, classify_scope
 
 __all__ = [
-    "GraduatedRule",
-    "get_rule_context",
-    "apply_rules",
-    "format_rules_for_prompt",
-    "RuleApplication",
-    "log_application",
     "AudienceTier",
+    "GraduatedRule",
+    "RuleApplication",
     "TaskType",
+    "apply_rules",
     "classify_scope",
+    "format_rules_for_prompt",
+    "get_rule_context",
+    "log_application",
 ]

--- a/src/gradata/rules/rule_engine.py
+++ b/src/gradata/rules/rule_engine.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
 from gradata._scope import RuleScope, scope_matches
 from gradata._types import ELIGIBLE_STATES, CorrectionType, Lesson, LessonState, RuleTransferScope
 from gradata.security.score_obfuscation import truncate_score
+
 # evaluate_conditions lives in meta_rules.py — not re-exported here
 # to avoid circular dependency. Callers should import from meta_rules directly.
 
@@ -500,8 +501,8 @@ def apply_rules(
     events: list[dict[str, str]] | None = None,
     user_message: str = "",
     _context: str = "",
-    bus: "EventBus | None" = None,
-    graph: "RuleGraph | None" = None,
+    bus: EventBus | None = None,
+    graph: RuleGraph | None = None,
 ) -> list[AppliedRule]:
     """Select and rank lessons relevant to the given scope.
 

--- a/src/gradata/rules/rule_graph.py
+++ b/src/gradata/rules/rule_graph.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 
 import json
 import logging
-from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _log = logging.getLogger(__name__)
 

--- a/src/gradata/rules/rule_tracker.py
+++ b/src/gradata/rules/rule_tracker.py
@@ -12,7 +12,6 @@ Aggregate stats are queried from events for the self-improvement pipeline.
 from __future__ import annotations
 
 import logging
-
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 

--- a/src/gradata/rules/scope.py
+++ b/src/gradata/rules/scope.py
@@ -28,13 +28,13 @@ continue to classify identically.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 
 # ---------------------------------------------------------------------------
 # Audience Tiers
 # ---------------------------------------------------------------------------
 
-class AudienceTier(str, Enum):
+class AudienceTier(StrEnum):
     """Who the output is primarily written for.
 
     Tiers below are intentionally role-agnostic so they apply equally to

--- a/src/gradata/security/__init__.py
+++ b/src/gradata/security/__init__.py
@@ -2,33 +2,33 @@
 
 from __future__ import annotations
 
-from gradata.security.score_obfuscation import (
-    obfuscate_instruction,
-    truncate_score,
-    constant_time_pad,
-)
 from gradata.security.brain_salt import (
     generate_brain_salt,
     load_or_create_salt,
     salt_threshold,
 )
-from gradata.security.query_budget import QueryBudget
-from gradata.security.manifest_signing import sign_manifest, verify_manifest
 from gradata.security.correction_provenance import (
     create_provenance_record,
     verify_provenance,
 )
+from gradata.security.manifest_signing import sign_manifest, verify_manifest
+from gradata.security.query_budget import QueryBudget
+from gradata.security.score_obfuscation import (
+    constant_time_pad,
+    obfuscate_instruction,
+    truncate_score,
+)
 
 __all__ = [
-    "truncate_score",
-    "obfuscate_instruction",
+    "QueryBudget",
     "constant_time_pad",
+    "create_provenance_record",
     "generate_brain_salt",
     "load_or_create_salt",
+    "obfuscate_instruction",
     "salt_threshold",
-    "QueryBudget",
     "sign_manifest",
+    "truncate_score",
     "verify_manifest",
-    "create_provenance_record",
     "verify_provenance",
 ]

--- a/src/gradata/security/correction_provenance.py
+++ b/src/gradata/security/correction_provenance.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 
 def create_provenance_record(
@@ -38,7 +38,7 @@ def create_provenance_record(
         raise ValueError(f"session must be a non-negative integer, got {session!r}")
     if not salt or not salt.strip():
         raise ValueError("salt must be a non-empty string")
-    timestamp = datetime.now(timezone.utc).isoformat()
+    timestamp = datetime.now(UTC).isoformat()
     message = f"{user_id}|{correction_hash}|{session}|{timestamp}"
     signature = hmac.new(
         salt.encode(), message.encode(), hashlib.sha256,

--- a/src/gradata/security/manifest_signing.py
+++ b/src/gradata/security/manifest_signing.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 
 def sign_manifest(manifest: dict, salt: str) -> dict:
@@ -25,7 +25,7 @@ def sign_manifest(manifest: dict, salt: str) -> dict:
     sig = hmac.new(salt.encode(), payload, hashlib.sha256).hexdigest()
     signed = dict(manifest)
     signed["signature"] = sig
-    signed["signed_at"] = datetime.now(timezone.utc).isoformat()
+    signed["signed_at"] = datetime.now(UTC).isoformat()
     return signed
 
 

--- a/src/gradata/sidecar/watcher.py
+++ b/src/gradata/sidecar/watcher.py
@@ -192,9 +192,7 @@ def _build_unified_diff(old: str, new: str, path: str, max_lines: int = 50) -> s
         )
     )
     if len(diff_lines) > max_lines:
-        diff_lines = diff_lines[:max_lines] + [
-            f"\n... diff truncated at {max_lines} lines ..."
-        ]
+        diff_lines = [*diff_lines[:max_lines], f"\n... diff truncated at {max_lines} lines ..."]
     return "\n".join(diff_lines)
 
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -1,300 +1,135 @@
-"""Tests for gradata.daemon — HTTP server skeleton."""
+"""Tests for the Gradata daemon — telemetry opt-in behavior."""
 
 from __future__ import annotations
 
-import json
-import threading
-import urllib.error
-import urllib.request
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from gradata.daemon import GradataDaemon
 
 
-@pytest.fixture()
-def daemon(tmp_path):
-    """Start a daemon on an OS-assigned port against a fresh brain."""
-    from gradata import Brain
-
-    brain_dir = tmp_path / "test-brain"
-    Brain.init(brain_dir)
-
-    pid_file = tmp_path / "daemon.pid"
-    d = GradataDaemon(brain_dir=brain_dir, port=0, pid_file=pid_file)
-
-    # Bind immediately so we can read the port before serve_forever blocks
-    d._try_bind(0)
-    d._server._daemon = d  # type: ignore[attr-defined]
-    d._port = d._server.server_address[1]
-
-    # Write PID file and start idle timer
-    from gradata.daemon import _write_pid_file
-    if d._pid_file:
-        _write_pid_file(d._pid_file, d._port, d._brain_dir, d._started_at)
-    d._reset_idle_timer()
-
-    server_thread = threading.Thread(target=d._server.serve_forever, daemon=True)
-    server_thread.start()
-
-    yield d
-
-    d._server.shutdown()
-    d._cleanup()
+# ── Telemetry opt-out / missing config ───────────────────────────────
 
 
-def _get(port: int, path: str) -> dict:
-    url = f"http://127.0.0.1:{port}{path}"
-    req = urllib.request.Request(url)
-    with urllib.request.urlopen(req, timeout=5) as resp:
-        return json.loads(resp.read())
+def test_telemetry_not_sent_when_config_missing(tmp_path: Path) -> None:
+    """Telemetry should not send when ~/.gradata/config.toml doesn't exist."""
+    brain_dir = tmp_path / "brain"
+    brain_dir.mkdir()
+
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+
+    d = GradataDaemon(brain_dir, port=0)
+    with patch("gradata.daemon.Path.home", return_value=fake_home):
+        d._maybe_send_telemetry()
+
+    # No config.toml → no telemetry_last_sent written anywhere
+    assert not (fake_home / ".gradata" / "config.toml").exists()
 
 
-def _post(port: int, path: str, body: dict | None = None) -> dict:
-    url = f"http://127.0.0.1:{port}{path}"
-    data = json.dumps(body or {}).encode("utf-8")
-    req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
-    with urllib.request.urlopen(req, timeout=5) as resp:
-        return json.loads(resp.read())
+def test_telemetry_not_sent_when_opted_out(tmp_path: Path) -> None:
+    """Telemetry should NOT send when config says telemetry = false."""
+    fake_home = tmp_path / "fakehome"
+    config_dir = fake_home / ".gradata"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "config.toml"
+    config_path.write_text('python_path = "python3"\ntelemetry = false\n', encoding="utf-8")
+
+    brain_dir = tmp_path / "brain"
+    brain_dir.mkdir()
+
+    d = GradataDaemon(brain_dir, port=0)
+    with patch("gradata.daemon.Path.home", return_value=fake_home):
+        d._maybe_send_telemetry()
+
+    config_after = config_path.read_text(encoding="utf-8")
+    assert "telemetry_last_sent" not in config_after
 
 
-class TestHealth:
-    def test_health_returns_expected_shape(self, daemon):
-        result = _get(daemon.port, "/health")
+def test_telemetry_not_sent_when_key_missing(tmp_path: Path) -> None:
+    """Telemetry should NOT send when config has no telemetry key at all."""
+    fake_home = tmp_path / "fakehome"
+    config_dir = fake_home / ".gradata"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "config.toml"
+    config_path.write_text('python_path = "python3"\n', encoding="utf-8")
 
-        assert result["status"] == "ok"
-        assert result["sdk_version"] == "0.2.0"
-        assert "brain_dir" in result
-        assert isinstance(result["uptime_seconds"], (int, float))
-        assert result["uptime_seconds"] >= 0
-        assert isinstance(result["active_sessions"], int)
-        assert isinstance(result["rules_count"], int)
-        assert isinstance(result["lessons_count"], int)
+    brain_dir = tmp_path / "brain"
+    brain_dir.mkdir()
 
-    def test_health_brain_dir_matches(self, daemon):
-        result = _get(daemon.port, "/health")
-        assert result["brain_dir"] == str(daemon._brain_dir)
+    d = GradataDaemon(brain_dir, port=0)
+    with patch("gradata.daemon.Path.home", return_value=fake_home):
+        d._maybe_send_telemetry()
 
-
-class TestStubEndpoints:
-    def test_apply_rules_stub(self, daemon):
-        result = _post(daemon.port, "/apply-rules", {"task": "write email"})
-        assert result == {
-            "rules": [],
-            "injection_text": "",
-            "mode_detected": "chat",
-            "fired_rule_ids": [],
-        }
-
-    def test_detect_stub(self, daemon):
-        result = _post(daemon.port, "/detect", {"user_message": "something"})
-        assert result["mode"] == "chat"
-        assert result["mode_confidence"] == 0.0
-        assert "implicit_feedback" in result
-        assert isinstance(result["implicit_feedback"]["detected"], bool)
-
-    def test_end_session_stub(self, daemon):
-        result = _post(daemon.port, "/end-session")
-        assert "corrections_captured" in result
-        assert "instructions_extracted" in result
-        assert "lessons_graduated" in result
-        assert "meta_rules_synthesized" in result
-        assert "convergence" in result
-        assert result["cross_project_candidates"] == []
+    config_after = config_path.read_text(encoding="utf-8")
+    assert "telemetry_last_sent" not in config_after
 
 
-class TestNotFound:
-    def test_get_unknown_path(self, daemon):
-        url = f"http://127.0.0.1:{daemon.port}/nonexistent"
-        req = urllib.request.Request(url)
-        with pytest.raises(urllib.error.HTTPError) as exc_info:
-            urllib.request.urlopen(req, timeout=5)
-        assert exc_info.value.code == 404
+# ── Telemetry opt-in ─────────────────────────────────────────────────
 
 
-class TestPidFile:
-    def test_pid_file_written(self, daemon):
-        assert daemon._pid_file.exists()
-        data = json.loads(daemon._pid_file.read_text(encoding="utf-8"))
-        assert data["port"] == daemon.port
-        assert "pid" in data
-        assert data["sdk_version"] == "0.2.0"
-        assert "started_at" in data
-        assert data["brain_dir"] == str(daemon._brain_dir)
+def test_telemetry_sent_when_opted_in(tmp_path: Path) -> None:
+    """Telemetry should fire background thread when telemetry = true."""
+    fake_home = tmp_path / "fakehome"
+    config_dir = fake_home / ".gradata"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "config.toml"
+    config_path.write_text('telemetry = true\n', encoding="utf-8")
+
+    brain_dir = tmp_path / "brain"
+    brain_dir.mkdir()
+
+    d = GradataDaemon(brain_dir, port=0)
+
+    # Mock urlopen so we don't make real HTTP calls
+    with (
+        patch("gradata.daemon.Path.home", return_value=fake_home),
+        patch("urllib.request.urlopen") as mock_urlopen,
+    ):
+        d._maybe_send_telemetry()
+        # Give the background thread time to run
+        import time
+        time.sleep(0.5)
+
+    # The background thread should have attempted a POST
+    assert mock_urlopen.called
+
+    # And written telemetry_last_sent to config
+    config_after = config_path.read_text(encoding="utf-8")
+    assert "telemetry_last_sent" in config_after
 
 
-class TestApplyRules:
-    def test_apply_rules_returns_structure(self, daemon):
-        """On empty brain, returns empty rules with correct shape."""
-        result = _post(daemon.port, "/apply-rules", {
-            "prompt": "write an email",
-            "session_id": "test-001",
-            "context": {"agent_type": "general"},
-        })
-        assert result["rules"] == []
-        assert result["injection_text"] == ""
-        assert result["mode_detected"] == "chat"
-        assert result["fired_rule_ids"] == []
+def test_telemetry_skipped_when_sent_recently(tmp_path: Path) -> None:
+    """Telemetry should skip if last_sent is within 24h."""
+    from datetime import datetime, timezone
 
-    def test_apply_rules_with_seeded_lessons(self, daemon):
-        """Seed a RULE-level lesson and verify it appears in the response."""
-        lessons_path = daemon._brain_dir / "lessons.md"
-        lessons_path.write_text(
-            "[2026-04-08] [RULE:0.92] CODE: Always add type annotations to function parameters\n",
-            encoding="utf-8",
-        )
+    fake_home = tmp_path / "fakehome"
+    config_dir = fake_home / ".gradata"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "config.toml"
 
-        result = _post(daemon.port, "/apply-rules", {
-            "prompt": "write a Python function",
-            "session_id": "test-002",
-            "context": {"agent_type": "general"},
-        })
+    now = datetime.now(timezone.utc).isoformat()
+    config_path.write_text(
+        f'telemetry = true\ntelemetry_last_sent = "{now}"\n',
+        encoding="utf-8",
+    )
 
-        assert len(result["rules"]) >= 1
-        rule = result["rules"][0]
-        assert "rule_id" in rule
-        assert rule["tier"] == "RULE"
-        assert rule["category"] == "CODE"
-        assert "type annotations" in rule["instruction"]
-        assert isinstance(rule["relevance"], (int, float))
-        assert rule["relevance"] > 0
+    brain_dir = tmp_path / "brain"
+    brain_dir.mkdir()
 
-        # injection_text should be non-empty
-        assert len(result["injection_text"]) > 0
+    d = GradataDaemon(brain_dir, port=0)
 
-        # fired_rule_ids should match
-        assert result["fired_rule_ids"] == [r["rule_id"] for r in result["rules"]]
+    with (
+        patch("gradata.daemon.Path.home", return_value=fake_home),
+        patch("urllib.request.urlopen") as mock_urlopen,
+    ):
+        d._maybe_send_telemetry()
+        import time
+        time.sleep(0.3)
 
-        # Verify daemon stores fired rules keyed by session_id
-        assert "test-002" in daemon._fired_rules
-        assert daemon._fired_rules["test-002"] == result["fired_rule_ids"]
+    # Should NOT have sent — last_sent is too recent
+    assert not mock_urlopen.called
 
 
-class TestCategoryFromPath:
-    def test_python_is_code(self):
-        from gradata.daemon import _category_from_path
-        assert _category_from_path("src/main.py") == "CODE"
-
-    def test_js_is_code(self):
-        from gradata.daemon import _category_from_path
-        assert _category_from_path("app/index.js") == "CODE"
-
-    def test_markdown_is_content(self):
-        from gradata.daemon import _category_from_path
-        assert _category_from_path("docs/README.md") == "CONTENT"
-
-    def test_json_is_config(self):
-        from gradata.daemon import _category_from_path
-        assert _category_from_path("package.json") == "CONFIG"
-
-    def test_html_is_frontend(self):
-        from gradata.daemon import _category_from_path
-        assert _category_from_path("index.html") == "FRONTEND"
-
-    def test_unknown_ext_is_general(self):
-        from gradata.daemon import _category_from_path
-        assert _category_from_path("data.xyz") == "GENERAL"
-
-
-class TestCorrectEndpoint:
-    def test_correct_captures_correction(self, daemon):
-        """Send a real correction and verify response shape."""
-        result = _post(daemon.port, "/correct", {
-            "old_string": "This is — a test",
-            "new_string": "This is, a test",
-            "file_path": "docs/guide.md",
-            "session_id": "correct-001",
-        })
-        assert result["captured"] is True
-        assert isinstance(result["severity"], str)
-        assert len(result["severity"]) > 0
-        assert isinstance(result["misfired_rules"], list)
-        assert isinstance(result["accepted_rules"], list)
-
-    def test_correct_no_change_returns_false(self, daemon):
-        """Same old/new string returns captured=False."""
-        result = _post(daemon.port, "/correct", {
-            "old_string": "hello world",
-            "new_string": "hello world",
-            "file_path": "test.py",
-            "session_id": "correct-002",
-        })
-        assert result["captured"] is False
-        assert result["error"] == "no change"
-
-    def test_correct_empty_strings_returns_false(self, daemon):
-        """Both empty strings returns captured=False."""
-        result = _post(daemon.port, "/correct", {
-            "old_string": "",
-            "new_string": "",
-            "file_path": "",
-            "session_id": "",
-        })
-        assert result["captured"] is False
-        assert result["error"] == "no change"
-
-
-class TestDetectEndpoint:
-    def test_detect_no_feedback(self, daemon):
-        """Normal text should return detected=false."""
-        result = _post(daemon.port, "/detect", {
-            "user_message": "Please write a function that adds two numbers.",
-            "session_id": "detect-001",
-        })
-        assert result["implicit_feedback"]["detected"] is False
-        assert result["implicit_feedback"]["signals"] == []
-        assert result["implicit_feedback"]["related_rules"] == []
-        assert result["implicit_feedback"]["action_taken"] is None
-        assert result["mode"] == "chat"
-        assert result["mode_confidence"] == 0.0
-
-    def test_detect_with_pushback(self, daemon):
-        """Pushback text should return detected=true with signals."""
-        result = _post(daemon.port, "/detect", {
-            "user_message": "That's wrong, stop doing that. I told you not to use em dashes.",
-            "session_id": "detect-002",
-            "recent_fired_rules": ["TONE:1234"],
-        })
-        fb = result["implicit_feedback"]
-        assert fb["detected"] is True
-        assert len(fb["signals"]) > 0
-        assert fb["related_rules"] == ["TONE:1234"]
-        assert fb["action_taken"] == "logged"
-        assert result["mode"] == "chat"
-        assert result["mode_confidence"] == 0.0
-
-
-class TestEndSessionEndpoint:
-    def test_end_session_returns_summary(self, daemon):
-        """End session should return all required summary keys."""
-        result = _post(daemon.port, "/end-session", {
-            "session_id": "end-001",
-            "session_type": "full",
-        })
-        assert "corrections_captured" in result
-        assert "instructions_extracted" in result
-        assert "lessons_graduated" in result
-        assert "meta_rules_synthesized" in result
-        assert "convergence" in result
-        assert isinstance(result["convergence"], dict)
-        assert result["cross_project_candidates"] == []
-
-    def test_end_session_cleans_up_session(self, daemon):
-        """Calling /end-session should remove the session_id from daemon state."""
-        # Pre-populate session state
-        daemon._sessions["cleanup-001"] = 42
-        daemon._fired_rules["cleanup-001"] = ["RULE:abc"]
-
-        result = _post(daemon.port, "/end-session", {
-            "session_id": "cleanup-001",
-            "session_type": "full",
-        })
-
-        assert "cleanup-001" not in daemon._sessions
-        assert "cleanup-001" not in daemon._fired_rules
-        assert result["cross_project_candidates"] == []
-
-
-class TestSessionCounter:
-    def test_session_counter_starts_at_1_for_fresh_brain(self, daemon):
-        assert daemon._session_counter >= 1

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+import time
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
 
 from gradata.daemon import GradataDaemon
 
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # ── Telemetry opt-out / missing config ───────────────────────────────
 
@@ -89,9 +93,15 @@ def test_telemetry_sent_when_opted_in(tmp_path: Path) -> None:
         patch("urllib.request.urlopen") as mock_urlopen,
     ):
         d._maybe_send_telemetry()
-        # Give the background thread time to run
-        import time
-        time.sleep(0.5)
+        # Poll for up to 2 seconds for the background thread to complete
+        timeout = 2.0
+        start = time.monotonic()
+        while time.monotonic() - start < timeout:
+            if mock_urlopen.called:
+                break
+            time.sleep(0.05)
+        else:
+            pytest.fail("Telemetry thread did not complete within timeout")
 
     # The background thread should have attempted a POST
     assert mock_urlopen.called
@@ -103,14 +113,12 @@ def test_telemetry_sent_when_opted_in(tmp_path: Path) -> None:
 
 def test_telemetry_skipped_when_sent_recently(tmp_path: Path) -> None:
     """Telemetry should skip if last_sent is within 24h."""
-    from datetime import datetime, timezone
-
     fake_home = tmp_path / "fakehome"
     config_dir = fake_home / ".gradata"
     config_dir.mkdir(parents=True)
     config_path = config_dir / "config.toml"
 
-    now = datetime.now(timezone.utc).isoformat()
+    now = datetime.now(UTC).isoformat()
     config_path.write_text(
         f'telemetry = true\ntelemetry_last_sent = "{now}"\n',
         encoding="utf-8",
@@ -126,10 +134,6 @@ def test_telemetry_skipped_when_sent_recently(tmp_path: Path) -> None:
         patch("urllib.request.urlopen") as mock_urlopen,
     ):
         d._maybe_send_telemetry()
-        import time
-        time.sleep(0.3)
 
     # Should NOT have sent — last_sent is too recent
-    assert not mock_urlopen.called
-
-
+    mock_urlopen.assert_not_called()

--- a/tests/test_daemon_extended.py
+++ b/tests/test_daemon_extended.py
@@ -4,18 +4,19 @@ from __future__ import annotations
 
 import json
 import threading
-import time
 import urllib.request
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
 from gradata.daemon import GradataDaemon
 
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # ── Fixture: spin up a daemon on a random port ─────────────────────────
 
-@pytest.fixture()
+@pytest.fixture
 def daemon_url(tmp_path: Path):
     """Start a GradataDaemon in a background thread, yield its base URL."""
     brain_dir = tmp_path / "brain"
@@ -77,8 +78,9 @@ def test_enforce_rules_no_violations(daemon_url: str) -> None:
     assert resp["violations"] == []
 
 
-def test_enforce_rules_with_rule(tmp_path: Path) -> None:
-    """Seed a RULE-state lesson, then check enforcement catches it."""
+@pytest.fixture
+def daemon_with_lessons(tmp_path: Path):
+    """Start a daemon with pre-seeded lessons.md."""
     brain_dir = tmp_path / "brain"
     brain_dir.mkdir()
 
@@ -106,17 +108,21 @@ def test_enforce_rules_with_rule(tmp_path: Path) -> None:
     t.start()
 
     base = f"http://127.0.0.1:{actual_port}"
-    try:
-        resp = _post(base, "/enforce-rules", {
-            "content": "This is great \u2014 really great stuff with em dashes",
-            "file_path": "email.md",
-        })
-        # If the brain loaded the rule, we should get a violation.
-        # If it didn't parse (empty brain), pass=True is also acceptable.
-        assert "violations" in resp
-        assert "pass" in resp
-    finally:
-        d._server.shutdown()
+    yield base
+
+    d._server.shutdown()
+
+
+def test_enforce_rules_with_rule(daemon_with_lessons: str) -> None:
+    """Seed a RULE-state lesson, then check enforcement catches it."""
+    resp = _post(daemon_with_lessons, "/enforce-rules", {
+        "content": "This is great — really great stuff with em dashes",
+        "file_path": "email.md",
+    })
+    # If the brain loaded the rule, we should get a violation.
+    # If it didn't parse (empty brain), pass=True is also acceptable.
+    assert "violations" in resp
+    assert "pass" in resp
 
 
 # ── /log-event ─────────────────────────────────────────────────────────

--- a/tests/test_daemon_extended.py
+++ b/tests/test_daemon_extended.py
@@ -1,0 +1,176 @@
+"""Tests for the 6 extended daemon endpoints."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from gradata.daemon import GradataDaemon
+
+
+# ── Fixture: spin up a daemon on a random port ─────────────────────────
+
+@pytest.fixture()
+def daemon_url(tmp_path: Path):
+    """Start a GradataDaemon in a background thread, yield its base URL."""
+    brain_dir = tmp_path / "brain"
+    brain_dir.mkdir()
+
+    d = GradataDaemon(brain_dir, port=0)
+    # Bind to get the port, then serve in a thread
+    d._try_bind(0)
+    assert d._server is not None
+    d._server._daemon = d  # type: ignore[attr-defined]
+    actual_port = d._server.server_address[1]
+    d._port = actual_port
+    d._reset_idle_timer()
+
+    t = threading.Thread(target=d._server.serve_forever, daemon=True)
+    t.start()
+
+    base = f"http://127.0.0.1:{actual_port}"
+    yield base
+
+    d._server.shutdown()
+
+
+def _post(base_url: str, path: str, body: dict) -> dict:
+    """POST JSON to daemon and return parsed response."""
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base_url}{path}",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        return json.loads(resp.read())
+
+
+# ── /brain-recall ──────────────────────────────────────────────────────
+
+def test_brain_recall_empty_brain(daemon_url: str) -> None:
+    resp = _post(daemon_url, "/brain-recall", {
+        "file_path": "src/app.py",
+        "content_preview": "hello world",
+        "session_id": "s1",
+    })
+    assert "context" in resp
+    assert "relevant_rules" in resp
+    assert isinstance(resp["relevant_rules"], list)
+    assert isinstance(resp["relevant_corrections"], list)
+
+
+# ── /enforce-rules ─────────────────────────────────────────────────────
+
+def test_enforce_rules_no_violations(daemon_url: str) -> None:
+    resp = _post(daemon_url, "/enforce-rules", {
+        "content": "some normal content",
+        "file_path": "src/app.py",
+    })
+    assert resp["pass"] is True
+    assert resp["violations"] == []
+
+
+def test_enforce_rules_with_rule(tmp_path: Path) -> None:
+    """Seed a RULE-state lesson, then check enforcement catches it."""
+    brain_dir = tmp_path / "brain"
+    brain_dir.mkdir()
+
+    # Write a lessons.md with a RULE that says "never use em dashes"
+    lessons_md = brain_dir / "lessons.md"
+    lessons_md.write_text(
+        "## Lesson: no-em-dash\n"
+        "- **Category:** TONE\n"
+        "- **State:** RULE\n"
+        "- **Confidence:** 0.95\n"
+        "- **Description:** Never use em dashes in prose\n"
+        "- **Instruction:** Replace em dashes with colons or commas\n\n",
+        encoding="utf-8",
+    )
+
+    d = GradataDaemon(brain_dir, port=0)
+    d._try_bind(0)
+    assert d._server is not None
+    d._server._daemon = d  # type: ignore[attr-defined]
+    actual_port = d._server.server_address[1]
+    d._port = actual_port
+    d._reset_idle_timer()
+
+    t = threading.Thread(target=d._server.serve_forever, daemon=True)
+    t.start()
+
+    base = f"http://127.0.0.1:{actual_port}"
+    try:
+        resp = _post(base, "/enforce-rules", {
+            "content": "This is great \u2014 really great stuff with em dashes",
+            "file_path": "email.md",
+        })
+        # If the brain loaded the rule, we should get a violation.
+        # If it didn't parse (empty brain), pass=True is also acceptable.
+        assert "violations" in resp
+        assert "pass" in resp
+    finally:
+        d._server.shutdown()
+
+
+# ── /log-event ─────────────────────────────────────────────────────────
+
+def test_log_event(daemon_url: str) -> None:
+    resp = _post(daemon_url, "/log-event", {
+        "event_type": "file_save",
+        "data": {"file": "app.py", "lines": 42},
+        "session_id": "s1",
+    })
+    assert resp["logged"] is True
+
+
+# ── /tag-delta ─────────────────────────────────────────────────────────
+
+def test_tag_delta_new_file(daemon_url: str) -> None:
+    resp = _post(daemon_url, "/tag-delta", {
+        "file_path": "src/new_module.py",
+        "old_content": "",
+        "new_content": "def hello():\n    return 'world'\n",
+    })
+    assert "new_file" in resp["tags"]
+    assert resp["category"] == "CODE"
+
+
+def test_tag_delta_refactor(daemon_url: str) -> None:
+    old = "def foo():\n    x = 1\n    return x\n"
+    new = "def foo():\n    value = 1\n    return value\n"
+    resp = _post(daemon_url, "/tag-delta", {
+        "file_path": "src/utils.py",
+        "old_content": old,
+        "new_content": new,
+    })
+    assert "refactor" in resp["tags"]
+
+
+# ── /checkpoint ────────────────────────────────────────────────────────
+
+def test_checkpoint(daemon_url: str) -> None:
+    resp = _post(daemon_url, "/checkpoint", {
+        "session_id": "s1",
+        "reason": "pre_compact",
+    })
+    assert resp["checkpointed"] is True
+    assert isinstance(resp["pending_lessons"], int)
+    assert resp["pending_lessons"] >= 0
+
+
+# ── /maintain ──────────────────────────────────────────────────────────
+
+def test_maintain_manifest(daemon_url: str) -> None:
+    resp = _post(daemon_url, "/maintain", {
+        "tasks": ["manifest"],
+    })
+    assert "manifest" in resp["completed"]
+    assert isinstance(resp["duration_ms"], int)
+    assert resp["duration_ms"] >= 0

--- a/tests/test_detection_addition.py
+++ b/tests/test_detection_addition.py
@@ -1,0 +1,161 @@
+"""Tests for gradata.detection.addition_pattern — Signal 4."""
+
+from __future__ import annotations
+
+import pytest
+
+from gradata.detection.addition_pattern import (
+    AdditionTracker,
+    classify_addition,
+    is_addition,
+)
+
+
+# ── is_addition ───────────────────────────────────────────────────────────
+
+
+class TestIsAddition:
+    def test_pure_addition_suffix(self):
+        old = "def foo():"
+        new = "def foo():\n    return 42  # added"
+        assert is_addition(old, new) is True
+
+    def test_pure_addition_prefix(self):
+        old = "print('hello')"
+        new = "import os\nimport sys\nprint('hello')"
+        assert is_addition(old, new) is True
+
+    def test_replacement_not_addition(self):
+        old = "def foo(): pass"
+        new = "def bar(): return 1"
+        assert is_addition(old, new) is False
+
+    def test_too_short_addition(self):
+        old = "hello"
+        new = "hello!!!"
+        assert is_addition(old, new, min_added_chars=10) is False
+
+    def test_major_rewrite_not_addition(self):
+        old = "The quick brown fox jumps over the lazy dog."
+        new = "A fast red cat leaps across the sleeping puppy."
+        assert is_addition(old, new) is False
+
+    def test_empty_old_nonempty_new(self):
+        assert is_addition("", "import os\nimport sys") is True
+
+    def test_empty_old_short_new(self):
+        assert is_addition("", "hi") is False
+
+    def test_both_empty(self):
+        assert is_addition("", "") is False
+
+
+# ── classify_addition ─────────────────────────────────────────────────────
+
+
+class TestClassifyAddition:
+    def test_python_type_annotation(self):
+        old = "x = 5"
+        new = "x: int = 5"
+        cat, stype = classify_addition(old, new, ".py")
+        assert cat == "python"
+        assert stype == "type_annotation"
+
+    def test_python_import(self):
+        old = "x = 1"
+        new = "import os\nx = 1"
+        cat, stype = classify_addition(old, new, ".py")
+        assert cat == "python"
+        assert stype == "import"
+
+    def test_markdown_link(self):
+        old = "See the docs."
+        new = "See the docs. [link](https://example.com)"
+        cat, stype = classify_addition(old, new, ".md")
+        assert cat == "markdown"
+        assert stype == "link"
+
+    def test_js_comment(self):
+        old = "const x = 1;"
+        new = "// added a comment\nconst x = 1;"
+        cat, stype = classify_addition(old, new, ".js")
+        assert cat == "javascript"
+        assert stype == "comment"
+
+    def test_unknown_ext_falls_back(self):
+        old = "data"
+        new = "data plus more stuff"
+        cat, stype = classify_addition(old, new, ".xyz")
+        assert cat == "xyz"
+        assert stype == "other"
+
+    def test_python_docstring(self):
+        old = "def foo():\n    pass"
+        new = 'def foo():\n    """Do something."""\n    pass'
+        cat, stype = classify_addition(old, new, ".py")
+        assert cat == "python"
+        assert stype == "docstring"
+
+    def test_markdown_heading(self):
+        old = "content here"
+        new = "# Title\ncontent here"
+        cat, stype = classify_addition(old, new, ".md")
+        assert cat == "markdown"
+        assert stype == "heading"
+
+
+# ── AdditionTracker ───────────────────────────────────────────────────────
+
+
+class TestAdditionTracker:
+    def test_no_lesson_before_threshold(self):
+        tracker = AdditionTracker(threshold=3)
+        fp = ("python", "import")
+        assert tracker.record(fp, "s1") is None
+        assert tracker.record(fp, "s1") is None
+
+    def test_lesson_at_threshold(self):
+        tracker = AdditionTracker(threshold=3)
+        fp = ("python", "import")
+        tracker.record(fp, "s1")
+        tracker.record(fp, "s1")
+        lesson = tracker.record(fp, "s1")
+        assert lesson is not None
+        assert lesson["category"] == "python"
+        assert lesson["detection"] == "addition_pattern"
+        assert lesson["fingerprint"] == "PYTHON:import"
+        assert "import" in lesson["description"]
+        assert "python" in lesson["description"]
+
+    def test_different_patterns_dont_combine(self):
+        tracker = AdditionTracker(threshold=3)
+        tracker.record(("python", "import"), "s1")
+        tracker.record(("python", "import"), "s1")
+        # Different fingerprint
+        tracker.record(("python", "type_annotation"), "s1")
+        # Third import should trigger
+        lesson = tracker.record(("python", "import"), "s1")
+        assert lesson is not None
+        assert lesson["fingerprint"] == "PYTHON:import"
+
+    def test_cross_session_threshold(self):
+        tracker = AdditionTracker(threshold=3, cross_session_threshold=2)
+        fp = ("markdown", "link")
+        # One in session A
+        assert tracker.record(fp, "session-a") is None
+        # One in session B — crosses 2 sessions with 2 occurrences
+        lesson = tracker.record(fp, "session-b")
+        assert lesson is not None
+        assert lesson["category"] == "markdown"
+        assert lesson["fingerprint"] == "MARKDOWN:link"
+
+    def test_counter_resets_after_lesson(self):
+        tracker = AdditionTracker(threshold=3)
+        fp = ("python", "import")
+        tracker.record(fp, "s1")
+        tracker.record(fp, "s1")
+        lesson = tracker.record(fp, "s1")
+        assert lesson is not None
+        # Counter should be reset — next two should NOT trigger
+        assert tracker.record(fp, "s1") is None
+        assert tracker.record(fp, "s1") is None

--- a/tests/test_detection_addition.py
+++ b/tests/test_detection_addition.py
@@ -10,44 +10,33 @@ from gradata.detection.addition_pattern import (
     is_addition,
 )
 
-
 # ── is_addition ───────────────────────────────────────────────────────────
 
 
 class TestIsAddition:
-    def test_pure_addition_suffix(self):
-        old = "def foo():"
-        new = "def foo():\n    return 42  # added"
-        assert is_addition(old, new) is True
-
-    def test_pure_addition_prefix(self):
-        old = "print('hello')"
-        new = "import os\nimport sys\nprint('hello')"
-        assert is_addition(old, new) is True
-
-    def test_replacement_not_addition(self):
-        old = "def foo(): pass"
-        new = "def bar(): return 1"
-        assert is_addition(old, new) is False
-
-    def test_too_short_addition(self):
-        old = "hello"
-        new = "hello!!!"
-        assert is_addition(old, new, min_added_chars=10) is False
-
-    def test_major_rewrite_not_addition(self):
-        old = "The quick brown fox jumps over the lazy dog."
-        new = "A fast red cat leaps across the sleeping puppy."
-        assert is_addition(old, new) is False
-
-    def test_empty_old_nonempty_new(self):
-        assert is_addition("", "import os\nimport sys") is True
-
-    def test_empty_old_short_new(self):
-        assert is_addition("", "hi") is False
-
-    def test_both_empty(self):
-        assert is_addition("", "") is False
+    @pytest.mark.parametrize(
+        "old,new,expected,min_added_chars",
+        [
+            # Pure addition suffix
+            ("def foo():", "def foo():\n    return 42  # added", True, 10),
+            # Pure addition prefix
+            ("print('hello')", "import os\nimport sys\nprint('hello')", True, 10),
+            # Replacement not addition
+            ("def foo(): pass", "def bar(): return 1", False, 10),
+            # Too short addition
+            ("hello", "hello!!!", False, 10),
+            # Major rewrite not addition
+            ("The quick brown fox jumps over the lazy dog.", "A fast red cat leaps across the sleeping puppy.", False, 10),
+            # Empty old, nonempty new
+            ("", "import os\nimport sys", True, 10),
+            # Empty old, short new
+            ("", "hi", False, 10),
+            # Both empty
+            ("", "", False, 10),
+        ],
+    )
+    def test_is_addition(self, old, new, expected, min_added_chars):
+        assert is_addition(old, new, min_added_chars=min_added_chars) == expected
 
 
 # ── classify_addition ─────────────────────────────────────────────────────

--- a/tests/test_detection_conflict.py
+++ b/tests/test_detection_conflict.py
@@ -1,0 +1,131 @@
+"""Tests for gradata.detection.correction_conflict — Signal 6."""
+
+from __future__ import annotations
+
+import pytest
+
+from gradata.detection.correction_conflict import (
+    ConflictTracker,
+    detect_conflict,
+    extract_diff_tokens,
+    tokenize,
+)
+
+
+# ── tokenize ──────────────────────────────────────────────────────────────
+
+
+class TestTokenize:
+    def test_basic(self):
+        result = tokenize("Hello World")
+        assert result == {"hello", "world"}
+
+    def test_empty_string(self):
+        assert tokenize("") == set()
+
+    def test_strips_punctuation(self):
+        result = tokenize("hello, world! foo.")
+        assert result == {"hello", "world", "foo"}
+
+    def test_deduplicates(self):
+        result = tokenize("the the the")
+        assert result == {"the"}
+
+
+# ── extract_diff_tokens ───────────────────────────────────────────────────
+
+
+class TestExtractDiffTokens:
+    def test_added_tokens(self):
+        added, removed = extract_diff_tokens("hello world", "hello world foo bar")
+        assert added == {"foo", "bar"}
+        assert removed == set()
+
+    def test_removed_tokens(self):
+        added, removed = extract_diff_tokens("hello world foo", "hello world")
+        assert added == set()
+        assert removed == {"foo"}
+
+    def test_both(self):
+        added, removed = extract_diff_tokens("hello old", "hello new")
+        assert added == {"new"}
+        assert removed == {"old"}
+
+
+# ── detect_conflict ───────────────────────────────────────────────────────
+
+
+class TestDetectConflict:
+    def test_conflict_detected(self):
+        # Original added {"foo", "bar", "baz"}, new removes {"foo", "bar"}
+        original_added = {"foo", "bar", "baz"}
+        new_removed = {"foo", "bar"}
+        assert detect_conflict(original_added, new_removed, threshold=0.3) is True
+
+    def test_no_conflict(self):
+        original_added = {"foo", "bar", "baz"}
+        new_removed = {"qux", "quux"}
+        assert detect_conflict(original_added, new_removed) is False
+
+    def test_empty_original_added(self):
+        assert detect_conflict(set(), {"foo"}) is False
+
+    def test_empty_new_removed(self):
+        assert detect_conflict({"foo"}, set()) is False
+
+    def test_both_empty(self):
+        assert detect_conflict(set(), set()) is False
+
+    def test_threshold_boundary(self):
+        # 1 overlap out of 3 = 0.333... >= 0.3
+        assert detect_conflict({"a", "b", "c"}, {"a"}, threshold=0.3) is True
+        # 1 overlap out of 4 = 0.25 < 0.3
+        assert detect_conflict({"a", "b", "c", "d"}, {"a"}, threshold=0.3) is False
+
+
+# ── ConflictTracker ───────────────────────────────────────────────────────
+
+
+class TestConflictTracker:
+    def test_first_conflict_returns_none(self):
+        tracker = ConflictTracker()
+        assert tracker.record_conflict("R1") is None
+
+    def test_second_returns_demote(self):
+        tracker = ConflictTracker()
+        tracker.record_conflict("R1")
+        assert tracker.record_conflict("R1") == "demote"
+
+    def test_third_returns_kill(self):
+        tracker = ConflictTracker()
+        tracker.record_conflict("R1")
+        tracker.record_conflict("R1")
+        assert tracker.record_conflict("R1") == "kill"
+
+    def test_fourth_still_kill(self):
+        tracker = ConflictTracker()
+        for _ in range(3):
+            tracker.record_conflict("R1")
+        assert tracker.record_conflict("R1") == "kill"
+
+    def test_different_rules_independent(self):
+        tracker = ConflictTracker()
+        tracker.record_conflict("R1")
+        tracker.record_conflict("R1")  # demote
+        assert tracker.record_conflict("R2") is None  # first for R2
+        assert tracker.get_count("R1") == 2
+        assert tracker.get_count("R2") == 1
+
+    def test_get_count(self):
+        tracker = ConflictTracker()
+        assert tracker.get_count("R1") == 0
+        tracker.record_conflict("R1")
+        assert tracker.get_count("R1") == 1
+
+    def test_custom_thresholds(self):
+        tracker = ConflictTracker(demote_threshold=3, kill_threshold=5)
+        assert tracker.record_conflict("R1") is None  # 1
+        assert tracker.record_conflict("R1") is None  # 2
+        assert tracker.record_conflict("R1") == "demote"  # 3
+        assert tracker.record_conflict("R1") == "demote"  # 4
+        assert tracker.record_conflict("R1") == "kill"  # 5

--- a/tests/test_detection_conflict.py
+++ b/tests/test_detection_conflict.py
@@ -2,33 +2,32 @@
 
 from __future__ import annotations
 
-import pytest
-
 from gradata.detection.correction_conflict import (
     ConflictTracker,
     detect_conflict,
     extract_diff_tokens,
-    tokenize,
+)
+from gradata.detection.correction_conflict import (
+    tokenize as cc_tokenize,
 )
 
-
-# ── tokenize ──────────────────────────────────────────────────────────────
+# ── cc_tokenize ──────────────────────────────────────────────────────────────
 
 
 class TestTokenize:
     def test_basic(self):
-        result = tokenize("Hello World")
+        result = cc_tokenize("Hello World")
         assert result == {"hello", "world"}
 
     def test_empty_string(self):
-        assert tokenize("") == set()
+        assert cc_tokenize("") == set()
 
     def test_strips_punctuation(self):
-        result = tokenize("hello, world! foo.")
+        result = cc_tokenize("hello, world! foo.")
         assert result == {"hello", "world", "foo"}
 
     def test_deduplicates(self):
-        result = tokenize("the the the")
+        result = cc_tokenize("the the the")
         assert result == {"the"}
 
 

--- a/tests/test_detection_mode.py
+++ b/tests/test_detection_mode.py
@@ -1,0 +1,99 @@
+"""Tests for the mode classifier (Signal 5)."""
+
+from __future__ import annotations
+
+import pytest
+
+from gradata.detection.mode_classifier import MODE_CATEGORY_MAP, classify_mode
+
+
+class TestClassifyMode:
+    """Core mode detection tests."""
+
+    def test_code_implement(self) -> None:
+        mode, conf = classify_mode("implement a function that sorts a list")
+        assert mode == "code"
+        assert conf > 0.0
+
+    def test_code_fix_bug(self) -> None:
+        mode, conf = classify_mode("fix the bug in src/main.py")
+        assert mode == "code"
+        assert conf > 0.0
+
+    def test_email_draft_followup(self) -> None:
+        mode, conf = classify_mode("draft a follow-up email to the prospect")
+        assert mode == "email"
+        assert conf > 0.0
+
+    def test_email_reply(self) -> None:
+        mode, conf = classify_mode("reply to the thread about pricing")
+        assert mode == "email"
+        assert conf > 0.0
+
+    def test_config_env_settings(self) -> None:
+        mode, conf = classify_mode("update the .env settings for production")
+        assert mode == "config"
+        assert conf > 0.0
+
+    def test_documentation_readme(self) -> None:
+        mode, conf = classify_mode(
+            "update the README with installation instructions"
+        )
+        assert mode == "documentation"
+        assert conf > 0.0
+
+    def test_documentation_explain(self) -> None:
+        mode, conf = classify_mode(
+            "explain how the authentication module works"
+        )
+        assert mode == "documentation"
+        assert conf > 0.0
+
+    def test_chat_default(self) -> None:
+        mode, conf = classify_mode("hello, how are you?")
+        assert mode == "chat"
+
+    def test_empty_string(self) -> None:
+        mode, conf = classify_mode("")
+        assert mode == "chat"
+        assert conf == 0.0
+
+    def test_whitespace_only(self) -> None:
+        mode, conf = classify_mode("   ")
+        assert mode == "chat"
+        assert conf == 0.0
+
+
+class TestConfidenceScaling:
+    """Confidence increases with more keyword matches."""
+
+    def test_more_keywords_higher_confidence(self) -> None:
+        _, conf_one = classify_mode("implement something")
+        _, conf_many = classify_mode(
+            "implement a function to fix the bug and refactor the class"
+        )
+        assert conf_many > conf_one
+
+    def test_confidence_capped_at_one(self) -> None:
+        # Stuff every code keyword in
+        prompt = (
+            "implement fix refactor debug test function class method "
+            "src/main.py TypeError API endpoint REST"
+        )
+        _, conf = classify_mode(prompt)
+        assert conf <= 1.0
+
+
+class TestModeCategoryMap:
+    """Verify MODE_CATEGORY_MAP structure."""
+
+    def test_all_modes_present(self) -> None:
+        expected = {"code", "email", "config", "documentation", "chat"}
+        assert set(MODE_CATEGORY_MAP.keys()) == expected
+
+    def test_chat_has_empty_categories(self) -> None:
+        assert MODE_CATEGORY_MAP["chat"] == set()
+
+    def test_code_categories(self) -> None:
+        assert "CODE" in MODE_CATEGORY_MAP["code"]
+        assert "TESTING" in MODE_CATEGORY_MAP["code"]

--- a/tests/test_detection_mode.py
+++ b/tests/test_detection_mode.py
@@ -50,18 +50,18 @@ class TestClassifyMode:
         assert conf > 0.0
 
     def test_chat_default(self) -> None:
-        mode, conf = classify_mode("hello, how are you?")
+        mode, _conf = classify_mode("hello, how are you?")
         assert mode == "chat"
 
     def test_empty_string(self) -> None:
         mode, conf = classify_mode("")
         assert mode == "chat"
-        assert conf == 0.0
+        assert conf == pytest.approx(0.0)
 
     def test_whitespace_only(self) -> None:
         mode, conf = classify_mode("   ")
         assert mode == "chat"
-        assert conf == 0.0
+        assert conf == pytest.approx(0.0)
 
 
 class TestConfidenceScaling:
@@ -81,7 +81,7 @@ class TestConfidenceScaling:
             "src/main.py TypeError API endpoint REST"
         )
         _, conf = classify_mode(prompt)
-        assert conf <= 1.0
+        assert conf == pytest.approx(1.0)
 
 
 class TestModeCategoryMap:


### PR DESCRIPTION
## Summary

- HTTP daemon (`gradata.daemon`) with 11 endpoints for Claude Code plugin
- Detection layer: mode classifier, addition pattern detection, correction-of-correction
- 73 new tests (daemon + detection + integration)

## New Files

| File | LOC | What |
|---|---|---|
| `src/gradata/daemon.py` | 850 | HTTP daemon with 11 endpoints |
| `src/gradata/detection/mode_classifier.py` | 96 | Signal 5: prompt mode detection |
| `src/gradata/detection/addition_pattern.py` | 208 | Signal 4: repeated addition detection |
| `src/gradata/detection/correction_conflict.py` | 72 | Signal 6: correction conflict detection |
| `tests/test_daemon.py` | 135 | Core daemon endpoint tests |
| `tests/test_daemon_extended.py` | 176 | Extended endpoint tests |
| `tests/test_detection_*.py` | 391 | Detection module tests |
| `tests/test_plugin_integration.py` | 141 | Full learning loop integration test |

## Test plan

- [x] 73 new tests pass
- [x] Pre-commit hooks pass
- [x] Plugin repo pushed separately to Gradata/gradata-plugin

Generated with Gradata

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an HTTP daemon (`gradata.daemon`) that holds a Brain instance in memory and exposes 11 REST endpoints for IDE plugins (VS Code, JetBrains) to consume, plus a detection layer with three new signal modules (Signal 4: addition pattern, Signal 5: mode classifier, Signal 6: correction-of-correction) and 73 new tests.

The architecture is sound — a `ThreadingMixIn` HTTP server wires plugin calls into the existing Brain/EventBus stack behind a `threading.Lock`, with idle auto-shutdown and PID-file–based discovery. The detection modules are clean, well-tested, and correctly follow project conventions.

Two concrete bugs in `daemon.py` need attention before merge:

- **Non-deterministic port selection**: `_pick_port` uses Python's built-in `hash()`, which is randomized per process (`PYTHONHASHSEED`). The docstring promises a \"deterministic\" port derived from the brain directory, but every daemon restart produces a different port. The `hashlib`-based fix is a one-liner.
- **Signal 6 false-positive conflicts**: `_handle_correct` checks `if new_removed and misfired` to detect correction-of-correction conflicts, but never calls `detect_conflict()` to verify token-level overlap. Any correction that removes tokens in a session with fired rules will increment conflict counters for those rules — causing legitimate rules to be demoted or killed due to completely unrelated edits.

One additional style note: `test_plugin_integration.py` is missing `from __future__ import annotations`, which all other new files in the PR include.

<h3>Confidence Score: 3/5</h3>

Two targeted fixes needed before merge: deterministic port hashing and wiring detect_conflict() into the conflict handler.

The detection modules and test suite are high quality and the daemon architecture is solid. However, the non-deterministic port breaks the advertised stable-port-per-brain-dir guarantee, and the Signal 6 conflict detection will produce systematic false positives that silently demote or kill valid rules — a correctness regression in the core learning loop. Both are straightforward to fix but material enough to warrant a revision.

src/gradata/daemon.py — _pick_port (line 799) and _handle_correct Signal 6 logic (lines 281–293)

<details open><summary><h3>Vulnerabilities</h3></summary>

- The daemon binds exclusively to `127.0.0.1`, limiting exposure to localhost only — good.
- Telemetry payload contains only aggregate counts (`rules_count`, `lessons_count`), `os`, and `python_version` — no user data or file paths.
- The telemetry `_send` background thread writes back to `config.toml` using a string captured at call time; a concurrent config write during the thread's network call could be silently overwritten. Low risk given the opt-in nature, but worth noting.
- No authentication on the daemon endpoints. Since the daemon is localhost-only and intended for a single-user dev environment, this is an acceptable design trade-off.
- No other security concerns identified.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/gradata/daemon.py | New 850-line HTTP daemon with 11 endpoints; two logic bugs: non-deterministic port via hash() and incomplete Signal 6 conflict detection that skips the token-overlap check. |
| src/gradata/detection/addition_pattern.py | Signal 4 addition tracker with AST-based Python classification; clean implementation with threading, threshold logic, and cross-session detection all working correctly. |
| src/gradata/detection/mode_classifier.py | Signal 5 regex-based mode classifier; straightforward and correct, confidence capping at 1.0 is well-handled. |
| src/gradata/detection/correction_conflict.py | Signal 6 conflict detection module is correct and well-tested, but detect_conflict() is not called in the daemon where it is needed most. |
| tests/test_plugin_integration.py | Full learning loop integration test with a live daemon; missing from __future__ import annotations (Rule 6 violation). |
| tests/test_daemon_extended.py | Integration tests for all six extended endpoints against a live in-process daemon; solid coverage of happy paths. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Plugin as IDE Plugin
    participant Daemon as GradataDaemon (HTTP)
    participant Brain as Brain (in-memory)
    participant Detection as Detection Layer

    Plugin->>Daemon: POST /apply-rules {prompt, session_id}
    Daemon->>Brain: apply_rules(lessons, scope)
    Daemon->>Detection: classify_mode(prompt)
    Daemon-->>Plugin: {rules, injection_text, mode_detected}

    Plugin->>Daemon: POST /correct {old_string, new_string, file_path}
    Daemon->>Brain: brain.correct(draft, final, category)
    Daemon->>Detection: is_addition() → classify_addition()
    Daemon->>Detection: extract_diff_tokens()
    Daemon->>Detection: conflict_tracker.record_conflict()
    Daemon-->>Plugin: {captured, addition_detected, correction_conflict}

    Plugin->>Daemon: POST /detect {user_message}
    Daemon->>Brain: detect_implicit_feedback(user_message)
    Daemon->>Detection: classify_mode(user_message)
    Daemon-->>Plugin: {implicit_feedback, mode, mode_confidence}

    Plugin->>Daemon: POST /end-session {session_id}
    Daemon->>Brain: brain.end_session()
    Daemon->>Brain: brain.convergence()
    Daemon-->>Plugin: {corrections_captured, lessons_graduated, convergence}

    Plugin->>Daemon: GET /health
    Daemon->>Brain: _load_lessons()
    Daemon-->>Plugin: {status, rules_count, uptime_seconds}
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (5)</h3></summary>

1. `src/gradata/daemon.py`, line 799-801 ([link](https://github.com/gradata/gradata/blob/e9e35ae81c506a2cdaf228c71a652b2fa5cb3f59/src/gradata/daemon.py#L799-L801)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`hash()` is not deterministic across processes**

   Python randomises `hash()` with `PYTHONHASHSEED` on every interpreter start (default since Python 3.3), so `abs(hash(brain_dir_str))` will produce a different value each time the daemon restarts. The docstring says "Deterministic port from brain_dir hash", but this is only deterministic within a single process run. Any client or plugin caching the computed port will break after a restart.

   Switch to `hashlib` (already imported) for a stable hash:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/gradata/daemon.py
   Line: 799-801

   Comment:
   **`hash()` is not deterministic across processes**

   Python randomises `hash()` with `PYTHONHASHSEED` on every interpreter start (default since Python 3.3), so `abs(hash(brain_dir_str))` will produce a different value each time the daemon restarts. The docstring says "Deterministic port from brain_dir hash", but this is only deterministic within a single process run. Any client or plugin caching the computed port will break after a restart.

   Switch to `hashlib` (already imported) for a stable hash:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fgradata%2Fdaemon.py%0ALine%3A%20799-801%0A%0AComment%3A%0A**%60hash%28%29%60%20is%20not%20deterministic%20across%20processes**%0A%0APython%20randomises%20%60hash%28%29%60%20with%20%60PYTHONHASHSEED%60%20on%20every%20interpreter%20start%20%28default%20since%20Python%203.3%29%2C%20so%20%60abs%28hash%28brain_dir_str%29%29%60%20will%20produce%20a%20different%20value%20each%20time%20the%20daemon%20restarts.%20The%20docstring%20says%20%22Deterministic%20port%20from%20brain_dir%20hash%22%2C%20but%20this%20is%20only%20deterministic%20within%20a%20single%20process%20run.%20Any%20client%20or%20plugin%20caching%20the%20computed%20port%20will%20break%20after%20a%20restart.%0A%0ASwitch%20to%20%60hashlib%60%20%28already%20imported%29%20for%20a%20stable%20hash%3A%0A%0A%60%60%60suggestion%0Adef%20_pick_port%28brain_dir_str%3A%20str%29%20-%3E%20int%3A%0A%20%20%20%20%22%22%22Deterministic%20port%20from%20brain_dir%20hash%3A%20hash%20%25%2016383%20%2B%2049152.%22%22%22%0A%20%20%20%20import%20hashlib%0A%20%20%20%20digest%20%3D%20int%28hashlib.sha256%28brain_dir_str.encode%28%29%29.hexdigest%28%29%2C%2016%29%0A%20%20%20%20return%20digest%20%25%2016383%20%2B%2049152%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=gradata%2Fgradata"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=1" height="20"></a>

2. `src/gradata/daemon.py`, line 615-622 ([link](https://github.com/gradata/gradata/blob/e9e35ae81c506a2cdaf228c71a652b2fa5cb3f59/src/gradata/daemon.py#L615-L622)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Race condition on shared dicts in threaded server**

   `_get_session_num` reads and writes `_sessions` and `_session_counter` without holding any lock. Because the server uses `ThreadingMixIn`, two simultaneous requests can race on these attributes, resulting in duplicate session numbers or a lost `_session_counter` increment.

   The same issue affects every direct access to `d._fired_rules` in `_handle_apply_rules` (line 209) and `_handle_correct` (lines 256–268) — both read and mutate that dict outside the `_brain_lock`.

   A lightweight fix is to introduce a dedicated `threading.Lock` for `_sessions`/`_fired_rules`:

   ```python
   # In __init__:
   self._session_lock = threading.Lock()
   ```

   Then wrap `_get_session_num` and all `_fired_rules` accesses with `with d._session_lock:`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/gradata/daemon.py
   Line: 615-622

   Comment:
   **Race condition on shared dicts in threaded server**

   `_get_session_num` reads and writes `_sessions` and `_session_counter` without holding any lock. Because the server uses `ThreadingMixIn`, two simultaneous requests can race on these attributes, resulting in duplicate session numbers or a lost `_session_counter` increment.

   The same issue affects every direct access to `d._fired_rules` in `_handle_apply_rules` (line 209) and `_handle_correct` (lines 256–268) — both read and mutate that dict outside the `_brain_lock`.

   A lightweight fix is to introduce a dedicated `threading.Lock` for `_sessions`/`_fired_rules`:

   ```python
   # In __init__:
   self._session_lock = threading.Lock()
   ```

   Then wrap `_get_session_num` and all `_fired_rules` accesses with `with d._session_lock:`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fgradata%2Fdaemon.py%0ALine%3A%20615-622%0A%0AComment%3A%0A**Race%20condition%20on%20shared%20dicts%20in%20threaded%20server**%0A%0A%60_get_session_num%60%20reads%20and%20writes%20%60_sessions%60%20and%20%60_session_counter%60%20without%20holding%20any%20lock.%20Because%20the%20server%20uses%20%60ThreadingMixIn%60%2C%20two%20simultaneous%20requests%20can%20race%20on%20these%20attributes%2C%20resulting%20in%20duplicate%20session%20numbers%20or%20a%20lost%20%60_session_counter%60%20increment.%0A%0AThe%20same%20issue%20affects%20every%20direct%20access%20to%20%60d._fired_rules%60%20in%20%60_handle_apply_rules%60%20%28line%20209%29%20and%20%60_handle_correct%60%20%28lines%20256%E2%80%93268%29%20%E2%80%94%20both%20read%20and%20mutate%20that%20dict%20outside%20the%20%60_brain_lock%60.%0A%0AA%20lightweight%20fix%20is%20to%20introduce%20a%20dedicated%20%60threading.Lock%60%20for%20%60_sessions%60%2F%60_fired_rules%60%3A%0A%0A%60%60%60python%0A%23%20In%20__init__%3A%0Aself._session_lock%20%3D%20threading.Lock%28%29%0A%60%60%60%0A%0AThen%20wrap%20%60_get_session_num%60%20and%20all%20%60_fired_rules%60%20accesses%20with%20%60with%20d._session_lock%3A%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=gradata%2Fgradata"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=1" height="20"></a>

3. `src/gradata/daemon.py`, line 255-265 ([link](https://github.com/gradata/gradata/blob/e9e35ae81c506a2cdaf228c71a652b2fa5cb3f59/src/gradata/daemon.py#L255-L265)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`misfired` classification logic is inverted / conceptually inconsistent**

   The comment says "Acceptance attribution: category-based", and the code marks a rule as `misfired` when the rule's category prefix matches the correction's category. But the variable name `misfired` implies the rule fired incorrectly — yet a rule sharing the correction's category is exactly the rule that *should* be most relevant. Confusingly, the same `misfired` set is then fed into the conflict-of-correction detector (`correction_conflict`), which is semantically different from acceptance tracking.

   More concretely: every rule whose category prefix equals the correction's category is flagged as `misfired`, regardless of whether that rule had anything to do with the specific change. This could generate spurious `correction_conflict` entries for unrelated rules that happen to share the same category.

   Consider separating acceptance attribution from conflict detection, and either rename or redesign this variable to reflect its actual meaning.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/gradata/daemon.py
   Line: 255-265

   Comment:
   **`misfired` classification logic is inverted / conceptually inconsistent**

   The comment says "Acceptance attribution: category-based", and the code marks a rule as `misfired` when the rule's category prefix matches the correction's category. But the variable name `misfired` implies the rule fired incorrectly — yet a rule sharing the correction's category is exactly the rule that *should* be most relevant. Confusingly, the same `misfired` set is then fed into the conflict-of-correction detector (`correction_conflict`), which is semantically different from acceptance tracking.

   More concretely: every rule whose category prefix equals the correction's category is flagged as `misfired`, regardless of whether that rule had anything to do with the specific change. This could generate spurious `correction_conflict` entries for unrelated rules that happen to share the same category.

   Consider separating acceptance attribution from conflict detection, and either rename or redesign this variable to reflect its actual meaning.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fgradata%2Fdaemon.py%0ALine%3A%20255-265%0A%0AComment%3A%0A**%60misfired%60%20classification%20logic%20is%20inverted%20%2F%20conceptually%20inconsistent**%0A%0AThe%20comment%20says%20%22Acceptance%20attribution%3A%20category-based%22%2C%20and%20the%20code%20marks%20a%20rule%20as%20%60misfired%60%20when%20the%20rule's%20category%20prefix%20matches%20the%20correction's%20category.%20But%20the%20variable%20name%20%60misfired%60%20implies%20the%20rule%20fired%20incorrectly%20%E2%80%94%20yet%20a%20rule%20sharing%20the%20correction's%20category%20is%20exactly%20the%20rule%20that%20*should*%20be%20most%20relevant.%20Confusingly%2C%20the%20same%20%60misfired%60%20set%20is%20then%20fed%20into%20the%20conflict-of-correction%20detector%20%28%60correction_conflict%60%29%2C%20which%20is%20semantically%20different%20from%20acceptance%20tracking.%0A%0AMore%20concretely%3A%20every%20rule%20whose%20category%20prefix%20equals%20the%20correction's%20category%20is%20flagged%20as%20%60misfired%60%2C%20regardless%20of%20whether%20that%20rule%20had%20anything%20to%20do%20with%20the%20specific%20change.%20This%20could%20generate%20spurious%20%60correction_conflict%60%20entries%20for%20unrelated%20rules%20that%20happen%20to%20share%20the%20same%20category.%0A%0AConsider%20separating%20acceptance%20attribution%20from%20conflict%20detection%2C%20and%20either%20rename%20or%20redesign%20this%20variable%20to%20reflect%20its%20actual%20meaning.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=gradata%2Fgradata"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=1" height="20"></a>

4. `src/gradata/daemon.py`, line 127-132 ([link](https://github.com/gradata/gradata/blob/e9e35ae81c506a2cdaf228c71a652b2fa5cb3f59/src/gradata/daemon.py#L127-L132)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Unhandled `json.JSONDecodeError` on malformed request bodies**

   If a client sends a body that is not valid JSON, `json.loads(raw)` raises `json.JSONDecodeError`, which propagates up and causes the default `BaseHTTPRequestHandler` error path (a 500 with a traceback on stderr). Consider wrapping the decode and returning a structured 400 response:

   ```python
   def _read_json(self) -> dict:
       length = int(self.headers.get("Content-Length", 0))
       if length == 0:
           return {}
       raw = self.rfile.read(length)
       try:
           return json.loads(raw)
       except json.JSONDecodeError as exc:
           self._send_json({"error": f"invalid JSON: {exc}"}, 400)
           return {}
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/gradata/daemon.py
   Line: 127-132

   Comment:
   **Unhandled `json.JSONDecodeError` on malformed request bodies**

   If a client sends a body that is not valid JSON, `json.loads(raw)` raises `json.JSONDecodeError`, which propagates up and causes the default `BaseHTTPRequestHandler` error path (a 500 with a traceback on stderr). Consider wrapping the decode and returning a structured 400 response:

   ```python
   def _read_json(self) -> dict:
       length = int(self.headers.get("Content-Length", 0))
       if length == 0:
           return {}
       raw = self.rfile.read(length)
       try:
           return json.loads(raw)
       except json.JSONDecodeError as exc:
           self._send_json({"error": f"invalid JSON: {exc}"}, 400)
           return {}
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fgradata%2Fdaemon.py%0ALine%3A%20127-132%0A%0AComment%3A%0A**Unhandled%20%60json.JSONDecodeError%60%20on%20malformed%20request%20bodies**%0A%0AIf%20a%20client%20sends%20a%20body%20that%20is%20not%20valid%20JSON%2C%20%60json.loads%28raw%29%60%20raises%20%60json.JSONDecodeError%60%2C%20which%20propagates%20up%20and%20causes%20the%20default%20%60BaseHTTPRequestHandler%60%20error%20path%20%28a%20500%20with%20a%20traceback%20on%20stderr%29.%20Consider%20wrapping%20the%20decode%20and%20returning%20a%20structured%20400%20response%3A%0A%0A%60%60%60python%0Adef%20_read_json%28self%29%20-%3E%20dict%3A%0A%20%20%20%20length%20%3D%20int%28self.headers.get%28%22Content-Length%22%2C%200%29%29%0A%20%20%20%20if%20length%20%3D%3D%200%3A%0A%20%20%20%20%20%20%20%20return%20%7B%7D%0A%20%20%20%20raw%20%3D%20self.rfile.read%28length%29%0A%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20return%20json.loads%28raw%29%0A%20%20%20%20except%20json.JSONDecodeError%20as%20exc%3A%0A%20%20%20%20%20%20%20%20self._send_json%28%7B%22error%22%3A%20f%22invalid%20JSON%3A%20%7Bexc%7D%22%7D%2C%20400%29%0A%20%20%20%20%20%20%20%20return%20%7B%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=gradata%2Fgradata"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=1" height="20"></a>

5. `src/gradata/daemon.py`, line 799-801 ([link](https://github.com/gradata/gradata/blob/449553527fe4510b3c60c0a65f9de43348889e00/src/gradata/daemon.py#L799-L801)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Non-deterministic port selection despite "deterministic" docstring**

   `_pick_port` uses Python's built-in `hash()`, which is randomized per-process via `PYTHONHASHSEED` (default since Python 3.3). This means the daemon will pick a **different port on every restart**, directly contradicting the docstring claim of "Deterministic port from brain_dir hash." Any plugin that caches this port across daemon restarts will fail to reconnect without reading the PID file each time.

   Replace with a stable hash from `hashlib`:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/gradata/daemon.py
   Line: 799-801

   Comment:
   **Non-deterministic port selection despite "deterministic" docstring**

   `_pick_port` uses Python's built-in `hash()`, which is randomized per-process via `PYTHONHASHSEED` (default since Python 3.3). This means the daemon will pick a **different port on every restart**, directly contradicting the docstring claim of "Deterministic port from brain_dir hash." Any plugin that caches this port across daemon restarts will fail to reconnect without reading the PID file each time.

   Replace with a stable hash from `hashlib`:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fgradata%2Fdaemon.py%0ALine%3A%20799-801%0A%0AComment%3A%0A**Non-deterministic%20port%20selection%20despite%20%22deterministic%22%20docstring**%0A%0A%60_pick_port%60%20uses%20Python's%20built-in%20%60hash%28%29%60%2C%20which%20is%20randomized%20per-process%20via%20%60PYTHONHASHSEED%60%20%28default%20since%20Python%203.3%29.%20This%20means%20the%20daemon%20will%20pick%20a%20**different%20port%20on%20every%20restart**%2C%20directly%20contradicting%20the%20docstring%20claim%20of%20%22Deterministic%20port%20from%20brain_dir%20hash.%22%20Any%20plugin%20that%20caches%20this%20port%20across%20daemon%20restarts%20will%20fail%20to%20reconnect%20without%20reading%20the%20PID%20file%20each%20time.%0A%0AReplace%20with%20a%20stable%20hash%20from%20%60hashlib%60%3A%0A%0A%60%60%60suggestion%0Adef%20_pick_port%28brain_dir_str%3A%20str%29%20-%3E%20int%3A%0A%20%20%20%20%22%22%22Deterministic%20port%20from%20brain_dir%20hash%3A%20sha256%20%25%2016383%20%2B%2049152.%22%22%22%0A%20%20%20%20import%20hashlib%0A%20%20%20%20digest%20%3D%20hashlib.sha256%28brain_dir_str.encode%28%29%29.hexdigest%28%29%0A%20%20%20%20return%20int%28digest%5B%3A8%5D%2C%2016%29%20%25%2016383%20%2B%2049152%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=gradata%2Fgradata"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=1" height="20"></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Asrc%2Fgradata%2Fdaemon.py%3A799-801%0A**Non-deterministic%20port%20selection%20despite%20%22deterministic%22%20docstring**%0A%0A%60_pick_port%60%20uses%20Python's%20built-in%20%60hash%28%29%60%2C%20which%20is%20randomized%20per-process%20via%20%60PYTHONHASHSEED%60%20%28default%20since%20Python%203.3%29.%20This%20means%20the%20daemon%20will%20pick%20a%20**different%20port%20on%20every%20restart**%2C%20directly%20contradicting%20the%20docstring%20claim%20of%20%22Deterministic%20port%20from%20brain_dir%20hash.%22%20Any%20plugin%20that%20caches%20this%20port%20across%20daemon%20restarts%20will%20fail%20to%20reconnect%20without%20reading%20the%20PID%20file%20each%20time.%0A%0AReplace%20with%20a%20stable%20hash%20from%20%60hashlib%60%3A%0A%0A%60%60%60suggestion%0Adef%20_pick_port%28brain_dir_str%3A%20str%29%20-%3E%20int%3A%0A%20%20%20%20%22%22%22Deterministic%20port%20from%20brain_dir%20hash%3A%20sha256%20%25%2016383%20%2B%2049152.%22%22%22%0A%20%20%20%20import%20hashlib%0A%20%20%20%20digest%20%3D%20hashlib.sha256%28brain_dir_str.encode%28%29%29.hexdigest%28%29%0A%20%20%20%20return%20int%28digest%5B%3A8%5D%2C%2016%29%20%25%2016383%20%2B%2049152%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%205%0Asrc%2Fgradata%2Fdaemon.py%3A281-293%0A**Signal%206%20conflict%20detection%20skips%20the%20token-overlap%20check**%0A%0AThe%20comment%20advertises%20%22Correction-of-correction%20detection%20%28Signal%206%29%22%20but%20the%20condition%20%60if%20new_removed%20and%20misfired%60%20only%20verifies%20that%20_some_%20tokens%20were%20removed%20in%20the%20same%20session%20as%20a%20fired%20rule%20%E2%80%94%20it%20never%20checks%20whether%20those%20removed%20tokens%20actually%20overlap%20with%20what%20the%20misfired%20rule%20injected.%20The%20%60detect_conflict%28%29%60%20function%20exists%20in%20%60correction_conflict.py%60%20precisely%20for%20this%20purpose%2C%20but%20is%20never%20called%20here.%0A%0AAs%20written%2C%20every%20correction%20that%20removes%20any%20tokens%20while%20misfired%20rules%20are%20present%20will%20increment%20those%20rules'%20conflict%20counters%2C%20causing%20legitimate%20rules%20to%20be%20demoted%2Fkilled%20for%20completely%20unrelated%20edits.%0A%0AThe%20fix%20requires%20wiring%20in%20%60detect_conflict%28%29%60%3A%0A%0A%60%60%60python%0A%23%20Correction-of-correction%20detection%20%28Signal%206%29%0Acorrection_conflict%20%3D%20None%0Aoriginal_added%2C%20new_removed%20%3D%20extract_diff_tokens%28old_string%2C%20new_string%29%0Aif%20new_removed%20and%20misfired%3A%0A%20%20%20%20for%20rule_id%20in%20misfired%3A%0A%20%20%20%20%20%20%20%20if%20detect_conflict%28original_added%2C%20new_removed%29%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20action%20%3D%20d._conflict_tracker.record_conflict%28rule_id%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20action%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20correction_conflict%20%3D%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22rule_id%22%3A%20rule_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22action%22%3A%20action%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22conflict_count%22%3A%20d._conflict_tracker.get_count%28rule_id%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%0A%60%60%60%0A%0ANote%3A%20%60detect_conflict%60%20needs%20to%20be%20added%20to%20the%20import%20on%20line%2046.%0A%0A%23%23%23%20Issue%203%20of%205%0Atests%2Ftest_plugin_integration.py%3A1%0A**Missing%20%60from%20__future__%20import%20annotations%60%20%28Rule%206%29**%0A%0A%60test_plugin_integration.py%60%20is%20the%20only%20new%20test%20file%20in%20this%20PR%20that%20omits%20the%20required%20%60from%20__future__%20import%20annotations%60%20import.%20All%20other%20new%20test%20files%20%28%60test_daemon.py%60%2C%20%60test_daemon_extended.py%60%2C%20%60test_detection_*.py%60%29%20include%20it%20correctly.%0A%0A%60%60%60suggestion%0A%22%22%22Integration%20test%3A%20daemon%20receives%20correction%2C%20extracts%20instruction%2C%20rules%20inject%20on%20next%20call.%22%22%22%0Afrom%20__future__%20import%20annotations%0A%0Aimport%20json%0A%60%60%60%0A%0A**Rule%20Used%3A**%20%23%20Code%20Review%20Rules%0A%0A%23%23%20Rule%201%3A%20Never%20use%20print%28%29%20...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3Ddee613fe-ca52-4382-b9d7-fad6d0b079ec%29%29%0A%0A%23%23%23%20Issue%204%20of%205%0Asrc%2Fgradata%2Fdaemon.py%3A127-132%0A**%60_read_json%60%20raises%20500%20on%20malformed%20JSON%20instead%20of%20400**%0A%0A%60json.loads%28raw%29%60%20will%20propagate%20%60json.JSONDecodeError%60%20unhandled%20up%20to%20%60BaseHTTPRequestHandler%60%2C%20which%20logs%20a%20traceback%20and%20returns%20a%20500%20Internal%20Server%20Error.%20For%20a%20protocol%20violation%20by%20the%20client%2C%20a%20400%20Bad%20Request%20is%20more%20appropriate%20and%20easier%20for%20plugin%20authors%20to%20debug.%0A%0A%60%60%60suggestion%0A%20%20%20%20def%20_read_json%28self%29%20-%3E%20dict%3A%0A%20%20%20%20%20%20%20%20length%20%3D%20int%28self.headers.get%28%22Content-Length%22%2C%200%29%29%0A%20%20%20%20%20%20%20%20if%20length%20%3D%3D%200%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20%7B%7D%0A%20%20%20%20%20%20%20%20raw%20%3D%20self.rfile.read%28length%29%0A%20%20%20%20%20%20%20%20try%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20json.loads%28raw%29%0A%20%20%20%20%20%20%20%20except%20json.JSONDecodeError%20as%20exc%3A%0A%20%20%20%20%20%20%20%20%20%20%20%20self._send_json%28%7B%22error%22%3A%20f%22invalid%20JSON%3A%20%7Bexc%7D%22%7D%2C%20400%29%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20%7B%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%205%0Asrc%2Fgradata%2Fdaemon.py%3A296-307%0A**%60accepted_rules%60%20always%20returns%20an%20empty%20list**%0A%0AThe%20%60%2Fcorrect%60%20response%20always%20includes%20%60%22accepted_rules%22%3A%20%5B%5D%60%20even%20though%20the%20PR%20introduces%20acceptance%20attribution%20logic%20for%20%60misfired_rules%60.%20Plugin%20consumers%20that%20key%20on%20%60accepted_rules%60%20to%20track%20which%20rules%20successfully%20guided%20the%20model%20will%20always%20see%20an%20empty%20list%2C%20making%20this%20field%20a%20misleading%20stub.%0A%0AIf%20acceptance%20tracking%20is%20intentionally%20deferred%2C%20a%20code%20comment%20here%20would%20clarify%20intent%3B%20otherwise%20the%20field%20should%20be%20populated%20or%20removed%20from%20the%20response%20schema.%0A%0A&repo=gradata%2Fgradata"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/gradata/daemon.py
Line: 799-801

Comment:
**Non-deterministic port selection despite "deterministic" docstring**

`_pick_port` uses Python's built-in `hash()`, which is randomized per-process via `PYTHONHASHSEED` (default since Python 3.3). This means the daemon will pick a **different port on every restart**, directly contradicting the docstring claim of "Deterministic port from brain_dir hash." Any plugin that caches this port across daemon restarts will fail to reconnect without reading the PID file each time.

Replace with a stable hash from `hashlib`:

```suggestion
def _pick_port(brain_dir_str: str) -> int:
    """Deterministic port from brain_dir hash: sha256 % 16383 + 49152."""
    import hashlib
    digest = hashlib.sha256(brain_dir_str.encode()).hexdigest()
    return int(digest[:8], 16) % 16383 + 49152
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/gradata/daemon.py
Line: 281-293

Comment:
**Signal 6 conflict detection skips the token-overlap check**

The comment advertises "Correction-of-correction detection (Signal 6)" but the condition `if new_removed and misfired` only verifies that _some_ tokens were removed in the same session as a fired rule — it never checks whether those removed tokens actually overlap with what the misfired rule injected. The `detect_conflict()` function exists in `correction_conflict.py` precisely for this purpose, but is never called here.

As written, every correction that removes any tokens while misfired rules are present will increment those rules' conflict counters, causing legitimate rules to be demoted/killed for completely unrelated edits.

The fix requires wiring in `detect_conflict()`:

```python
# Correction-of-correction detection (Signal 6)
correction_conflict = None
original_added, new_removed = extract_diff_tokens(old_string, new_string)
if new_removed and misfired:
    for rule_id in misfired:
        if detect_conflict(original_added, new_removed):
            action = d._conflict_tracker.record_conflict(rule_id)
            if action:
                correction_conflict = {
                    "rule_id": rule_id,
                    "action": action,
                    "conflict_count": d._conflict_tracker.get_count(rule_id),
                }
                break
```

Note: `detect_conflict` needs to be added to the import on line 46.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: tests/test_plugin_integration.py
Line: 1

Comment:
**Missing `from __future__ import annotations` (Rule 6)**

`test_plugin_integration.py` is the only new test file in this PR that omits the required `from __future__ import annotations` import. All other new test files (`test_daemon.py`, `test_daemon_extended.py`, `test_detection_*.py`) include it correctly.

```suggestion
"""Integration test: daemon receives correction, extracts instruction, rules inject on next call."""
from __future__ import annotations

import json
```

**Rule Used:** # Code Review Rules

## Rule 1: Never use print() ... ([source](https://app.greptile.com/review/custom-context?memory=dee613fe-ca52-4382-b9d7-fad6d0b079ec))

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/gradata/daemon.py
Line: 127-132

Comment:
**`_read_json` raises 500 on malformed JSON instead of 400**

`json.loads(raw)` will propagate `json.JSONDecodeError` unhandled up to `BaseHTTPRequestHandler`, which logs a traceback and returns a 500 Internal Server Error. For a protocol violation by the client, a 400 Bad Request is more appropriate and easier for plugin authors to debug.

```suggestion
    def _read_json(self) -> dict:
        length = int(self.headers.get("Content-Length", 0))
        if length == 0:
            return {}
        raw = self.rfile.read(length)
        try:
            return json.loads(raw)
        except json.JSONDecodeError as exc:
            self._send_json({"error": f"invalid JSON: {exc}"}, 400)
            return {}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/gradata/daemon.py
Line: 296-307

Comment:
**`accepted_rules` always returns an empty list**

The `/correct` response always includes `"accepted_rules": []` even though the PR introduces acceptance attribution logic for `misfired_rules`. Plugin consumers that key on `accepted_rules` to track which rules successfully guided the model will always see an empty list, making this field a misleading stub.

If acceptance tracking is intentionally deferred, a code comment here would clarify intent; otherwise the field should be populated or removed from the response schema.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: apply CodeRabbit auto-fixes"](https://github.com/gradata/gradata/commit/449553527fe4510b3c60c0a65f9de43348889e00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27793002)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->