### PR TITLE
feat: emails + legal pages + auto-deploy CI

### DIFF
--- a/.github/workflows/dashboard-source-maps.yml
+++ b/.github/workflows/dashboard-source-maps.yml
@@ -1,0 +1,63 @@
+name: Dashboard Build + Deploy
+
+# Builds the dashboard with Sentry source-map upload, then deploys to Cloudflare
+# Pages via wrangler. This replaces Cloudflare's native git-builder, which can't
+# handle the cloud/dashboard subpath build.
+#
+# Triggers only on main-branch pushes that touch the dashboard, so other PRs
+# don't burn minutes. Add "[skip ci]" to a commit message to skip.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "cloud/dashboard/**"
+      - ".github/workflows/dashboard-source-maps.yml"
+  workflow_dispatch:
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    defaults:
+      run:
+        working-directory: cloud/dashboard
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: cloud/dashboard/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build with Sentry source-map upload
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          # NEXT_PUBLIC_* must be present at build time — Next.js inlines them.
+          # CF Pages env vars don't reach this runner; secrets do.
+          NEXT_PUBLIC_SENTRY_RELEASE: gradata-dashboard@${{ github.sha }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_API_URL: ${{ secrets.NEXT_PUBLIC_API_URL }}
+          NEXT_PUBLIC_SENTRY_DSN: ${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+        run: pnpm build
+
+      - name: Deploy to Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler@latest pages deploy out --project-name=gradata-dashboard --branch=main --commit-dirty=true

--- a/.github/workflows/loadtest-nightly.yml
+++ b/.github/workflows/loadtest-nightly.yml
@@ -1,0 +1,87 @@
+name: loadtest-nightly
+
+# Nightly SLO canary against production. Runs baseline + spike only —
+# authed-read and sync-write require coordinated test workspaces and
+# would be too noisy to run unattended.
+
+on:
+  schedule:
+    # 03:00 UTC = quiet window for the US/EU timezones
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Base URL to test against'
+        required: false
+        default: 'https://gradata-production.up.railway.app'
+
+concurrency:
+  group: loadtest-nightly
+  cancel-in-progress: false
+
+jobs:
+  baseline:
+    name: baseline (smoke)
+    runs-on: ubuntu-latest
+    # Skip if the triggering commit message contains [skip ci]
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run baseline.js
+        uses: grafana/k6-action@v0.3.1
+        with:
+          filename: cloud/loadtest/k6/baseline.js
+        env:
+          BASE_URL: ${{ github.event.inputs.base_url || 'https://gradata-production.up.railway.app' }}
+
+      - name: Comment on commit if thresholds breached
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.sha;
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.repos.createCommitComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: sha,
+              body: `:rotating_light: **Nightly loadtest: baseline SLO breach**\n\n` +
+                    `p95 > 500ms or error_rate > 1% on \`/health\`.\n\n` +
+                    `See run: ${runUrl}\n\n` +
+                    `Rollback playbook: \`cloud/loadtest/README.md\``,
+            });
+
+  spike:
+    name: spike (rate limit check)
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    # Run spike regardless of baseline outcome — they test different things.
+    needs: []
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run spike.js
+        uses: grafana/k6-action@v0.3.1
+        with:
+          filename: cloud/loadtest/k6/spike.js
+        env:
+          BASE_URL: ${{ github.event.inputs.base_url || 'https://gradata-production.up.railway.app' }}
+
+      - name: Comment on commit if thresholds breached
+        if: failure() && github.event_name == 'schedule'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.sha;
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.repos.createCommitComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: sha,
+              body: `:rotating_light: **Nightly loadtest: spike SLO breach**\n\n` +
+                    `5xx detected under spike load — SlowAPI should return 429, not 500.\n\n` +
+                    `Check Sentry (\`gradata-cloud\` project) for stack traces.\n\n` +
+                    `See run: ${runUrl}\n\n` +
+                    `Rollback playbook: \`cloud/loadtest/README.md\``,
+            });

--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -1,0 +1,175 @@
+name: SDK Publish
+
+# Trigger on SDK version tags: sdk-v0.5.0, sdk-v0.5.1rc1, etc.
+# Release candidates (rc/a/b/dev suffix) publish to TestPyPI;
+# final versions publish to PyPI.
+on:
+  push:
+    tags:
+      - "sdk-v*"
+
+concurrency:
+  group: sdk-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      is_prerelease: ${{ steps.meta.outputs.is_prerelease }}
+      already_published: ${{ steps.check.outputs.already_published }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Derive version from tag
+        id: meta
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#sdk-v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          if [[ "${VERSION}" =~ (rc|a|b|dev|alpha|beta) ]]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Tag:     ${TAG}"
+          echo "Version: ${VERSION}"
+
+      - name: Verify tag matches pyproject.toml version
+        run: |
+          PYPROJECT_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          TAG_VERSION="${{ steps.meta.outputs.version }}"
+          if [ "${PYPROJECT_VERSION}" != "${TAG_VERSION}" ]; then
+            echo "::error::Tag version (${TAG_VERSION}) does not match pyproject.toml version (${PYPROJECT_VERSION})."
+            echo "::error::Bump pyproject.toml to ${TAG_VERSION} or retag."
+            exit 1
+          fi
+          echo "Version match confirmed: ${PYPROJECT_VERSION}"
+
+      - name: Check if version already exists on PyPI
+        id: check
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          IS_PRE="${{ steps.meta.outputs.is_prerelease }}"
+          if [ "${IS_PRE}" = "true" ]; then
+            INDEX_URL="https://test.pypi.org/pypi/gradata/json"
+            INDEX_NAME="TestPyPI"
+          else
+            INDEX_URL="https://pypi.org/pypi/gradata/json"
+            INDEX_NAME="PyPI"
+          fi
+          echo "Querying ${INDEX_NAME} at ${INDEX_URL}"
+          HTTP_STATUS=$(curl -s -o /tmp/pypi.json -w "%{http_code}" "${INDEX_URL}" || echo "000")
+          if [ "${HTTP_STATUS}" = "404" ]; then
+            echo "Project not yet on ${INDEX_NAME} — first publish."
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "${HTTP_STATUS}" != "200" ]; then
+            echo "::warning::Unexpected HTTP ${HTTP_STATUS} from ${INDEX_NAME}. Proceeding."
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if python -c "import json,sys; d=json.load(open('/tmp/pypi.json')); sys.exit(0 if '${VERSION}' in d.get('releases',{}) else 1)"; then
+            echo "::warning::gradata==${VERSION} is already published to ${INDEX_NAME}. Skipping publish step."
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "gradata==${VERSION} not yet on ${INDEX_NAME}. Will publish."
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dev dependencies
+        if: steps.check.outputs.already_published != 'true'
+        run: uv pip install --system -e ".[dev]"
+
+      - name: Run tests (gate before publish)
+        if: steps.check.outputs.already_published != 'true'
+        run: python -m pytest tests/ -v --tb=short --ignore=tests/test_spec_compliance.py
+
+      - name: Build wheel and sdist
+        if: steps.check.outputs.already_published != 'true'
+        run: |
+          rm -rf dist/
+          uv build
+          ls -la dist/
+
+      - name: Upload distributions
+        if: steps.check.outputs.already_published != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-testpypi:
+    name: Publish to TestPyPI (pre-release)
+    needs: build
+    if: needs.build.outputs.is_prerelease == 'true' && needs.build.outputs.already_published != 'true'
+    runs-on: ubuntu-latest
+
+    # Trusted Publisher — configure at test.pypi.org/manage/account/publishing/
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    if: needs.build.outputs.is_prerelease == 'false' && needs.build.outputs.already_published != 'true'
+    runs-on: ubuntu-latest
+
+    # Trusted Publisher — configure at pypi.org/manage/account/publishing/
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
+  skipped:
+    name: Publish skipped (version already on index)
+    needs: build
+    if: needs.build.outputs.already_published == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report
+        run: |
+          echo "::warning::gradata==${{ needs.build.outputs.version }} already exists on the target index."
+          echo "::warning::Bump pyproject.toml and retag if you intended to publish a new version."

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -1,0 +1,63 @@
+name: SDK Test
+
+on:
+  push:
+    paths:
+      - "src/gradata/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - ".github/workflows/sdk-test.yml"
+  pull_request:
+    paths:
+      - "src/gradata/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - ".github/workflows/sdk-test.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: sdk-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: "Test (Python ${{ matrix.python-version }})"
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install dev dependencies
+        run: uv pip install --system -e ".[dev]"
+
+      - name: Run test suite
+        run: python -m pytest tests/ -v --tb=short --ignore=tests/test_spec_compliance.py
+
+      - name: Build distributions (smoke test)
+        run: uv build
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "gradata-wheel-py${{ matrix.python-version }}"
+          path: dist/*.whl
+          if-no-files-found: error
+          retention-days: 14

--- a/cloud/SENTRY-SETUP.md
+++ b/cloud/SENTRY-SETUP.md
@@ -38,15 +38,19 @@ In Cloudflare → Pages → `gradata-dashboard` → Settings → Environment var
 ```
 VITE_SENTRY_DSN=https://...@o0.ingest.sentry.io/<project-id>
 VITE_SENTRY_ENVIRONMENT=production           # optional, defaults to MODE
-VITE_SENTRY_RELEASE=gradata-dashboard@<ver>  # optional
-
-# For source-map upload (makes prod stack traces readable)
-SENTRY_AUTH_TOKEN=<token-from-step-1>
-SENTRY_ORG=gradata
-SENTRY_PROJECT=gradata-dashboard
+VITE_SENTRY_RELEASE=gradata-dashboard@<ver>  # optional; GH Actions overrides per build
 ```
 
 **Important:** Vite reads `VITE_*` vars **at build time**. After setting them, trigger a rebuild (retry deploy, or push a commit). Reading env changes requires a new build.
+
+### Source maps (for readable stack traces)
+
+Source-map upload happens **automatically on every push to `main`** that touches `cloud/dashboard/**`, via `.github/workflows/dashboard-source-maps.yml`. No manual `sentry-cli` runs, no Cloudflare-side env vars for the Sentry auth token — the workflow holds them as GitHub Actions secrets.
+
+See [`cloud/dashboard/SOURCE-MAPS.md`](./dashboard/SOURCE-MAPS.md) for:
+- The five GitHub Actions secrets to configure (`SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`)
+- How to verify source maps uploaded after a deploy
+- How to skip the workflow (`[skip ci]` in commit message)
 
 Open the dashboard in a browser and check console for:
 

--- a/cloud/app/models.py
+++ b/cloud/app/models.py
@@ -116,6 +116,24 @@ class UpdateProfileRequest(BaseModel):
     display_name: str
 
 
+class NotificationPrefs(BaseModel):
+    """User notification preferences. SIM16 default: weekly digest, alerts opt-in."""
+
+    alert_correction_spike: bool = True
+    alert_rule_regression: bool = True
+    alert_meta_rule_emerged: bool = False
+    digest_cadence: str = "weekly"  # daily|weekly|monthly|off
+    digest_email: str = ""           # blank = use account email
+    slack_webhook: str = ""          # blank = no Slack delivery
+
+    @field_validator("digest_cadence")
+    @classmethod
+    def cadence_valid(cls, v: str) -> str:
+        if v not in {"daily", "weekly", "monthly", "off"}:
+            raise ValueError("digest_cadence must be daily|weekly|monthly|off")
+        return v
+
+
 # ---------------------------------------------------------------------------
 # API key models
 # ---------------------------------------------------------------------------

--- a/cloud/app/routes/users.py
+++ b/cloud/app/routes/users.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, Request
 
 from app.auth import get_current_user_id
 from app.db import get_db
-from app.models import UpdateProfileRequest, UserProfile
+from app.models import NotificationPrefs, UpdateProfileRequest, UserProfile
 
 _log = logging.getLogger(__name__)
 
@@ -87,3 +87,41 @@ async def update_profile(
         display_name=body.display_name,
         workspaces=workspaces,
     )
+
+
+@router.get("/users/me/notifications", response_model=NotificationPrefs)
+async def get_notifications(
+    request: Request,
+    user_id: str = Depends(get_current_user_id),
+) -> NotificationPrefs:
+    """Return the authenticated user's notification preferences.
+
+    Stored as a single JSON column on workspace_members for now (one workspace
+    per user during launch). Falls back to defaults if no row.
+    """
+    db = get_db()
+    rows = await db.select(
+        "workspace_members",
+        columns="notification_prefs",
+        filters={"user_id": user_id},
+    )
+    if not rows or not rows[0].get("notification_prefs"):
+        return NotificationPrefs()
+    return NotificationPrefs(**rows[0]["notification_prefs"])
+
+
+@router.put("/users/me/notifications", response_model=NotificationPrefs)
+async def update_notifications(
+    body: NotificationPrefs,
+    request: Request,
+    user_id: str = Depends(get_current_user_id),
+) -> NotificationPrefs:
+    """Replace the authenticated user's notification preferences."""
+    db = get_db()
+    await db.update(
+        "workspace_members",
+        data={"notification_prefs": body.model_dump()},
+        filters={"user_id": user_id},
+    )
+    _log.info("Updated notification_prefs for user=%s cadence=%s", user_id, body.digest_cadence)
+    return body

--- a/cloud/dashboard/SOURCE-MAPS.md
+++ b/cloud/dashboard/SOURCE-MAPS.md
@@ -1,0 +1,78 @@
+# Source maps → Sentry
+
+Production stack traces are minified gibberish (`a.b.c` at line 1) without source maps. This doc covers the setup that makes them readable.
+
+## Why
+
+When the dashboard throws in prod, Sentry captures a stack trace against the minified JS bundle. Without source maps, frames look like:
+
+```
+at p (/assets/index-a8f2c91.js:1:12834)
+```
+
+With source maps uploaded, Sentry maps that back to:
+
+```
+at loadBrain (src/pages/BrainDetail.tsx:42:12)
+```
+
+The Vite Sentry plugin (`@sentry/vite-plugin`, already wired in `vite.config.ts`) generates `.map` files during build, uploads them to Sentry tagged with the release, then deletes them from the `dist/` output so they're never served to browsers.
+
+## How it runs
+
+Every push to `main` that touches `cloud/dashboard/**` triggers `.github/workflows/dashboard-source-maps.yml`:
+
+1. Checkout, install pnpm 10 + Node 20
+2. `pnpm install --frozen-lockfile`
+3. `pnpm build` with `SENTRY_AUTH_TOKEN` set → Vite builds, plugin uploads + deletes maps
+4. `wrangler pages deploy dist` → pushes the built output to Cloudflare Pages
+
+This replaces the Cloudflare-native git-builder, which fails because it isn't configured to build from the `cloud/dashboard/` subpath.
+
+## Required GitHub Actions secrets
+
+Configure under repo → Settings → Secrets and variables → Actions:
+
+| Secret | Value / where to get it |
+|---|---|
+| `SENTRY_AUTH_TOKEN` | Sentry → User settings → Auth tokens → **Create new token**. Scopes: `project:write` + `project:releases`. Copy once; Sentry won't show it again. |
+| `SENTRY_ORG` | `gradata` |
+| `SENTRY_PROJECT` | `gradata-dashboard` |
+| `CLOUDFLARE_API_TOKEN` | Cloudflare → My Profile → API Tokens → **Create Token**. Template: "Custom". Permission: `Account → Cloudflare Pages → Edit`. Account Resources: include your account. |
+| `CLOUDFLARE_ACCOUNT_ID` | `d568e4421afe0100d09df9e4d29bef81` |
+
+All five must be set or the workflow will fail at either the build or deploy step.
+
+## Verifying a deploy uploaded maps
+
+1. Watch the workflow run in GitHub → Actions → Dashboard Build + Deploy
+2. The "Build with Sentry source-map upload" step log should contain lines like `Successfully uploaded 12 source maps` and `Successfully created release gradata-dashboard@<sha>`
+3. Open the dashboard, open DevTools, throw an error (easiest: paste `throw new Error('test')` in the console on a page that has a React error boundary, or comment out a required prop on a dev branch)
+4. In Sentry → gradata-dashboard → Issues, open the new event. The stack trace should show **original file paths** (e.g. `src/pages/X.tsx`) not bundled asset names. If frames still show `/assets/index-<hash>.js`, the upload didn't run or the release tag doesn't match
+
+If you see "Source map was not found" in Sentry, check the release name on the event matches the release the maps were uploaded under — both should be `gradata-dashboard@<full-commit-sha>`.
+
+## Skipping the workflow
+
+Include `[skip ci]` in the commit message:
+
+```bash
+git commit -m "docs: tweak wording [skip ci]"
+```
+
+The workflow's `if:` guard drops the job. Use this for pure-docs changes inside `cloud/dashboard/` that shouldn't trigger a redeploy.
+
+## Manual trigger
+
+Workflow has `workflow_dispatch:` — go to Actions → Dashboard Build + Deploy → **Run workflow** to trigger a build off `main` without pushing a commit. Useful after rotating secrets.
+
+## Local dry-run
+
+To verify the build path works without touching real credentials:
+
+```bash
+cd cloud/dashboard
+SENTRY_AUTH_TOKEN=dummy SENTRY_ORG=gradata SENTRY_PROJECT=gradata-dashboard pnpm build
+```
+
+The Sentry plugin will fail to upload (expected — dummy token) but the build itself should succeed. This confirms the plugin is wired correctly and only the auth is missing.

--- a/cloud/dashboard/app/(dashboard)/docs/page.tsx
+++ b/cloud/dashboard/app/(dashboard)/docs/page.tsx
@@ -1,0 +1,234 @@
+'use client'
+
+import { useState } from 'react'
+import { GlassCard } from '@/components/layout/GlassCard'
+
+/**
+ * In-dashboard docs page — common SDK patterns, copy-paste-ready.
+ * Lives behind auth so we can later show personalized snippets
+ * (e.g. inject the user's API key into the example).
+ */
+
+interface Snippet {
+  id: string
+  title: string
+  language: 'bash' | 'python' | 'typescript'
+  code: string
+  notes?: string
+}
+
+const SNIPPETS: Array<{ section: string; items: Snippet[] }> = [
+  {
+    section: 'Install',
+    items: [
+      {
+        id: 'install',
+        title: 'Install the SDK',
+        language: 'bash',
+        code: 'pip install gradata',
+      },
+      {
+        id: 'verify',
+        title: 'Verify install',
+        language: 'bash',
+        code: `python -c "import gradata; print(gradata.__version__)"`,
+      },
+    ],
+  },
+  {
+    section: 'Initialize a brain',
+    items: [
+      {
+        id: 'init-local',
+        title: 'Local-only brain (no cloud sync)',
+        language: 'python',
+        code: `import gradata
+
+brain = gradata.Brain.init(
+    name="my-brain",
+    domain="engineering",  # any string — used to scope rules
+)`,
+        notes: 'Local mode — corrections + lessons stay on disk in `~/.gradata/<name>/`. No network.',
+      },
+      {
+        id: 'init-cloud',
+        title: 'Cloud-synced brain',
+        language: 'python',
+        code: `import gradata
+
+brain = gradata.Brain.init(
+    name="my-brain",
+    domain="engineering",
+    api_key="gd_YOUR_KEY_HERE",  # generate at app.gradata.ai/api-keys
+)`,
+        notes: 'Synthesized principles + counters reach api.gradata.ai. Raw correction text NEVER leaves your machine.',
+      },
+    ],
+  },
+  {
+    section: 'Run a session',
+    items: [
+      {
+        id: 'session',
+        title: 'Wrap your work in a session',
+        language: 'python',
+        code: `with brain.session() as s:
+    response = s.ask("Draft a response to this RFP question")
+    # ... your code uses response ...
+
+# Corrections you log in this session sync at end_session()`,
+      },
+      {
+        id: 'correct',
+        title: 'Log a correction',
+        language: 'python',
+        code: `brain.correct(
+    draft="We are pleased to inform you of our quarterly results.",
+    final="Our Q3 numbers are in — here's what changed.",
+    category="Tone & Register",  # optional; SDK auto-classifies
+)`,
+        notes: 'Severity is computed automatically from edit-distance. SDK extracts the behavioral instruction.',
+      },
+    ],
+  },
+  {
+    section: 'Inject rules into a prompt',
+    items: [
+      {
+        id: 'inject',
+        title: 'Get the active rules for a prompt',
+        language: 'python',
+        code: `prompt = "Draft a follow-up to last week's investor email."
+
+rules = brain.rules_for(prompt, max=10)
+# rules is a list of strings — graduated principles
+# Inject them into your system prompt:
+system = "You are an assistant.\\n\\nFollow these:\\n" + "\\n".join(f"- {r}" for r in rules)`,
+        notes: 'max=10 caps the injection budget. SDK picks the most relevant + highest-confidence rules.',
+      },
+    ],
+  },
+  {
+    section: 'Inspect what the brain learned',
+    items: [
+      {
+        id: 'inspect',
+        title: 'List graduated rules',
+        language: 'python',
+        code: `for lesson in brain.lessons(state="RULE"):
+    print(f"{lesson.confidence:.2f}  {lesson.description}")
+`,
+      },
+      {
+        id: 'meta',
+        title: 'Find meta-rules (universal principles)',
+        language: 'python',
+        code: `for meta in brain.meta_rules():
+    print(meta.title)
+    print(f"  derived from {len(meta.source_lessons)} rules")
+`,
+      },
+    ],
+  },
+  {
+    section: 'TypeScript / JavaScript',
+    items: [
+      {
+        id: 'ts-install',
+        title: 'Install the JS SDK',
+        language: 'bash',
+        code: 'npm install @gradata/sdk',
+        notes: 'JS SDK is a thin wrapper around the cloud API. For full graduation engine, use the Python SDK.',
+      },
+      {
+        id: 'ts-correct',
+        title: 'Log a correction from a Node app',
+        language: 'typescript',
+        code: `import { Brain } from '@gradata/sdk'
+
+const brain = new Brain({ apiKey: process.env.GRADATA_API_KEY! })
+
+await brain.correct({
+  draft: "We are pleased to inform you...",
+  final: "Hey, quick update —",
+  category: 'Tone & Register',
+})`,
+      },
+    ],
+  },
+]
+
+export default function DocsPage() {
+  return (
+    <>
+      <header className="mb-7">
+        <h1 className="text-[22px]">Docs</h1>
+        <p className="mt-1 text-[13px] text-[var(--color-body)]">
+          Copy-paste-ready snippets for the most common Gradata SDK patterns
+        </p>
+      </header>
+
+      <div className="space-y-8">
+        {SNIPPETS.map((section) => (
+          <section key={section.section}>
+            <h2 className="mb-4 font-mono text-[10px] font-semibold uppercase tracking-wider text-[var(--color-accent-blue)]">
+              {section.section}
+            </h2>
+            <div className="space-y-4">
+              {section.items.map((item) => (
+                <SnippetCard key={item.id} snippet={item} />
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+
+      <div className="mt-12 text-center">
+        <p className="font-mono text-[11px] text-[var(--color-body)]">
+          Full reference at{' '}
+          <a
+            href="https://github.com/Gradata/gradata"
+            className="text-[var(--color-accent-blue)] underline-offset-4 hover:underline"
+          >
+            github.com/Gradata/gradata
+          </a>
+        </p>
+      </div>
+    </>
+  )
+}
+
+function SnippetCard({ snippet }: { snippet: Snippet }) {
+  const [copied, setCopied] = useState(false)
+  const copy = () => {
+    navigator.clipboard.writeText(snippet.code)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }
+
+  return (
+    <GlassCard gradTop>
+      <div className="mb-3 flex items-baseline justify-between gap-3">
+        <h3 className="text-[14px] font-semibold">{snippet.title}</h3>
+        <span className="font-mono text-[10px] uppercase tracking-wider text-[var(--color-body)]">
+          {snippet.language}
+        </span>
+      </div>
+      <div className="relative">
+        <pre className="overflow-x-auto rounded-[0.5rem] border border-[var(--color-border)] bg-black/40 p-4 font-mono text-[12px] leading-relaxed">
+          {snippet.code}
+        </pre>
+        <button
+          type="button"
+          onClick={copy}
+          className="absolute right-3 top-3 rounded-[0.25rem] border border-[var(--color-border)] bg-[rgba(21,29,48,0.8)] px-2.5 py-1 font-mono text-[10px] text-[var(--color-body)] backdrop-blur-md transition-all hover:border-[var(--color-border-hover)] hover:text-[var(--color-text)]"
+        >
+          {copied ? 'copied' : 'copy'}
+        </button>
+      </div>
+      {snippet.notes && (
+        <p className="mt-3 text-[11px] text-[var(--color-body)]">{snippet.notes}</p>
+      )}
+    </GlassCard>
+  )
+}

--- a/cloud/dashboard/app/(dashboard)/notifications/page.tsx
+++ b/cloud/dashboard/app/(dashboard)/notifications/page.tsx
@@ -1,10 +1,13 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { GlassCard } from '@/components/layout/GlassCard'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { LoadingSpinner } from '@/components/shared/LoadingSpinner'
+import { useApi } from '@/hooks/useApi'
+import api from '@/lib/api'
 
 /**
  * Notification preferences per SIM16 validation:
@@ -25,22 +28,41 @@ interface Toggles {
   slack_webhook: string
 }
 
+const DEFAULTS: Toggles = {
+  alert_correction_spike: true,
+  alert_rule_regression: true,
+  alert_meta_rule_emerged: false,
+  digest_cadence: 'weekly',
+  digest_email: '',
+  slack_webhook: '',
+}
+
 export default function NotificationsPage() {
-  const [toggles, setToggles] = useState<Toggles>({
-    alert_correction_spike: true,
-    alert_rule_regression: true,
-    alert_meta_rule_emerged: false,
-    digest_cadence: 'weekly',
-    digest_email: '',
-    slack_webhook: '',
-  })
+  const { data: serverPrefs, loading } = useApi<Toggles>('/users/me/notifications')
+  const [toggles, setToggles] = useState<Toggles>(DEFAULTS)
   const [saved, setSaved] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (serverPrefs) setToggles(serverPrefs)
+  }, [serverPrefs])
+
+  if (loading) return <LoadingSpinner className="py-20" />
 
   const handleSave = async () => {
-    // TODO(backend): POST /users/me/notifications
-    await new Promise((r) => setTimeout(r, 300))
-    setSaved(true)
-    setTimeout(() => setSaved(false), 2000)
+    setSaving(true)
+    setSaveError(null)
+    try {
+      const res = await api.put<Toggles>('/users/me/notifications', toggles)
+      setToggles(res.data)
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2000)
+    } catch (err: any) {
+      setSaveError(err?.response?.data?.detail ?? 'Could not save preferences')
+    } finally {
+      setSaving(false)
+    }
   }
 
   return (
@@ -120,12 +142,19 @@ export default function NotificationsPage() {
         </GlassCard>
 
         <div className="flex items-center justify-end gap-3">
+          {saveError && (
+            <span className="font-mono text-[11px] text-[var(--color-destructive)]">
+              {saveError}
+            </span>
+          )}
           {saved && (
             <span className="font-mono text-[11px] text-[var(--color-success)]">
               ✓ preferences saved
             </span>
           )}
-          <Button onClick={handleSave}>Save preferences</Button>
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? 'Saving…' : 'Save preferences'}
+          </Button>
         </div>
       </div>
     </>

--- a/cloud/dashboard/app/forgot-password/page.tsx
+++ b/cloud/dashboard/app/forgot-password/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { AuthLegalLinks } from '@/components/layout/AuthLegalLinks'
 import { useAuth } from '@/hooks/useAuth'
 
 export default function ForgotPasswordPage() {
@@ -27,7 +28,7 @@ export default function ForgotPasswordPage() {
 
   if (sent) {
     return (
-      <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="flex min-h-screen flex-col items-center justify-center px-4">
         <Card className="w-full max-w-sm">
           <CardHeader className="text-center">
             <CardTitle className="text-xl">Check your email</CardTitle>
@@ -41,12 +42,13 @@ export default function ForgotPasswordPage() {
             </Link>
           </CardContent>
         </Card>
+        <AuthLegalLinks />
       </div>
     )
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center px-4">
+    <div className="flex min-h-screen flex-col items-center justify-center px-4">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
           <CardTitle className="text-xl">Reset your password</CardTitle>
@@ -73,6 +75,7 @@ export default function ForgotPasswordPage() {
           </form>
         </CardContent>
       </Card>
+      <AuthLegalLinks />
     </div>
   )
 }

--- a/cloud/dashboard/app/legal/privacy/page.tsx
+++ b/cloud/dashboard/app/legal/privacy/page.tsx
@@ -1,0 +1,281 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { GlassCard } from '@/components/layout/GlassCard'
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy — Gradata',
+  description:
+    'How Gradata handles data: what stays local, what reaches the cloud, who we share with, and how to exercise your rights.',
+}
+
+const LAST_UPDATED = '2026-04-13'
+
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="min-h-screen bg-[var(--color-bg)] px-4 py-10 md:py-16">
+      <div className="mx-auto max-w-3xl">
+        <header className="mb-8">
+          <Link
+            href="/"
+            className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-body)] underline-offset-4 hover:text-[var(--color-accent-blue)] hover:underline"
+          >
+            ← Back to Gradata
+          </Link>
+          <h1 className="mt-4 text-[32px] leading-tight md:text-[40px]">Privacy Policy</h1>
+          <p className="mt-2 font-mono text-[11px] uppercase tracking-wider text-[var(--color-body)]">
+            Last updated {LAST_UPDATED}
+          </p>
+        </header>
+
+        <GlassCard gradTop className="mb-6">
+          <p className="text-[14px] leading-relaxed text-[var(--color-body)]">
+            Gradata is an AI memory layer that learns from the corrections you make. This policy explains
+            what data our cloud service (app.gradata.ai and api.gradata.ai) collects, what it never
+            collects, where that data lives, and how you control it. We write in plain English on
+            purpose.
+          </p>
+        </GlassCard>
+
+        <Section title="1. What we collect">
+          <p>
+            When you create an account and use the cloud dashboard, we collect:
+          </p>
+          <ul className="mt-3 list-disc space-y-2 pl-5">
+            <li>
+              <strong>Account data.</strong> Email address and an optional display name from Supabase
+              Auth. If you later sign in with Google, we receive the name and email on that Google
+              profile.
+            </li>
+            <li>
+              <strong>Synthesized principles.</strong> The distilled rule text the SDK produces after
+              corrections graduate. These are short, declarative statements (for example, <em>never
+              use em dashes in emails</em>). The raw correction body is not part of this.
+            </li>
+            <li>
+              <strong>Aggregate metrics.</strong> Counters and timestamps the SDK uploads so the
+              graduation engine can reason about recency: correction counts, graduation counts, fire
+              counts, session IDs, and session timestamps. Numbers and IDs, not content.
+            </li>
+            <li>
+              <strong>Billing metadata.</strong> If you subscribe, Stripe creates a customer record and
+              a subscription record. We store the Stripe customer ID, plan tier, and subscription
+              status. We do not see or store card numbers or CVCs — Stripe handles payment details
+              directly.
+            </li>
+            <li>
+              <strong>Error events.</strong> When something breaks in the backend or dashboard, Sentry
+              receives a stack trace and the minimum metadata needed to fix it. See section 3 for the
+              scrubbing rules.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="2. What we do not collect">
+          <p>The architecture is local-first. The following never leaves your device:</p>
+          <ul className="mt-3 list-disc space-y-2 pl-5">
+            <li>
+              <strong>Raw correction text.</strong> Your diffs, drafts, and edits stay in the local
+              brain file on your machine. Only the synthesized principle is uploaded.
+            </li>
+            <li>
+              <strong>Draft or final content.</strong> The SDK strips draft and final previews before
+              any upload.
+            </li>
+            <li>
+              <strong>Local files or source code.</strong> Gradata does not read or transmit the
+              project files you run it against.
+            </li>
+            <li>
+              <strong>IP addresses.</strong> Sentry is configured with <code className="font-mono text-[12px]">send_default_pii=false</code>,
+              so IPs and usernames are stripped from error events. Cloudflare, our CDN, may record
+              request IPs in its own edge logs under its privacy policy; we do not receive or store
+              them ourselves.
+            </li>
+            <li>
+              <strong>Tracking cookies.</strong> We set an auth session cookie and nothing else. No
+              advertising pixels, no third-party analytics cookies, no fingerprinting.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="3. Error tracking details">
+          <p>Sentry is disabled unless a DSN is configured. When it is on, it drops:</p>
+          <ul className="mt-3 list-disc space-y-2 pl-5">
+            <li>Request bodies (these can contain Stripe customer emails or webhook payloads)</li>
+            <li>Cookies, <code className="font-mono text-[12px]">Authorization</code> headers, <code className="font-mono text-[12px]">X-API-Key</code>, and <code className="font-mono text-[12px]">X-Stripe-Signature</code> headers</li>
+            <li>Service role keys, webhook secrets, access tokens, and refresh tokens anywhere in the event</li>
+            <li>IP addresses and usernames</li>
+            <li>Local variables in stack frames</li>
+          </ul>
+          <p className="mt-3">
+            Session replay captures on error only and masks all text content.
+          </p>
+        </Section>
+
+        <Section title="4. Where your data lives">
+          <p>
+            Your data is processed by a small set of vendors (sub-processors). Each is linked to their
+            own privacy policy.
+          </p>
+          <ul className="mt-3 list-disc space-y-2 pl-5">
+            <li>
+              <strong>Supabase</strong> — Postgres database and authentication, hosted in a US region by
+              default. Stores account, workspace, brain, principle, metric, and billing metadata rows.{' '}
+              <ExtLink href="https://supabase.com/privacy">supabase.com/privacy</ExtLink>
+            </li>
+            <li>
+              <strong>Stripe</strong> — subscription billing and payment processing. PCI-compliant.
+              Receives the minimum billing metadata needed to charge and invoice.{' '}
+              <ExtLink href="https://stripe.com/privacy">stripe.com/privacy</ExtLink>
+            </li>
+            <li>
+              <strong>Cloudflare</strong> — CDN and edge network for the dashboard. May retain edge
+              request logs per its policy.{' '}
+              <ExtLink href="https://www.cloudflare.com/privacypolicy/">cloudflare.com/privacypolicy</ExtLink>
+            </li>
+            <li>
+              <strong>Sentry</strong> — error and performance event storage. Only receives scrubbed
+              events as described in section 3.{' '}
+              <ExtLink href="https://sentry.io/privacy/">sentry.io/privacy</ExtLink>
+            </li>
+            <li>
+              <strong>Google</strong> — only if you choose to sign in with Google OAuth. We receive
+              your Google profile email and name.{' '}
+              <ExtLink href="https://policies.google.com/privacy">policies.google.com/privacy</ExtLink>
+            </li>
+          </ul>
+          <p className="mt-3">
+            We do not sell personal data, and we do not share it with advertising networks.
+          </p>
+        </Section>
+
+        <Section title="5. Security">
+          <p>
+            Traffic between your SDK, the dashboard, and our API is served over TLS 1.2 or higher.
+            Supabase enforces row-level security so every dashboard query is scoped to the signed-in
+            user. Service role keys are only held by the backend, never exposed to the browser. Stripe
+            processes card data; we never see or store PANs or CVCs.
+          </p>
+          <p className="mt-3">
+            No system is unbreakable. We avoid marketing superlatives like &ldquo;military-grade&rdquo; or
+            &ldquo;unhackable&rdquo; because they are not meaningful claims.
+          </p>
+        </Section>
+
+        <Section title="6. Retention">
+          <p>
+            We retain account, principle, and metric data while your account is active. After you
+            delete your account, we delete your personal records within 30 days. Aggregate metrics may
+            be retained in anonymized form for product analytics. Stripe retains billing records for as
+            long as required by its own policies and applicable financial regulations.
+          </p>
+          <p className="mt-3">
+            Error events in Sentry expire according to Sentry&rsquo;s standard retention (typically 30
+            or 90 days depending on plan).
+          </p>
+        </Section>
+
+        <Section title="7. Your rights">
+          <p>You can:</p>
+          <ul className="mt-3 list-disc space-y-2 pl-5">
+            <li>
+              <strong>Access or export</strong> the data we hold about you. Email{' '}
+              <EmailLink>support@gradata.ai</EmailLink> and we will return a copy within 30 days.
+            </li>
+            <li>
+              <strong>Correct</strong> inaccurate account data from the dashboard settings page or by
+              email.
+            </li>
+            <li>
+              <strong>Delete</strong> your account and associated cloud data. Email{' '}
+              <EmailLink>support@gradata.ai</EmailLink> or use the dashboard account page. Raw
+              corrections on your device are deleted when you remove the local brain file.
+            </li>
+            <li>
+              <strong>Object or restrict</strong> processing where GDPR, UK GDPR, or similar laws apply
+              to you. Contact us and we will comply within the statutory timeframe.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="8. Children">
+          <p>
+            Gradata is not designed for and is not directed at anyone under the age of 16. If you
+            believe a child has created an account, email{' '}
+            <EmailLink>support@gradata.ai</EmailLink> and we will remove it.
+          </p>
+        </Section>
+
+        <Section title="9. International transfers">
+          <p>
+            Our primary Supabase region is in the United States. If you are in the EU, UK, or another
+            region with specific data transfer rules, using Gradata constitutes consent to transfer of
+            your data to the US under standard contractual clauses where required.
+          </p>
+        </Section>
+
+        <Section title="10. Changes to this policy">
+          <p>
+            If we make material changes, we will email the address on your account at least 30 days
+            before they take effect, and we will update the &ldquo;Last updated&rdquo; date at the top
+            of this page. Non-material clarifications may land without a separate notice.
+          </p>
+        </Section>
+
+        <Section title="11. Contact">
+          <p>
+            Questions, data requests, or privacy concerns:{' '}
+            <EmailLink>support@gradata.ai</EmailLink>. For legal notices specifically:{' '}
+            <EmailLink>legal@gradata.ai</EmailLink>.
+          </p>
+        </Section>
+
+        <footer className="mt-12 flex items-center justify-between border-t border-[var(--color-border)] pt-6 text-[12px] text-[var(--color-body)]">
+          <Link href="/" className="font-mono uppercase tracking-wider hover:text-[var(--color-accent-blue)]">
+            ← Back to Gradata
+          </Link>
+          <Link href="/legal/terms" className="font-mono uppercase tracking-wider hover:text-[var(--color-accent-blue)]">
+            Terms of Service →
+          </Link>
+        </footer>
+      </div>
+    </div>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-6">
+      <GlassCard>
+        <h2 className="mb-3 text-[18px]">{title}</h2>
+        <div className="space-y-2 text-[14px] leading-relaxed text-[var(--color-body)]">
+          {children}
+        </div>
+      </GlassCard>
+    </section>
+  )
+}
+
+function ExtLink({ href, children }: { href: string; children: React.ReactNode }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-[var(--color-accent-blue)] underline-offset-4 hover:underline"
+    >
+      {children}
+    </a>
+  )
+}
+
+function EmailLink({ children }: { children: string }) {
+  return (
+    <a
+      href={`mailto:${children}`}
+      className="text-[var(--color-accent-blue)] underline-offset-4 hover:underline"
+    >
+      {children}
+    </a>
+  )
+}

--- a/cloud/dashboard/app/legal/terms/page.tsx
+++ b/cloud/dashboard/app/legal/terms/page.tsx
@@ -1,0 +1,275 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { GlassCard } from '@/components/layout/GlassCard'
+
+export const metadata: Metadata = {
+  title: 'Terms of Service — Gradata',
+  description:
+    'The agreement between you and Gradata: how you can use the service, what we promise, and what we don’t.',
+}
+
+const LAST_UPDATED = '2026-04-13'
+
+export default function TermsOfServicePage() {
+  return (
+    <div className="min-h-screen bg-[var(--color-bg)] px-4 py-10 md:py-16">
+      <div className="mx-auto max-w-3xl">
+        <header className="mb-8">
+          <Link
+            href="/"
+            className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-body)] underline-offset-4 hover:text-[var(--color-accent-blue)] hover:underline"
+          >
+            ← Back to Gradata
+          </Link>
+          <h1 className="mt-4 text-[32px] leading-tight md:text-[40px]">Terms of Service</h1>
+          <p className="mt-2 font-mono text-[11px] uppercase tracking-wider text-[var(--color-body)]">
+            Last updated {LAST_UPDATED}
+          </p>
+        </header>
+
+        <GlassCard gradTop className="mb-6">
+          <p className="text-[14px] leading-relaxed text-[var(--color-body)]">
+            These terms govern your use of Gradata (the SDK and the cloud service at app.gradata.ai and
+            api.gradata.ai). By creating an account or using the service, you agree to them. If you
+            are agreeing on behalf of a company, you confirm that you have authority to bind that
+            company.
+          </p>
+        </GlassCard>
+
+        <Section title="1. The service">
+          <p>
+            Gradata is an AI memory layer that learns from your corrections. It has two parts:
+          </p>
+          <ul className="mt-3 list-disc space-y-2 pl-5">
+            <li>
+              The <strong>SDK</strong>, distributed under the GNU Affero General Public License v3.0,
+              which runs on your machine and maintains a local brain file.
+            </li>
+            <li>
+              The <strong>cloud dashboard and API</strong>, proprietary hosted services that provide
+              observability, team features, billing, and the graduation engine that produces
+              synthesized principles.
+            </li>
+          </ul>
+          <p className="mt-3">
+            The service may change. We add features, retire features, and change how things work. We
+            aim to give useful notice for breaking changes, but we do not promise any specific feature
+            will exist forever.
+          </p>
+        </Section>
+
+        <Section title="2. Your account">
+          <p>
+            You must provide accurate account information and keep your credentials safe. You are
+            responsible for everything that happens under your account, including API key usage. If
+            you suspect your credentials or API key have been compromised, rotate them immediately and
+            email <EmailLink>support@gradata.ai</EmailLink>.
+          </p>
+          <p className="mt-3">
+            You must be at least 16 years old to use Gradata. If you are using Gradata in a country
+            that sets a higher age of digital consent, you must meet that threshold.
+          </p>
+        </Section>
+
+        <Section title="3. Acceptable use">
+          <p>You agree not to:</p>
+          <ul className="mt-3 list-disc space-y-2 pl-5">
+            <li>Scrape, crawl, or automate access beyond documented API endpoints</li>
+            <li>Resell the service or rebrand it as your own without a separate written agreement</li>
+            <li>Use outputs from the service to train a competing AI memory or learning product</li>
+            <li>Attempt to probe, test, or reverse-engineer the security of the platform</li>
+            <li>Upload content you do not have the right to upload</li>
+            <li>Use the service for anything illegal, defamatory, harassing, or that infringes the rights of others</li>
+          </ul>
+          <p className="mt-3">
+            The SDK itself is AGPL-3.0; the AGPL governs what you can do with that source code. These
+            terms govern the hosted service, not your use of the open source code.
+          </p>
+        </Section>
+
+        <Section title="4. Plans and billing">
+          <p>Paid plans are billed by Stripe. The current tiers are:</p>
+          <ul className="mt-3 list-disc space-y-2 pl-5">
+            <li><strong>Free</strong> — limited usage; no card required</li>
+            <li><strong>Cloud</strong> — $29 per month, billed monthly</li>
+            <li><strong>Team</strong> — $99 per month, billed monthly</li>
+            <li><strong>Enterprise</strong> — custom pricing, contact us</li>
+          </ul>
+          <p className="mt-3">
+            Subscriptions renew automatically until canceled. You can cancel at any time from the
+            dashboard billing page; your plan continues until the end of the paid period and does not
+            renew after that. <strong>We do not issue prorated refunds</strong> for unused time inside
+            a billing period. If a charge is made in error, email{' '}
+            <EmailLink>support@gradata.ai</EmailLink> and we will investigate.
+          </p>
+          <p className="mt-3">
+            Prices are in US dollars and do not include taxes. You are responsible for any sales tax,
+            VAT, or similar taxes that apply where you are.
+          </p>
+          <p className="mt-3">
+            We may change prices. We will give you at least 30 days notice by email before a price
+            change takes effect on your plan. If you do not accept the change, you can cancel before
+            it takes effect.
+          </p>
+        </Section>
+
+        <Section title="5. API rate limits and fair use">
+          <p>
+            Be reasonable with API usage. If your workload starts to affect other customers we may
+            throttle your requests, contact you to discuss a higher tier, or in extreme cases suspend
+            service. We will reach out before taking the last step whenever practical.
+          </p>
+        </Section>
+
+        <Section title="6. Intellectual property">
+          <p>
+            <strong>You own your data.</strong> The synthesized principles, metrics, and any outputs
+            derived from your corrections are yours. You grant us a limited license to process that
+            data so that we can operate the service for you.
+          </p>
+          <p className="mt-3">
+            <strong>We own the platform.</strong> The cloud dashboard, backend API, graduation engine,
+            and all associated branding and know-how are ours. The SDK source code is licensed to you
+            separately under the AGPL-3.0; its license terms live in the{' '}
+            <a
+              href="https://github.com/gradata-ai"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[var(--color-accent-blue)] underline-offset-4 hover:underline"
+            >
+              public repository
+            </a>
+            .
+          </p>
+          <p className="mt-3">
+            If you submit feedback or suggestions, we may use them without obligation. We will not
+            identify you as the source without your permission.
+          </p>
+        </Section>
+
+        <Section title="7. Termination">
+          <p>
+            You can terminate your account at any time by canceling from the dashboard and emailing{' '}
+            <EmailLink>support@gradata.ai</EmailLink> to request deletion.
+          </p>
+          <p className="mt-3">
+            We can terminate or suspend your account if you violate these terms, if we are legally
+            required to, or if your account is inactive for an extended period. For non-cause
+            termination of a paying account, we will give at least 30 days notice so you can export
+            your data.
+          </p>
+          <p className="mt-3">
+            On termination, sections 6 (intellectual property), 8 (disclaimers), 9 (limitation of
+            liability), 10 (indemnification), and 12 (governing law) survive.
+          </p>
+        </Section>
+
+        <Section title="8. Disclaimer of warranties">
+          <p>
+            The service is provided <strong>&ldquo;as is&rdquo;</strong> and <strong>&ldquo;as
+            available&rdquo;</strong>. To the maximum extent permitted by law, we disclaim all
+            warranties, whether express, implied, statutory, or otherwise, including warranties of
+            merchantability, fitness for a particular purpose, non-infringement, and any warranty that
+            the service will be uninterrupted, error-free, or that learned principles will be
+            accurate.
+          </p>
+        </Section>
+
+        <Section title="9. Limitation of liability">
+          <p>
+            To the maximum extent permitted by law, our total liability arising out of or related to
+            these terms or the service is <strong>capped at the fees you paid to Gradata in the
+            twelve (12) months preceding the event giving rise to the claim</strong>. If you are on
+            the free plan, that cap is one hundred US dollars.
+          </p>
+          <p className="mt-3">
+            Neither party will be liable for indirect, incidental, special, consequential, or punitive
+            damages, lost profits, lost revenue, lost data, or business interruption, even if advised
+            of the possibility. Nothing in this section limits liability that cannot be limited under
+            applicable law (such as fraud or willful misconduct).
+          </p>
+        </Section>
+
+        <Section title="10. Indemnification">
+          <p>
+            You agree to defend and indemnify us against third-party claims arising from your misuse
+            of the service, your violation of these terms, or your violation of another party&rsquo;s
+            rights. We will defend and indemnify you against third-party claims that your authorized
+            use of the service infringes that third party&rsquo;s intellectual property rights. Both
+            carve-outs exclude the other party&rsquo;s negligence or willful misconduct. The party
+            seeking indemnification must give prompt notice and reasonable cooperation.
+          </p>
+        </Section>
+
+        <Section title="11. Changes to these terms">
+          <p>
+            We may update these terms. For material changes, we will email the address on your account
+            at least 30 days before the change takes effect. If you keep using the service after the
+            effective date, you accept the updated terms. If you do not accept them, you can cancel
+            before they take effect.
+          </p>
+        </Section>
+
+        <Section title="12. Governing law and disputes">
+          <p>
+            These terms are governed by the laws of the State of Delaware, United States, without
+            regard to its conflict of laws principles. Exclusive jurisdiction and venue for any
+            dispute lies in the state and federal courts located in Delaware, and both parties consent
+            to that jurisdiction. If you are a consumer in a jurisdiction that grants you the right to
+            sue in your home country, nothing in this section removes that right.
+          </p>
+        </Section>
+
+        <Section title="13. Miscellaneous">
+          <p>
+            These terms, together with the Privacy Policy and any order form, are the entire agreement
+            between you and us about the service. If any part is unenforceable, the rest stays in
+            effect. Failure to enforce a term is not a waiver. You cannot assign these terms without
+            our written consent; we can assign them to an affiliate or to a buyer of substantially all
+            of our assets.
+          </p>
+        </Section>
+
+        <Section title="14. Contact">
+          <p>
+            Legal notices: <EmailLink>legal@gradata.ai</EmailLink>. Everything else:{' '}
+            <EmailLink>support@gradata.ai</EmailLink>.
+          </p>
+        </Section>
+
+        <footer className="mt-12 flex items-center justify-between border-t border-[var(--color-border)] pt-6 text-[12px] text-[var(--color-body)]">
+          <Link href="/" className="font-mono uppercase tracking-wider hover:text-[var(--color-accent-blue)]">
+            ← Back to Gradata
+          </Link>
+          <Link href="/legal/privacy" className="font-mono uppercase tracking-wider hover:text-[var(--color-accent-blue)]">
+            Privacy Policy →
+          </Link>
+        </footer>
+      </div>
+    </div>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-6">
+      <GlassCard>
+        <h2 className="mb-3 text-[18px]">{title}</h2>
+        <div className="space-y-2 text-[14px] leading-relaxed text-[var(--color-body)]">
+          {children}
+        </div>
+      </GlassCard>
+    </section>
+  )
+}
+
+function EmailLink({ children }: { children: string }) {
+  return (
+    <a
+      href={`mailto:${children}`}
+      className="text-[var(--color-accent-blue)] underline-offset-4 hover:underline"
+    >
+      {children}
+    </a>
+  )
+}

--- a/cloud/dashboard/app/login/page.tsx
+++ b/cloud/dashboard/app/login/page.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { AuthLegalLinks } from '@/components/layout/AuthLegalLinks'
 import { useAuth } from '@/hooks/useAuth'
 
 export default function LoginPage() {
@@ -33,7 +34,7 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center px-4">
+    <div className="flex min-h-screen flex-col items-center justify-center px-4">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
           <div className="mx-auto mb-2 h-10 w-10 rounded-xl bg-gradient-brand shadow-[0_0_16px_rgba(58,130,255,0.3)] flex items-center justify-center">
@@ -91,6 +92,7 @@ export default function LoginPage() {
           </Button>
         </CardContent>
       </Card>
+      <AuthLegalLinks />
     </div>
   )
 }

--- a/cloud/dashboard/app/signup/page.tsx
+++ b/cloud/dashboard/app/signup/page.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { AuthLegalLinks } from '@/components/layout/AuthLegalLinks'
 import { useAuth } from '@/hooks/useAuth'
 
 export default function SignupPage() {
@@ -39,7 +40,7 @@ export default function SignupPage() {
 
   if (success) {
     return (
-      <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="flex min-h-screen flex-col items-center justify-center px-4">
         <Card className="w-full max-w-sm">
           <CardHeader className="text-center">
             <CardTitle className="text-xl">Check your email</CardTitle>
@@ -53,12 +54,13 @@ export default function SignupPage() {
             </Link>
           </CardContent>
         </Card>
+        <AuthLegalLinks />
       </div>
     )
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center px-4">
+    <div className="flex min-h-screen flex-col items-center justify-center px-4">
       <Card className="w-full max-w-sm">
         <CardHeader className="text-center">
           <div className="mx-auto mb-2 h-10 w-10 rounded-xl bg-gradient-brand shadow-[0_0_16px_rgba(58,130,255,0.3)] flex items-center justify-center">
@@ -99,6 +101,7 @@ export default function SignupPage() {
           </form>
         </CardContent>
       </Card>
+      <AuthLegalLinks />
     </div>
   )
 }

--- a/cloud/dashboard/src/components/layout/AuthLegalLinks.tsx
+++ b/cloud/dashboard/src/components/layout/AuthLegalLinks.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+
+/**
+ * Tiny Privacy · Terms links for the bottom of auth cards
+ * (login, signup, forgot password). Font-mono, opacity 50%.
+ */
+export function AuthLegalLinks() {
+  return (
+    <div className="mt-6 flex items-center justify-center gap-3 font-mono text-[10px] uppercase tracking-wider text-[var(--color-body)] opacity-50">
+      <Link
+        href="/legal/privacy"
+        className="transition-colors hover:text-[var(--color-accent-blue)] hover:opacity-100"
+      >
+        Privacy
+      </Link>
+      <span aria-hidden>·</span>
+      <Link
+        href="/legal/terms"
+        className="transition-colors hover:text-[var(--color-accent-blue)] hover:opacity-100"
+      >
+        Terms
+      </Link>
+    </div>
+  )
+}

--- a/cloud/dashboard/src/components/layout/DashboardLayout.tsx
+++ b/cloud/dashboard/src/components/layout/DashboardLayout.tsx
@@ -18,6 +18,7 @@ const SECTIONS = [
       { href: '/observability', label: 'Observability', icon: '◐' },
       { href: '/privacy', label: 'Privacy', icon: '◉' },
       { href: '/setup', label: 'Setup', icon: '⌨' },
+      { href: '/docs', label: 'Docs', icon: '◰' },
     ],
   },
   {

--- a/cloud/dashboard/src/components/layout/DashboardLayout.tsx
+++ b/cloud/dashboard/src/components/layout/DashboardLayout.tsx
@@ -161,6 +161,28 @@ function Header({ onMenuClick }: { onMenuClick: () => void }) {
   )
 }
 
+function LegalFooter() {
+  return (
+    <div className="mt-12 flex items-center justify-center gap-3 font-mono text-[10px] uppercase tracking-wider text-[var(--color-body)] opacity-50">
+      <Link
+        href="/legal/privacy"
+        className="transition-colors hover:text-[var(--color-accent-blue)] hover:opacity-100"
+      >
+        Privacy
+      </Link>
+      <span aria-hidden>·</span>
+      <Link
+        href="/legal/terms"
+        className="transition-colors hover:text-[var(--color-accent-blue)] hover:opacity-100"
+      >
+        Terms
+      </Link>
+      <span aria-hidden>·</span>
+      <span>© 2026 Gradata</span>
+    </div>
+  )
+}
+
 export function DashboardLayout({ children }: { children: React.ReactNode }) {
   const [mobileOpen, setMobileOpen] = useState(false)
   return (
@@ -170,7 +192,10 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
       <div className="flex flex-1 flex-col overflow-hidden">
         <Header onMenuClick={() => setMobileOpen(true)} />
         <main className="flex-1 overflow-y-auto p-4 md:p-8">
-          <div className="mx-auto max-w-[1280px]">{children}</div>
+          <div className="mx-auto max-w-[1280px]">
+            {children}
+            <LegalFooter />
+          </div>
         </main>
       </div>
     </div>

--- a/cloud/loadtest/README.md
+++ b/cloud/loadtest/README.md
@@ -1,0 +1,136 @@
+# Gradata Cloud — k6 Load Tests
+
+k6 load tests against the FastAPI backend deployed on Railway.
+
+Base URL (default): `https://gradata-production.up.railway.app`
+
+> `https://api.gradata.ai` is the intended custom domain, but SSL is
+> currently broken (Cloudflare orange-cloud blocks the Railway cert).
+> Point k6 at the Railway URL directly until that's fixed.
+
+---
+
+## Install k6
+
+```bash
+# macOS
+brew install k6
+
+# Windows
+scoop install k6
+
+# Docker
+docker pull grafana/k6:latest
+
+# Linux — see https://k6.io/docs/get-started/installation/
+```
+
+## Scenarios
+
+All scripts accept `BASE_URL` via `-e BASE_URL=...` (default:
+`https://gradata-production.up.railway.app`).
+
+| Script | Purpose | VUs | Duration | Auth | Nightly? |
+|---|---|---|---|---|---|
+| `k6/baseline.js` | Smoke test — public `/health` endpoints | 5 | 2m | No | Yes |
+| `k6/authed-read.js` | Dashboard read load (`/brains`, `/users/me`) | 25 (ramp) | 5m | Yes | No |
+| `k6/sync-write.js` | SDK write load (`POST /sync`) | 10 | 3m | Yes | No |
+| `k6/spike.js` | Burst traffic to verify rate limiting | 0→100 | 2m | No | Yes |
+
+### Run
+
+```bash
+cd cloud/loadtest
+
+# 1. Smoke (no auth, safe anywhere)
+k6 run k6/baseline.js
+
+# 2. Authed read — requires a real gd_* key for a TEST workspace
+K6_API_KEY=gd_xxx k6 run k6/authed-read.js
+
+# 3. Write load — ALSO writes rows, so use a throwaway test workspace
+K6_API_KEY=gd_xxx K6_BRAIN_NAME=k6-loadtest k6 run k6/sync-write.js
+
+# 4. Spike — no auth, OK on prod (/health is cheap)
+k6 run k6/spike.js
+
+# Override base URL for staging / local
+k6 run k6/baseline.js -e BASE_URL=http://localhost:8000
+
+# Docker (no local install)
+docker run --rm -v $(pwd)/k6:/scripts grafana/k6:latest run /scripts/baseline.js
+```
+
+### CI
+
+`.github/workflows/loadtest-nightly.yml` runs `baseline.js` + `spike.js`
+nightly at 03:00 UTC against production. Authed scenarios are opt-in via
+`workflow_dispatch` to avoid writing synthetic rows without coordination.
+
+---
+
+## SLOs
+
+| Scenario | p95 | Error rate | Notes |
+|---|---|---|---|
+| baseline | < 500ms | < 1% | Public, no auth. If this breaks, Railway is sick. |
+| authed-read | < 800ms | < 2% | Includes DB round-trip + auth validation. |
+| sync-write | < 1500ms | < 5% | Write path — slower by design. |
+| spike | p99 < 3s | **0% 5xx** | 429s are expected (SlowAPI). 5xx is a real bug. |
+
+### Reading k6 output
+
+```
+http_req_duration...: avg=120ms  min=42ms  med=105ms  max=2.1s  p(90)=190ms  p(95)=240ms
+http_req_failed.....: 0.12%   ✓ 2  ✗ 1643
+```
+
+- **p95 (95th percentile)**: 95% of requests completed faster than this.
+  The "worst case most users see." Main SLO gate.
+- **p99**: 1% of requests were slower than this. Watch for tail latency
+  regressions — a creeping p99 often means the DB is about to fall over.
+- **http_req_failed**: fraction of requests with a non-2xx/3xx status
+  *excluding* explicit `expect` overrides. A spike here usually means
+  connection errors or 5xx, not 404/429.
+- **checks**: logical assertions inside the script. These should be 100%.
+  If `checks` drops below `http_req_failed`, you have logic bugs, not
+  network ones.
+
+k6 exits 0 if all thresholds pass, non-zero otherwise. CI treats a
+non-zero exit as an SLO breach.
+
+---
+
+## Rollback playbook — deploy regressed SLOs
+
+1. **Confirm it's real.** Re-run the failing scenario against production.
+   Check the last 3 nightly runs in GitHub Actions to distinguish a
+   regression from a flake (one red run on a busy night ≠ broken deploy).
+2. **Identify the bad deploy.** Railway dashboard → Deployments → note
+   the commit SHA of the last green deploy.
+3. **Roll back.** In Railway: Deployments → pick the last green → ⋮ →
+   "Redeploy". This replays the known-good image; no git push needed.
+4. **Verify.** Re-run `baseline.js` and `spike.js` against prod. Both
+   should go green within ~60s of the redeploy finishing.
+5. **Fix forward.** Open a revert PR or a fix PR against `main`. The
+   nightly workflow will re-check once merged.
+
+### Sentry cross-check
+
+All 5xx responses during load tests land in Sentry (`gradata-cloud`
+project). If `spike.js` fails its "zero 5xx" SLO, check Sentry for the
+stack trace before assuming it's k6's fault.
+
+---
+
+## Safety notes
+
+- `sync-write.js` writes real rows. Use a dedicated test workspace — the
+  `brain_name` defaults to `k6-loadtest` so it's easy to filter/clean up
+  in Supabase.
+- `authed-read.js` and `sync-write.js` `fail()` cleanly if `K6_API_KEY`
+  is unset. Don't stub the key — a "silent pass" hides regressions.
+- The spike test is safe to run against production at any time; `/health`
+  is cheap and SlowAPI prevents overrun.
+- Rate limiting is keyed on client IP. If you're running from a shared
+  runner (GitHub Actions), expect 429s earlier than from a residential IP.

--- a/cloud/loadtest/k6/authed-read.js
+++ b/cloud/loadtest/k6/authed-read.js
@@ -1,0 +1,123 @@
+// authed-read.js — k6 authenticated read-heavy load test.
+//
+// 25 VUs for 5 minutes with a ramp, hitting /api/v1/brains and
+// /api/v1/users/me. Simulates a busy dashboard session.
+//
+// Requires K6_API_KEY (a real gd_* API key for a test workspace).
+// If unset, exits cleanly with a message — do NOT fake-pass.
+//
+// Run:
+//   K6_API_KEY=gd_xxx k6 run k6/authed-read.js
+//   K6_API_KEY=gd_xxx k6 run k6/authed-read.js -e BASE_URL=https://gradata-production.up.railway.app
+
+import http from 'k6/http';
+import { check, sleep, fail } from 'k6';
+import { Rate } from 'k6/metrics';
+
+const BASE_URL = __ENV.BASE_URL || 'https://gradata-production.up.railway.app';
+const API_KEY = __ENV.K6_API_KEY;
+
+const errorRate = new Rate('errors');
+
+export const options = {
+  // Ramp: 0 -> 25 over 1m, hold 25 for 3m, ramp down 25 -> 0 over 1m.
+  stages: [
+    { duration: '1m', target: 25 },
+    { duration: '3m', target: 25 },
+    { duration: '1m', target: 0 },
+  ],
+  thresholds: {
+    // SLO: p95 < 800ms, error rate < 2%. Auth adds a little latency.
+    http_req_duration: ['p(95)<800'],
+    http_req_failed: ['rate<0.02'],
+    errors: ['rate<0.02'],
+  },
+  tags: {
+    scenario: 'authed-read',
+  },
+};
+
+export function setup() {
+  if (!API_KEY) {
+    // Fail LOUD — don't let CI pretend this passed.
+    fail(
+      'K6_API_KEY is unset. Set K6_API_KEY=gd_... (a real API key from a test ' +
+        'workspace) to run authed-read.js. Refusing to run without auth.'
+    );
+  }
+  // Sanity check: make sure the key actually works before burning the full run.
+  const probe = http.get(`${BASE_URL}/api/v1/users/me`, {
+    headers: { Authorization: `Bearer ${API_KEY}` },
+    tags: { endpoint: 'setup_probe' },
+  });
+  if (probe.status !== 200) {
+    fail(
+      `Setup probe failed: GET /api/v1/users/me returned ${probe.status}. ` +
+        `Check K6_API_KEY is a valid gd_* key. Body: ${probe.body}`
+    );
+  }
+  return { baseUrl: BASE_URL };
+}
+
+export default function (data) {
+  const headers = {
+    Authorization: `Bearer ${API_KEY}`,
+    'Content-Type': 'application/json',
+  };
+
+  // 70/30 split: brains list is the hotter endpoint in real usage.
+  const pickBrains = Math.random() < 0.7;
+
+  if (pickBrains) {
+    const res = http.get(`${data.baseUrl}/api/v1/brains`, {
+      headers,
+      tags: { endpoint: 'brains_list' },
+    });
+    const ok = check(res, {
+      '/brains 200': (r) => r.status === 200,
+      '/brains returns array': (r) => {
+        try {
+          return Array.isArray(r.json());
+        } catch (_e) {
+          return false;
+        }
+      },
+    });
+    errorRate.add(!ok);
+  } else {
+    const res = http.get(`${data.baseUrl}/api/v1/users/me`, {
+      headers,
+      tags: { endpoint: 'users_me' },
+    });
+    const ok = check(res, {
+      '/users/me 200': (r) => r.status === 200,
+      '/users/me has user_id': (r) => {
+        try {
+          return typeof r.json('user_id') === 'string';
+        } catch (_e) {
+          return false;
+        }
+      },
+    });
+    errorRate.add(!ok);
+  }
+
+  // Think time between requests — real dashboards don't hammer 24/7.
+  sleep(Math.random() * 2 + 0.5);
+}
+
+export function handleSummary(data) {
+  const m = data.metrics;
+  const p95 = m.http_req_duration ? m.http_req_duration.values['p(95)'] : 'n/a';
+  const p99 = m.http_req_duration ? m.http_req_duration.values['p(99)'] : 'n/a';
+  const failed = m.http_req_failed ? m.http_req_failed.values.rate : 'n/a';
+  return {
+    stdout: `
+authed-read.js summary
+----------------------
+http_req_duration  p95=${p95}ms  p99=${p99}ms
+http_req_failed    rate=${failed}
+SLO: p95<800ms, error_rate<2%
+`,
+  };
+}

--- a/cloud/loadtest/k6/baseline.js
+++ b/cloud/loadtest/k6/baseline.js
@@ -1,0 +1,83 @@
+// baseline.js — k6 smoke test for the Gradata cloud backend.
+//
+// 5 VUs for 2 minutes hitting public, unauthenticated endpoints.
+// Used as a canary: if this fails, something is fundamentally wrong.
+//
+// Run:
+//   k6 run k6/baseline.js
+//   k6 run k6/baseline.js -e BASE_URL=https://gradata-production.up.railway.app
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate } from 'k6/metrics';
+
+const BASE_URL = __ENV.BASE_URL || 'https://gradata-production.up.railway.app';
+
+const errorRate = new Rate('errors');
+
+export const options = {
+  vus: 5,
+  duration: '2m',
+  thresholds: {
+    // SLO: p95 latency under 500ms, error rate under 1%
+    http_req_duration: ['p(95)<500'],
+    http_req_failed: ['rate<0.01'],
+    errors: ['rate<0.01'],
+  },
+  tags: {
+    scenario: 'baseline',
+  },
+};
+
+export default function () {
+  // Primary: root /health (always present, no auth, cheap)
+  const healthRes = http.get(`${BASE_URL}/health`, {
+    tags: { endpoint: 'health' },
+  });
+
+  const healthOk = check(healthRes, {
+    '/health status is 200': (r) => r.status === 200,
+    '/health body has status field': (r) => {
+      try {
+        return r.json('status') === 'healthy';
+      } catch (_e) {
+        return false;
+      }
+    },
+  });
+  errorRate.add(!healthOk);
+
+  // Secondary: try /api/v1/health (may 404 — that's fine, we just want to
+  // confirm the router is reachable). We don't assert 200 here since the
+  // backend doesn't currently expose this path.
+  const apiHealthRes = http.get(`${BASE_URL}/api/v1/health`, {
+    tags: { endpoint: 'api_health' },
+  });
+  check(apiHealthRes, {
+    '/api/v1/health responds (any status)': (r) => r.status > 0,
+    '/api/v1/health not 5xx': (r) => r.status < 500,
+  });
+
+  sleep(1);
+}
+
+export function handleSummary(data) {
+  return {
+    stdout: textSummary(data),
+  };
+}
+
+// Minimal text summary — avoids k6/x/jslib dep for portability.
+function textSummary(data) {
+  const m = data.metrics;
+  const p95 = m.http_req_duration ? m.http_req_duration.values['p(95)'] : 'n/a';
+  const p99 = m.http_req_duration ? m.http_req_duration.values['p(99)'] : 'n/a';
+  const failed = m.http_req_failed ? m.http_req_failed.values.rate : 'n/a';
+  return `
+baseline.js summary
+-------------------
+http_req_duration  p95=${p95}ms  p99=${p99}ms
+http_req_failed    rate=${failed}
+SLO: p95<500ms, error_rate<1%
+`;
+}

--- a/cloud/loadtest/k6/spike.js
+++ b/cloud/loadtest/k6/spike.js
@@ -1,0 +1,75 @@
+// spike.js — k6 spike test against /health.
+//
+// 0 -> 100 VUs over 30s, hold 1m, ramp down 30s. Pounds /health to verify
+// SlowAPI rate limiting kicks in (429s expected and fine) and that the
+// backend never returns 5xx under load.
+//
+// Run:
+//   k6 run k6/spike.js
+//   k6 run k6/spike.js -e BASE_URL=https://gradata-production.up.railway.app
+
+import http from 'k6/http';
+import { check } from 'k6';
+import { Rate, Counter } from 'k6/metrics';
+
+const BASE_URL = __ENV.BASE_URL || 'https://gradata-production.up.railway.app';
+
+const fiveXX = new Rate('five_xx_rate');
+const rateLimited = new Counter('rate_limited_429');
+const successes = new Counter('success_200');
+
+export const options = {
+  stages: [
+    { duration: '30s', target: 100 },
+    { duration: '1m', target: 100 },
+    { duration: '30s', target: 0 },
+  ],
+  thresholds: {
+    // The ONLY hard SLO: zero 5xx. SlowAPI should return 429, never 500.
+    five_xx_rate: ['rate==0'],
+    // Keep an eye on p99 but don't fail on it — spike tests expect slow tails.
+    http_req_duration: ['p(99)<3000'],
+  },
+  tags: {
+    scenario: 'spike',
+  },
+};
+
+export default function () {
+  const res = http.get(`${BASE_URL}/health`, {
+    tags: { endpoint: 'health_spike' },
+  });
+
+  // Classify — 200 is good, 429 is expected (rate limited), 5xx is BAD.
+  const is5xx = res.status >= 500;
+  fiveXX.add(is5xx);
+  if (res.status === 429) rateLimited.add(1);
+  if (res.status === 200) successes.add(1);
+
+  check(res, {
+    'no 5xx response': (r) => r.status < 500,
+    'status is 200 or 429': (r) => r.status === 200 || r.status === 429,
+  });
+}
+
+export function handleSummary(data) {
+  const m = data.metrics;
+  const p95 = m.http_req_duration ? m.http_req_duration.values['p(95)'] : 'n/a';
+  const p99 = m.http_req_duration ? m.http_req_duration.values['p(99)'] : 'n/a';
+  const total = m.http_reqs ? m.http_reqs.values.count : 0;
+  const ok = m.success_200 ? m.success_200.values.count : 0;
+  const rl = m.rate_limited_429 ? m.rate_limited_429.values.count : 0;
+  const bad = m.five_xx_rate ? m.five_xx_rate.values.rate : 'n/a';
+  return {
+    stdout: `
+spike.js summary
+----------------
+total_requests  ${total}
+200 OK          ${ok}
+429 rate_limit  ${rl}
+5xx rate        ${bad}  (SLO: must be 0)
+http_req_dur    p95=${p95}ms  p99=${p99}ms
+SLO: zero 5xx (429s are expected — SlowAPI rate limiting working).
+`,
+  };
+}

--- a/cloud/loadtest/k6/sync-write.js
+++ b/cloud/loadtest/k6/sync-write.js
@@ -1,0 +1,130 @@
+// sync-write.js — k6 write load test against POST /api/v1/sync.
+//
+// 10 VUs for 3 minutes sending small synthetic correction + event payloads
+// in the shape the SDK uses when GRADATA_API_KEY is set (see
+// cloud/app/models.py::SyncRequest).
+//
+// Requires K6_API_KEY (a gd_* API key for a TEST workspace — writes land
+// in the DB!). If unset, exits cleanly — do NOT fake-pass.
+//
+// Run:
+//   K6_API_KEY=gd_xxx k6 run k6/sync-write.js
+
+import http from 'k6/http';
+import { check, sleep, fail } from 'k6';
+import { Rate } from 'k6/metrics';
+
+const BASE_URL = __ENV.BASE_URL || 'https://gradata-production.up.railway.app';
+const API_KEY = __ENV.K6_API_KEY;
+const BRAIN_NAME = __ENV.K6_BRAIN_NAME || 'k6-loadtest';
+
+const errorRate = new Rate('errors');
+
+export const options = {
+  vus: 10,
+  duration: '3m',
+  thresholds: {
+    // SLO: writes are slower, allow p95<1500ms and error_rate<5%.
+    http_req_duration: ['p(95)<1500'],
+    http_req_failed: ['rate<0.05'],
+    errors: ['rate<0.05'],
+  },
+  tags: {
+    scenario: 'sync-write',
+  },
+};
+
+export function setup() {
+  if (!API_KEY) {
+    fail(
+      'K6_API_KEY is unset. Set K6_API_KEY=gd_... (from a TEST workspace — ' +
+        'this test writes rows!) to run sync-write.js. Refusing to run.'
+    );
+  }
+  return { baseUrl: BASE_URL };
+}
+
+// Generate a small-but-realistic SyncRequest payload.
+// Matches cloud/app/models.py::SyncRequest.
+function buildPayload(vu, iter) {
+  const now = new Date().toISOString();
+  const session = Math.floor(Math.random() * 10000) + 1;
+  return {
+    brain_name: BRAIN_NAME,
+    corrections: [
+      {
+        session,
+        category: 'LOADTEST',
+        severity: 'minor',
+        description: `k6 synthetic correction vu=${vu} iter=${iter}`,
+        draft_preview: 'draft text',
+        final_preview: 'final text',
+        created_at: now,
+      },
+    ],
+    lessons: [],
+    events: [
+      {
+        type: 'loadtest.ping',
+        source: 'k6',
+        data: { vu, iter, ts: now },
+        tags: ['loadtest', 'k6'],
+        session,
+        created_at: now,
+      },
+    ],
+    meta_rules: [],
+    manifest: { source: 'k6-loadtest', version: '1' },
+  };
+}
+
+export default function (data) {
+  const headers = {
+    Authorization: `Bearer ${API_KEY}`,
+    'Content-Type': 'application/json',
+  };
+
+  const payload = JSON.stringify(buildPayload(__VU, __ITER));
+  const res = http.post(`${data.baseUrl}/api/v1/sync`, payload, {
+    headers,
+    tags: { endpoint: 'sync' },
+  });
+
+  const ok = check(res, {
+    '/sync 200': (r) => r.status === 200,
+    '/sync status=ok': (r) => {
+      try {
+        return r.json('status') === 'ok';
+      } catch (_e) {
+        return false;
+      }
+    },
+    '/sync counts present': (r) => {
+      try {
+        return typeof r.json('corrections_synced') === 'number';
+      } catch (_e) {
+        return false;
+      }
+    },
+  });
+  errorRate.add(!ok);
+
+  // Small think time — SDK syncs are not back-to-back in real usage.
+  sleep(Math.random() * 1 + 0.2);
+}
+
+export function handleSummary(data) {
+  const m = data.metrics;
+  const p95 = m.http_req_duration ? m.http_req_duration.values['p(95)'] : 'n/a';
+  const p99 = m.http_req_duration ? m.http_req_duration.values['p(99)'] : 'n/a';
+  const failed = m.http_req_failed ? m.http_req_failed.values.rate : 'n/a';
+  return {
+    stdout: `
+sync-write.js summary
+---------------------
+http_req_duration  p95=${p95}ms  p99=${p99}ms
+http_req_failed    rate=${failed}
+SLO: p95<1500ms, error_rate<5%
+`,
+  };
+}

--- a/cloud/migrations/002_notification_prefs.sql
+++ b/cloud/migrations/002_notification_prefs.sql
@@ -1,0 +1,14 @@
+-- 002_notification_prefs.sql
+-- Adds notification_prefs JSONB column to workspace_members so users can
+-- persist alert toggles and digest cadence from the dashboard.
+
+ALTER TABLE workspace_members
+  ADD COLUMN IF NOT EXISTS notification_prefs JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+-- Index on the cadence key — used by the future digest scheduler to fetch
+-- "all users with digest_cadence = 'weekly'" without a full table scan.
+CREATE INDEX IF NOT EXISTS idx_workspace_members_digest_cadence
+  ON workspace_members ((notification_prefs->>'digest_cadence'));
+
+COMMENT ON COLUMN workspace_members.notification_prefs IS
+  'Notification preferences shape: { alert_correction_spike, alert_rule_regression, alert_meta_rule_emerged, digest_cadence, digest_email, slack_webhook }';

--- a/cloud/supabase/email-templates/README.md
+++ b/cloud/supabase/email-templates/README.md
@@ -1,0 +1,45 @@
+# Gradata Supabase Email Templates
+
+Branded V3 Dark Cinematic email templates for Supabase Auth. Email-client-safe (inline CSS, table layout, no external fonts, no JS, no background images).
+
+Sender: `Gradata <noreply@gradata.ai>`
+Theme: dark `#0C1120` background, `#F8FAFC` text, CTA gradient `#3A82FF → #7C3AED`.
+
+## Templates
+
+| File | Supabase template | Subject line | Variables used |
+|---|---|---|---|
+| `confirm-signup.html` | **Confirm signup** | `Confirm your Gradata account` | `{{ .ConfirmationURL }}` |
+| `magic-link.html` | **Magic Link** | `Sign in to Gradata` | `{{ .ConfirmationURL }}`, `{{ .Email }}` |
+| `change-email.html` | **Change Email Address** | `Confirm your new email` | `{{ .ConfirmationURL }}`, `{{ .Email }}` |
+| `reset-password.html` | **Reset Password** | `Reset your Gradata password` | `{{ .ConfirmationURL }}`, `{{ .Email }}` |
+| `invite-user.html` | **Invite user** | `You've been invited to a Gradata workspace` | `{{ .ConfirmationURL }}`, `{{ .Email }}`, `{{ .Role }}`, `{{ .InvitedAt }}` |
+| `reauthentication.html` | **Reauthentication** | `Confirm it's you` | `{{ .Token }}`, `{{ .ConfirmationURL }}`, `{{ .Email }}` |
+
+> `{{ .Role }}` and `{{ .InvitedAt }}` require passing `role` and `invited_at` in the invite metadata (`supabase.auth.admin.inviteUserByEmail(email, { data: { role: 'admin' } })`). If omitted, they render blank — the template still reads cleanly.
+
+## How to install (5 steps)
+
+1. **Open Supabase dashboard** → project → **Authentication** → **Email Templates**.
+2. **Set sender** under *Authentication* → *Email* → SMTP settings. Set *Sender name* to `Gradata` and *Sender email* to `noreply@gradata.ai`.
+3. **For each template above**: click the template name, paste the **Subject line** from the table, then paste the full HTML body from the corresponding file in this directory. Keep `{{ .ConfirmationURL }}` and other `{{ .Variable }}` tokens literal — Supabase substitutes them at send time.
+4. **Save** each template. Supabase renders a live preview — confirm the dark gradient button shows with white text.
+5. **Test** by triggering each flow (sign up a throwaway email, request a magic link, reset a password, invite a teammate, run a sensitive action that triggers reauthentication). Check Gmail, Outlook, and Apple Mail — all three render the table layout consistently.
+
+## Preview locally
+
+Open any `.html` file directly in a browser. The `{{ ... }}` tokens show literally — that's expected; Supabase replaces them at send time.
+
+## Design notes
+
+- **Layout**: nested `<table>` elements only (Outlook-safe). Max width 560px.
+- **CSS**: all inline (Gmail strips `<style>` tags).
+- **Font stack**: `system-ui` — no external font loading.
+- **CTA button**: gradient background set on a `<td>` wrapper so clients that strip anchor backgrounds still show color. Minimum 140px wide, 12px vertical padding.
+- **Fallback link**: bare URL in monospace below each button so the email works even if the button fails to render.
+- **Dark mode**: uses explicit `#0C1120` / `#F8FAFC` rather than CSS variables. Some clients (Outlook, older iOS Mail) force light mode — the template reads fine on light backgrounds too because button color and text contrast are absolute.
+- **No images**: Gmail blocks remote images by default. The Gradata wordmark is rendered as styled text.
+
+## Updating templates
+
+Edit the HTML file, then re-paste into Supabase. Keep each file under 250 lines — these are transactional emails, not marketing.

--- a/cloud/supabase/email-templates/change-email.html
+++ b/cloud/supabase/email-templates/change-email.html
@@ -1,0 +1,96 @@
+<!-- Subject: Confirm your new email -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta name="color-scheme" content="dark light" />
+    <meta name="supported-color-schemes" content="dark light" />
+    <title>Confirm your new email</title>
+  </head>
+  <body style="margin:0;padding:0;background:#0C1120;color:#F8FAFC;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,system-ui,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#0C1120;padding:32px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;width:100%;background:#10172A;border:1px solid #1F2937;border-radius:14px;overflow:hidden;">
+            <tr>
+              <td style="padding:28px 32px 8px 32px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td align="left">
+                      <span style="display:inline-block;font-weight:700;font-size:18px;letter-spacing:-0.01em;color:#F8FAFC;">
+                        <span style="background:linear-gradient(135deg,#3A82FF,#7C3AED);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;color:#7C3AED;">Gradata</span>
+                      </span>
+                    </td>
+                    <td align="right" style="font-size:12px;color:#94A3B8;">Email change</td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:16px 32px 8px 32px;">
+                <h1 style="margin:16px 0 12px 0;font-size:24px;line-height:1.25;font-weight:700;color:#F8FAFC;letter-spacing:-0.01em;">Confirm your new email</h1>
+                <p style="margin:0 0 12px 0;font-size:15px;line-height:1.6;color:#CBD5E1;">
+                  You requested to change your Gradata login to <span style="color:#F8FAFC;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;">{{ .Email }}</span>. Confirm below to finish the switch.
+                </p>
+                <p style="margin:0 0 16px 0;font-size:13px;line-height:1.6;color:#94A3B8;">
+                  Until you confirm, your old email stays active. This link expires in 24 hours.
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td align="center" style="padding:16px 32px 8px 32px;">
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td align="center" style="border-radius:10px;background:linear-gradient(135deg,#3A82FF,#7C3AED);">
+                      <a href="{{ .ConfirmationURL }}"
+                         style="display:inline-block;padding:12px 28px;font-size:15px;font-weight:600;color:#FFFFFF;text-decoration:none;border-radius:10px;min-width:160px;text-align:center;">
+                        Confirm new email
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:16px 32px 8px 32px;">
+                <p style="margin:0 0 6px 0;font-size:12px;color:#94A3B8;">
+                  Or paste this URL into your browser:
+                </p>
+                <p style="margin:0;font-size:12px;line-height:1.5;color:#7C3AED;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;word-break:break-all;">
+                  <a href="{{ .ConfirmationURL }}" style="color:#7C3AED;text-decoration:underline;">{{ .ConfirmationURL }}</a>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:20px 32px 24px 32px;">
+                <p style="margin:0;font-size:12px;color:#64748B;font-style:italic;">
+                  Mem0 remembers. Gradata learns.
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:16px 32px 28px 32px;border-top:1px solid #1F2937;">
+                <p style="margin:0 0 6px 0;font-size:11px;line-height:1.6;color:#64748B;opacity:0.85;">
+                  Didn't request this? Ignore this email and your login stays the same.
+                </p>
+                <p style="margin:8px 0 0 0;font-size:11px;line-height:1.6;color:#64748B;opacity:0.85;">
+                  <a href="https://app.gradata.ai/legal/privacy" style="color:#94A3B8;text-decoration:underline;">Privacy</a>
+                  &nbsp;&middot;&nbsp;
+                  <a href="https://app.gradata.ai/legal/terms" style="color:#94A3B8;text-decoration:underline;">Terms</a>
+                  &nbsp;&middot;&nbsp;
+                  &copy; 2026 Gradata
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/cloud/supabase/email-templates/confirm-signup.html
+++ b/cloud/supabase/email-templates/confirm-signup.html
@@ -1,0 +1,99 @@
+<!-- Subject: Confirm your Gradata account -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta name="color-scheme" content="dark light" />
+    <meta name="supported-color-schemes" content="dark light" />
+    <title>Confirm your Gradata account</title>
+  </head>
+  <body style="margin:0;padding:0;background:#0C1120;color:#F8FAFC;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,system-ui,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#0C1120;padding:32px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;width:100%;background:#10172A;border:1px solid #1F2937;border-radius:14px;overflow:hidden;">
+            <!-- Header -->
+            <tr>
+              <td style="padding:28px 32px 8px 32px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td align="left">
+                      <span style="display:inline-block;font-weight:700;font-size:18px;letter-spacing:-0.01em;color:#F8FAFC;">
+                        <span style="background:linear-gradient(135deg,#3A82FF,#7C3AED);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;color:#7C3AED;">Gradata</span>
+                      </span>
+                    </td>
+                    <td align="right" style="font-size:12px;color:#94A3B8;">AI memory layer</td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <!-- Body -->
+            <tr>
+              <td style="padding:16px 32px 8px 32px;">
+                <h1 style="margin:16px 0 12px 0;font-size:24px;line-height:1.25;font-weight:700;color:#F8FAFC;letter-spacing:-0.01em;">Confirm your Gradata account</h1>
+                <p style="margin:0 0 16px 0;font-size:15px;line-height:1.6;color:#CBD5E1;">
+                  Confirm your email so we can sync your brain across devices. This link expires in 24 hours.
+                </p>
+              </td>
+            </tr>
+
+            <!-- CTA -->
+            <tr>
+              <td align="center" style="padding:16px 32px 8px 32px;">
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td align="center" style="border-radius:10px;background:linear-gradient(135deg,#3A82FF,#7C3AED);">
+                      <a href="{{ .ConfirmationURL }}"
+                         style="display:inline-block;padding:12px 28px;font-size:15px;font-weight:600;color:#FFFFFF;text-decoration:none;border-radius:10px;min-width:140px;text-align:center;">
+                        Confirm account
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <!-- Plain link fallback -->
+            <tr>
+              <td style="padding:16px 32px 8px 32px;">
+                <p style="margin:0 0 6px 0;font-size:12px;color:#94A3B8;">
+                  Or paste this URL into your browser:
+                </p>
+                <p style="margin:0;font-size:12px;line-height:1.5;color:#7C3AED;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;word-break:break-all;">
+                  <a href="{{ .ConfirmationURL }}" style="color:#7C3AED;text-decoration:underline;">{{ .ConfirmationURL }}</a>
+                </p>
+              </td>
+            </tr>
+
+            <!-- Tagline strip -->
+            <tr>
+              <td style="padding:20px 32px 24px 32px;">
+                <p style="margin:0;font-size:12px;color:#64748B;font-style:italic;">
+                  Mem0 remembers. Gradata learns.
+                </p>
+              </td>
+            </tr>
+
+            <!-- Footer -->
+            <tr>
+              <td style="padding:16px 32px 28px 32px;border-top:1px solid #1F2937;">
+                <p style="margin:0 0 6px 0;font-size:11px;line-height:1.6;color:#64748B;opacity:0.85;">
+                  Didn't request this? You can safely ignore this email. Nothing will change on your account.
+                </p>
+                <p style="margin:8px 0 0 0;font-size:11px;line-height:1.6;color:#64748B;opacity:0.85;">
+                  <a href="https://app.gradata.ai/legal/privacy" style="color:#94A3B8;text-decoration:underline;">Privacy</a>
+                  &nbsp;&middot;&nbsp;
+                  <a href="https://app.gradata.ai/legal/terms" style="color:#94A3B8;text-decoration:underline;">Terms</a>
+                  &nbsp;&middot;&nbsp;
+                  &copy; 2026 Gradata
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/cloud/supabase/email-templates/invite-user.html
+++ b/cloud/supabase/email-templates/invite-user.html
@@ -1,0 +1,104 @@
+<!-- Subject: You've been invited to a Gradata workspace -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta name="color-scheme" content="dark light" />
+    <meta name="supported-color-schemes" content="dark light" />
+    <title>You've been invited to a Gradata workspace</title>
+  </head>
+  <body style="margin:0;padding:0;background:#0C1120;color:#F8FAFC;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,system-ui,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#0C1120;padding:32px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;width:100%;background:#10172A;border:1px solid #1F2937;border-radius:14px;overflow:hidden;">
+            <tr>
+              <td style="padding:28px 32px 8px 32px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td align="left">
+                      <span style="display:inline-block;font-weight:700;font-size:18px;letter-spacing:-0.01em;color:#F8FAFC;">
+                        <span style="background:linear-gradient(135deg,#3A82FF,#7C3AED);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;color:#7C3AED;">Gradata</span>
+                      </span>
+                    </td>
+                    <td align="right" style="font-size:12px;color:#94A3B8;">Workspace invite</td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:16px 32px 8px 32px;">
+                <h1 style="margin:16px 0 12px 0;font-size:24px;line-height:1.25;font-weight:700;color:#F8FAFC;letter-spacing:-0.01em;">You've been invited to a Gradata workspace</h1>
+                <p style="margin:0 0 12px 0;font-size:15px;line-height:1.6;color:#CBD5E1;">
+                  You've been added as <span style="color:#F8FAFC;font-weight:600;">{{ .Role }}</span> on a Gradata workspace. Accept the invite to start syncing corrections and memory with your team.
+                </p>
+                <p style="margin:0 0 16px 0;font-size:13px;line-height:1.6;color:#94A3B8;">
+                  Invite sent <span style="color:#CBD5E1;">{{ .InvitedAt }}</span>. It expires in 7 days.
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td align="center" style="padding:16px 32px 8px 32px;">
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td align="center" style="border-radius:10px;background:linear-gradient(135deg,#3A82FF,#7C3AED);">
+                      <a href="{{ .ConfirmationURL }}"
+                         style="display:inline-block;padding:12px 28px;font-size:15px;font-weight:600;color:#FFFFFF;text-decoration:none;border-radius:10px;min-width:140px;text-align:center;">
+                        Accept invite
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:16px 32px 8px 32px;">
+                <p style="margin:0 0 6px 0;font-size:12px;color:#94A3B8;">
+                  Or paste this URL into your browser:
+                </p>
+                <p style="margin:0;font-size:12px;line-height:1.5;color:#7C3AED;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;word-break:break-all;">
+                  <a href="{{ .ConfirmationURL }}" style="color:#7C3AED;text-decoration:underline;">{{ .ConfirmationURL }}</a>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:16px 32px 8px 32px;">
+                <p style="margin:8px 0 0 0;font-size:12px;line-height:1.6;color:#94A3B8;">
+                  Invite addressed to <span style="color:#CBD5E1;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;">{{ .Email }}</span>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:20px 32px 24px 32px;">
+                <p style="margin:0;font-size:12px;color:#64748B;font-style:italic;">
+                  Mem0 remembers. Gradata learns.
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:16px 32px 28px 32px;border-top:1px solid #1F2937;">
+                <p style="margin:0 0 6px 0;font-size:11px;line-height:1.6;color:#64748B;opacity:0.85;">
+                  Don't recognize this? Ignore this email and no account will be created.
+                </p>
+                <p style="margin:8px 0 0 0;font-size:11px;line-height:1.6;color:#64748B;opacity:0.85;">
+                  <a href="https://app.gradata.ai/legal/privacy" style="color:#94A3B8;text-decoration:underline;">Privacy</a>
+                  &nbsp;&middot;&nbsp;
+                  <a href="https://app.gradata.ai/legal/terms" style="color:#94A3B8;text-decoration:underline;">Terms</a>
+                  &nbsp;&middot;&nbsp;
+                  &copy; 2026 Gradata
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/cloud/supabase/email-templates/magic-link.html
+++ b/cloud/supabase/email-templates/magic-link.html
@@ -1,0 +1,101 @@
+<!-- Subject: Sign in to Gradata -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta name="color-scheme" content="dark light" />
+    <meta name="supported-color-schemes" content="dark light" />
+    <title>Sign in to Gradata</title>
+  </head>
+  <body style="margin:0;padding:0;background:#0C1120;color:#F8FAFC;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,system-ui,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#0C1120;padding:32px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;width:100%;background:#10172A;border:1px solid #1F2937;border-radius:14px;overflow:hidden;">
+            <tr>
+              <td style="padding:28px 32px 8px 32px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td align="left">
+                      <span style="display:inline-block;font-weight:700;font-size:18px;letter-spacing:-0.01em;color:#F8FAFC;">
+                        <span style="background:linear-gradient(135deg,#3A82FF,#7C3AED);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;color:#7C3AED;">Gradata</span>
+                      </span>
+                    </td>
+                    <td align="right" style="font-size:12px;color:#94A3B8;">Sign-in link</td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:16px 32px 8px 32px;">
+                <h1 style="margin:16px 0 12px 0;font-size:24px;line-height:1.25;font-weight:700;color:#F8FAFC;letter-spacing:-0.01em;">Sign in to Gradata</h1>
+                <p style="margin:0 0 16px 0;font-size:15px;line-height:1.6;color:#CBD5E1;">
+                  Click the button to sign in. The link expires in 1 hour and only works once.
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td align="center" style="padding:16px 32px 8px 32px;">
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td align="center" style="border-radius:10px;background:linear-gradient(135deg,#3A82FF,#7C3AED);">
+                      <a href="{{ .ConfirmationURL }}"
+                         style="display:inline-block;padding:12px 28px;font-size:15px;font-weight:600;color:#FFFFFF;text-decoration:none;border-radius:10px;min-width:140px;text-align:center;">
+                        Sign in
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:16px 32px 8px 32px;">
+                <p style="margin:0 0 6px 0;font-size:12px;color:#94A3B8;">
+                  Or paste this URL into your browser:
+                </p>
+                <p style="margin:0;font-size:12px;line-height:1.5;color:#7C3AED;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;word-break:break-all;">
+                  <a href="{{ .ConfirmationURL }}" style="color:#7C3AED;text-decoration:underline;">{{ .ConfirmationURL }}</a>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:16px 32px 8px 32px;">
+                <p style="margin:8px 0 0 0;font-size:12px;line-height:1.6;color:#94A3B8;">
+                  Requested for <span style="color:#CBD5E1;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;">{{ .Email }}</span>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:20px 32px 24px 32px;">
+                <p style="margin:0;font-size:12px;color:#64748B;font-style:italic;">
+                  Mem0 remembers. Gradata learns.
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:16px 32px 28px 32px;border-top:1px solid #1F2937;">
+                <p style="margin:0 0 6px 0;font-size:11px;line-height:1.6;color:#64748B;opacity:0.85;">
+                  Didn't request this? Ignore this email — no one can sign in without the link.
+                </p>
+                <p style="margin:8px 0 0 0;font-size:11px;line-height:1.6;color:#64748B;opacity:0.85;">
+                  <a href="https://app.gradata.ai/legal/privacy" style="color:#94A3B8;text-decoration:underline;">Privacy</a>
+                  &nbsp;&middot;&nbsp;
+                  <a href="https://app.gradata.ai/legal/terms" style="color:#94A3B8;text-decoration:underline;">Terms</a>
+                  &nbsp;&middot;&nbsp;
+                  &copy; 2026 Gradata
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/cloud/supabase/email-templates/reauthentication.html
+++ b/cloud/supabase/email-templates/reauthentication.html
@@ -1,0 +1,117 @@
+<!-- Subject: Confirm it's you -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta name="color-scheme" content="dark light" />
+    <meta name="supported-color-schemes" content="dark light" />
+    <title>Confirm it's you</title>
+  </head>
+  <body style="margin:0;padding:0;background:#0C1120;color:#F8FAFC;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,system-ui,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#0C1120;padding:32px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;width:100%;background:#10172A;border:1px solid #1F2937;border-radius:14px;overflow:hidden;">
+            <tr>
+              <td style="padding:28px 32px 8px 32px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td align="left">
+                      <span style="display:inline-block;font-weight:700;font-size:18px;letter-spacing:-0.01em;color:#F8FAFC;">
+                        <span style="background:linear-gradient(135deg,#3A82FF,#7C3AED);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;color:#7C3AED;">Gradata</span>
+                      </span>
+                    </td>
+                    <td align="right" style="font-size:12px;color:#94A3B8;">Security check</td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:16px 32px 8px 32px;">
+                <h1 style="margin:16px 0 12px 0;font-size:24px;line-height:1.25;font-weight:700;color:#F8FAFC;letter-spacing:-0.01em;">Confirm it's you</h1>
+                <p style="margin:0 0 16px 0;font-size:15px;line-height:1.6;color:#CBD5E1;">
+                  A sensitive action was requested on your Gradata account. Enter this code to confirm. It expires in 10 minutes.
+                </p>
+              </td>
+            </tr>
+
+            <!-- OTP code block -->
+            <tr>
+              <td align="center" style="padding:8px 32px 8px 32px;">
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="background:#0C1120;border:1px solid #1F2937;border-radius:12px;">
+                  <tr>
+                    <td align="center" style="padding:20px 36px;">
+                      <div style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:32px;font-weight:700;letter-spacing:0.3em;color:#F8FAFC;">
+                        {{ .Token }}
+                      </div>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <tr>
+              <td align="center" style="padding:16px 32px 8px 32px;">
+                <p style="margin:0 0 12px 0;font-size:12px;color:#94A3B8;">Or confirm with one click:</p>
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td align="center" style="border-radius:10px;background:linear-gradient(135deg,#3A82FF,#7C3AED);">
+                      <a href="{{ .ConfirmationURL }}"
+                         style="display:inline-block;padding:12px 28px;font-size:15px;font-weight:600;color:#FFFFFF;text-decoration:none;border-radius:10px;min-width:140px;text-align:center;">
+                        Confirm
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:16px 32px 8px 32px;">
+                <p style="margin:0 0 6px 0;font-size:12px;color:#94A3B8;">
+                  Or paste this URL into your browser:
+                </p>
+                <p style="margin:0;font-size:12px;line-height:1.5;color:#7C3AED;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;word-break:break-all;">
+                  <a href="{{ .ConfirmationURL }}" style="color:#7C3AED;text-decoration:underline;">{{ .ConfirmationURL }}</a>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:16px 32px 8px 32px;">
+                <p style="margin:8px 0 0 0;font-size:12px;line-height:1.6;color:#94A3B8;">
+                  Requested for <span style="color:#CBD5E1;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;">{{ .Email }}</span>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:20px 32px 24px 32px;">
+                <p style="margin:0;font-size:12px;color:#64748B;font-style:italic;">
+                  Mem0 remembers. Gradata learns.
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:16px 32px 28px 32px;border-top:1px solid #1F2937;">
+                <p style="margin:0 0 6px 0;font-size:11px;line-height:1.6;color:#64748B;opacity:0.85;">
+                  Didn't request this? Ignore this email and consider changing your password at <a href="https://app.gradata.ai" style="color:#94A3B8;text-decoration:underline;">app.gradata.ai</a>.
+                </p>
+                <p style="margin:8px 0 0 0;font-size:11px;line-height:1.6;color:#64748B;opacity:0.85;">
+                  <a href="https://app.gradata.ai/legal/privacy" style="color:#94A3B8;text-decoration:underline;">Privacy</a>
+                  &nbsp;&middot;&nbsp;
+                  <a href="https://app.gradata.ai/legal/terms" style="color:#94A3B8;text-decoration:underline;">Terms</a>
+                  &nbsp;&middot;&nbsp;
+                  &copy; 2026 Gradata
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/cloud/supabase/email-templates/reset-password.html
+++ b/cloud/supabase/email-templates/reset-password.html
@@ -1,0 +1,104 @@
+<!-- Subject: Reset your Gradata password -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta name="color-scheme" content="dark light" />
+    <meta name="supported-color-schemes" content="dark light" />
+    <title>Reset your Gradata password</title>
+  </head>
+  <body style="margin:0;padding:0;background:#0C1120;color:#F8FAFC;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,system-ui,sans-serif;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#0C1120;padding:32px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="560" cellpadding="0" cellspacing="0" border="0" style="max-width:560px;width:100%;background:#10172A;border:1px solid #1F2937;border-radius:14px;overflow:hidden;">
+            <tr>
+              <td style="padding:28px 32px 8px 32px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td align="left">
+                      <span style="display:inline-block;font-weight:700;font-size:18px;letter-spacing:-0.01em;color:#F8FAFC;">
+                        <span style="background:linear-gradient(135deg,#3A82FF,#7C3AED);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;color:#7C3AED;">Gradata</span>
+                      </span>
+                    </td>
+                    <td align="right" style="font-size:12px;color:#94A3B8;">Password reset</td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:16px 32px 8px 32px;">
+                <h1 style="margin:16px 0 12px 0;font-size:24px;line-height:1.25;font-weight:700;color:#F8FAFC;letter-spacing:-0.01em;">Reset your password</h1>
+                <p style="margin:0 0 12px 0;font-size:15px;line-height:1.6;color:#CBD5E1;">
+                  Click the button to choose a new password. This link expires in 1 hour and only works once.
+                </p>
+                <p style="margin:0 0 16px 0;font-size:13px;line-height:1.6;color:#94A3B8;">
+                  Your current password keeps working until you complete the reset.
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td align="center" style="padding:16px 32px 8px 32px;">
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                  <tr>
+                    <td align="center" style="border-radius:10px;background:linear-gradient(135deg,#3A82FF,#7C3AED);">
+                      <a href="{{ .ConfirmationURL }}"
+                         style="display:inline-block;padding:12px 28px;font-size:15px;font-weight:600;color:#FFFFFF;text-decoration:none;border-radius:10px;min-width:160px;text-align:center;">
+                        Reset password
+                      </a>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:16px 32px 8px 32px;">
+                <p style="margin:0 0 6px 0;font-size:12px;color:#94A3B8;">
+                  Or paste this URL into your browser:
+                </p>
+                <p style="margin:0;font-size:12px;line-height:1.5;color:#7C3AED;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;word-break:break-all;">
+                  <a href="{{ .ConfirmationURL }}" style="color:#7C3AED;text-decoration:underline;">{{ .ConfirmationURL }}</a>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:16px 32px 8px 32px;">
+                <p style="margin:8px 0 0 0;font-size:12px;line-height:1.6;color:#94A3B8;">
+                  Reset requested for <span style="color:#CBD5E1;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;">{{ .Email }}</span>
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:20px 32px 24px 32px;">
+                <p style="margin:0;font-size:12px;color:#64748B;font-style:italic;">
+                  Mem0 remembers. Gradata learns.
+                </p>
+              </td>
+            </tr>
+
+            <tr>
+              <td style="padding:16px 32px 28px 32px;border-top:1px solid #1F2937;">
+                <p style="margin:0 0 6px 0;font-size:11px;line-height:1.6;color:#64748B;opacity:0.85;">
+                  Didn't request this? Ignore this email. Your password hasn't changed.
+                </p>
+                <p style="margin:8px 0 0 0;font-size:11px;line-height:1.6;color:#64748B;opacity:0.85;">
+                  <a href="https://app.gradata.ai/legal/privacy" style="color:#94A3B8;text-decoration:underline;">Privacy</a>
+                  &nbsp;&middot;&nbsp;
+                  <a href="https://app.gradata.ai/legal/terms" style="color:#94A3B8;text-decoration:underline;">Terms</a>
+                  &nbsp;&middot;&nbsp;
+                  &copy; 2026 Gradata
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/cloud/tests/test_notifications.py
+++ b/cloud/tests/test_notifications.py
@@ -1,0 +1,89 @@
+"""Tests for /users/me/notifications GET + PUT."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def stub_user(client):
+    """Override the get_current_user_id Depends() with a fixed-id stub."""
+    from app.auth import get_current_user_id
+
+    async def _stub_user_id() -> str:
+        return "test-user-1"
+
+    client.app.dependency_overrides[get_current_user_id] = _stub_user_id
+    yield "test-user-1"
+    client.app.dependency_overrides.pop(get_current_user_id, None)
+
+
+class TestGetNotifications:
+    def test_returns_defaults_when_no_row(self, client, mock_supabase, auth_headers, stub_user):
+        mock_supabase.add_response("workspace_members", "select", [])
+        resp = client.get("/api/v1/users/me/notifications", headers=auth_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        # SIM16-validated defaults
+        assert body["alert_correction_spike"] is True
+        assert body["alert_rule_regression"] is True
+        assert body["alert_meta_rule_emerged"] is False
+        assert body["digest_cadence"] == "weekly"
+        assert body["digest_email"] == ""
+        assert body["slack_webhook"] == ""
+
+    def test_returns_stored_prefs(self, client, mock_supabase, auth_headers, stub_user):
+        mock_supabase.add_response("workspace_members", "select", [
+            {"user_id": "test-user-1", "notification_prefs": {
+                "alert_correction_spike": False,
+                "alert_rule_regression": True,
+                "alert_meta_rule_emerged": True,
+                "digest_cadence": "daily",
+                "digest_email": "alerts@example.com",
+                "slack_webhook": "https://hooks.slack.com/services/x",
+            }},
+        ])
+        resp = client.get("/api/v1/users/me/notifications", headers=auth_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["digest_cadence"] == "daily"
+        assert body["digest_email"] == "alerts@example.com"
+        assert body["alert_correction_spike"] is False
+
+    def test_falls_back_to_defaults_when_prefs_blank(self, client, mock_supabase, auth_headers, stub_user):
+        mock_supabase.add_response("workspace_members", "select", [{"user_id": "test-user-1", "notification_prefs": None}])
+        resp = client.get("/api/v1/users/me/notifications", headers=auth_headers)
+        assert resp.status_code == 200
+        assert resp.json()["digest_cadence"] == "weekly"
+
+
+class TestPutNotifications:
+    def test_replaces_prefs_and_returns_them(self, client, mock_supabase, auth_headers, stub_user):
+        payload = {
+            "alert_correction_spike": False,
+            "alert_rule_regression": False,
+            "alert_meta_rule_emerged": True,
+            "digest_cadence": "monthly",
+            "digest_email": "",
+            "slack_webhook": "",
+        }
+        resp = client.put("/api/v1/users/me/notifications", json=payload, headers=auth_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["digest_cadence"] == "monthly"
+        assert body["alert_meta_rule_emerged"] is True
+
+    def test_rejects_invalid_cadence(self, client, mock_supabase, auth_headers, stub_user):
+        payload = {"digest_cadence": "yearly"}
+        resp = client.put("/api/v1/users/me/notifications", json=payload, headers=auth_headers)
+        # Pydantic ValidationError → 422
+        assert resp.status_code == 422
+
+    def test_accepts_partial_payload_using_defaults(self, client, mock_supabase, auth_headers, stub_user):
+        # Pydantic fills in defaults for omitted fields
+        payload = {"digest_cadence": "off"}
+        resp = client.put("/api/v1/users/me/notifications", json=payload, headers=auth_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["digest_cadence"] == "off"
+        # Defaults preserved
+        assert body["alert_correction_spike"] is True

--- a/marketing/.gitignore
+++ b/marketing/.gitignore
@@ -1,0 +1,29 @@
+# deps
+node_modules/
+.pnp
+.pnp.*
+.yarn/*
+
+# next
+.next/
+out/
+build/
+dist/
+
+# env
+.env*.local
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# misc
+.DS_Store
+*.pem
+.vercel
+next-env.d.ts.bak
+
+# typescript
+*.tsbuildinfo

--- a/marketing/README.md
+++ b/marketing/README.md
@@ -1,0 +1,69 @@
+# gradata.ai — Marketing Site
+
+Next.js 16 App Router, static export. Replaces the legacy Vite SPA at `.tmp/website/`.
+
+## Why Next.js
+
+The previous Vite SPA served blank HTML to Googlebot and AEO crawlers, killing organic
+discovery. This site pre-renders every route to real HTML at build time — SEO content
+lives in the markup, not in a JS bundle.
+
+## Develop
+
+```bash
+cd marketing
+pnpm install
+pnpm dev
+# http://localhost:3000
+```
+
+## Build
+
+```bash
+pnpm build
+# static HTML lands in out/
+ls out/
+```
+
+## Deploy (Cloudflare Pages)
+
+```bash
+pnpm build
+wrangler pages deploy out --project-name=gradata-website
+```
+
+The Pages project is `gradata-website` (custom domain `gradata.ai`).
+
+## Structure
+
+```
+marketing/
+├─ app/
+│  ├─ layout.tsx          # Root layout: V3 theme, fonts, JSON-LD, noise overlay
+│  ├─ page.tsx            # Home — hero + KPI proof row + CTA
+│  ├─ how-it-works/       # Graduation pipeline explainer
+│  ├─ pricing/            # 4 plan cards
+│  ├─ docs/               # Quickstart + link to GitHub docs
+│  ├─ legal/privacy/
+│  ├─ legal/terms/
+│  ├─ sitemap.ts          # Generates /sitemap.xml
+│  ├─ robots.ts           # Generates /robots.txt
+│  └─ globals.css
+├─ src/
+│  ├─ components/         # Header, Footer, Hero, GlassCard, NoiseOverlay, etc.
+│  └─ lib/                # site metadata + cn util
+├─ public/
+│  ├─ _headers            # Cloudflare Pages security headers
+│  ├─ _redirects          # www → apex, /login → app.gradata.ai
+│  └─ favicon.svg
+├─ next.config.ts         # output: 'export', images unoptimized
+└─ wrangler.toml
+```
+
+## SEO checklist
+
+- [x] Per-route `metadata` exports (title, description, openGraph, twitter, canonical)
+- [x] JSON-LD `Organization` schema in root layout
+- [x] `sitemap.ts` auto-generates `/sitemap.xml`
+- [x] `robots.ts` auto-generates `/robots.txt` with sitemap reference
+- [x] All HTML pre-rendered — content visible to crawlers without JS execution

--- a/marketing/app/docs/page.tsx
+++ b/marketing/app/docs/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from "next";
+import { GlassCard } from "@/components/GlassCard";
+import { CodeBlock } from "@/components/CodeBlock";
+import { site } from "@/lib/site";
+
+export const metadata: Metadata = {
+  title: "Docs",
+  description: "Install Gradata and run your first correction in under a minute.",
+  openGraph: {
+    title: "Docs — Gradata",
+    description: "Install Gradata and run your first correction in under a minute.",
+    url: `${site.url}/docs/`,
+    type: "article",
+  },
+  alternates: { canonical: `${site.url}/docs/` },
+};
+
+export default function DocsPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-20 sm:px-6">
+      <header className="mb-10">
+        <div className="mb-4 text-xs uppercase tracking-widest text-[color:var(--color-muted-foreground)]">
+          Docs
+        </div>
+        <h1 className="font-heading text-4xl font-semibold tracking-tight sm:text-5xl">
+          Get started in 60 seconds.
+        </h1>
+        <p className="mt-4 text-[color:var(--color-muted-foreground)]">
+          The full technical docs live on GitHub. Here&apos;s the shortest path from zero to your
+          first graduated rule.
+        </p>
+      </header>
+
+      <div className="space-y-6">
+        <CodeBlock
+          language="bash"
+          code={`pip install gradata`}
+          caption="Requires Python 3.10+"
+        />
+        <CodeBlock
+          language="python"
+          code={`from gradata import Gradata
+
+brain = Gradata(profile="my-agent")
+
+# Feed it your first correction
+brain.correct(
+    draft="Sure thing! Here's the TPS report.",
+    final="Here is the TPS report.",
+    task="email_reply",
+)
+
+# Inspect what the brain learned
+print(brain.rules(task="email_reply"))`}
+        />
+
+        <GlassCard className="p-6">
+          <div className="font-heading text-lg font-semibold">Full documentation</div>
+          <p className="mt-2 text-sm text-[color:var(--color-muted-foreground)]">
+            Complete API reference, architecture deep-dives, and integration guides for Claude, GPT,
+            Gemini, and local models are on GitHub.
+          </p>
+          <a
+            href={site.docsUrl}
+            className="mt-4 inline-flex items-center rounded-md border border-[color:var(--color-border)] px-4 py-2 text-sm font-medium hover:bg-[color:var(--color-card)]"
+          >
+            Read the docs on GitHub →
+          </a>
+        </GlassCard>
+      </div>
+    </div>
+  );
+}

--- a/marketing/app/globals.css
+++ b/marketing/app/globals.css
@@ -1,0 +1,74 @@
+@import "tailwindcss";
+
+@theme {
+  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
+  --font-heading: "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  --color-background: oklch(0.13 0.01 270);
+  --color-foreground: oklch(0.95 0.01 270);
+  --color-card: oklch(0.17 0.015 270);
+  --color-card-foreground: oklch(0.95 0.01 270);
+  --color-muted: oklch(0.22 0.02 270);
+  --color-muted-foreground: oklch(0.65 0.02 270);
+  --color-border: oklch(0.28 0.02 270);
+  --color-primary: oklch(0.55 0.25 270);
+  --color-primary-foreground: oklch(0.98 0 0);
+  --color-accent: oklch(0.7 0.18 160);
+
+  --radius-sm: 0.375rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+  --radius-xl: 1rem;
+}
+
+:root {
+  color-scheme: dark;
+}
+
+html,
+body {
+  background: var(--color-background);
+  color: var(--color-foreground);
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  font-family: var(--font-heading);
+  letter-spacing: -0.02em;
+}
+
+code,
+pre,
+kbd {
+  font-family: var(--font-mono);
+}
+
+::selection {
+  background: oklch(0.55 0.25 270 / 0.3);
+  color: var(--color-foreground);
+}
+
+/* Subtle vignette */
+.bg-gradient-radial {
+  background: radial-gradient(
+    ellipse 80% 60% at 50% 0%,
+    oklch(0.55 0.25 270 / 0.08),
+    transparent 60%
+  );
+}
+
+/* Smooth anchor scroll */
+html {
+  scroll-behavior: smooth;
+}

--- a/marketing/app/how-it-works/page.tsx
+++ b/marketing/app/how-it-works/page.tsx
@@ -1,0 +1,114 @@
+import type { Metadata } from "next";
+import { GlassCard } from "@/components/GlassCard";
+import { CodeBlock } from "@/components/CodeBlock";
+import { site } from "@/lib/site";
+
+export const metadata: Metadata = {
+  title: "How it works",
+  description:
+    "Corrections become instincts. Instincts become patterns. Patterns become rules. Rules become meta-rules. Gradata's graduation pipeline, explained.",
+  openGraph: {
+    title: "How it works — Gradata",
+    description:
+      "Corrections become instincts. Instincts become patterns. Patterns become rules. Rules become meta-rules.",
+    url: `${site.url}/how-it-works/`,
+    type: "article",
+  },
+  alternates: { canonical: `${site.url}/how-it-works/` },
+};
+
+const STAGES = [
+  {
+    tag: "01",
+    name: "INSTINCT",
+    threshold: "confidence ≥ 0.40",
+    description:
+      "The first time you correct something, it's logged as an event with severity and edit-distance metadata.",
+  },
+  {
+    tag: "02",
+    name: "PATTERN",
+    threshold: "confidence ≥ 0.60",
+    description:
+      "Repeated corrections on the same shape promote the lesson. Severity-weighted survival boosts confidence.",
+  },
+  {
+    tag: "03",
+    name: "RULE",
+    threshold: "confidence ≥ 0.90",
+    description:
+      "Durable lessons graduate to rules and get injected into matching tasks (max 10 per session, scope-matched).",
+  },
+  {
+    tag: "04",
+    name: "META-RULE",
+    threshold: "3+ graduated rules cluster",
+    description:
+      "Rules that share structure collapse into meta-rules — the compressed principles behind your judgment.",
+  },
+];
+
+export default function HowItWorksPage() {
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-20 sm:px-6">
+      <header className="mb-12 max-w-2xl">
+        <div className="mb-4 text-xs uppercase tracking-widest text-[color:var(--color-muted-foreground)]">
+          How it works
+        </div>
+        <h1 className="font-heading text-4xl font-semibold tracking-tight sm:text-5xl">
+          Corrections in. Judgment out.
+        </h1>
+        <p className="mt-4 text-[color:var(--color-muted-foreground)]">
+          Every edit you make teaches the brain. The graduation pipeline promotes durable lessons
+          into rules, and clusters of rules into meta-rules you can export and share.
+        </p>
+      </header>
+
+      <section className="mb-14">
+        <CodeBlock
+          language="python"
+          code={`from gradata import Gradata
+
+brain = Gradata(profile="writing")
+
+draft = llm.generate(prompt)
+final = human_edit(draft)
+
+# Every edit is a lesson. Severity is measured
+# via edit distance; rules graduate automatically.
+brain.correct(draft=draft, final=final, task="reply")
+
+# Next time, matching rules inject into the prompt.
+next_draft = llm.generate(prompt, context=brain.context_for("reply"))`}
+          caption="Python SDK. AGPL-3.0. Works with any model."
+        />
+      </section>
+
+      <section className="space-y-4">
+        {STAGES.map((s) => (
+          <GlassCard key={s.tag} className="p-6">
+            <div className="flex flex-wrap items-baseline gap-3">
+              <span className="font-mono text-xs text-[color:var(--color-muted-foreground)]">{s.tag}</span>
+              <span className="font-heading text-xl font-semibold">{s.name}</span>
+              <span className="rounded-full border border-[color:var(--color-border)] px-2 py-0.5 text-xs text-[color:var(--color-muted-foreground)]">
+                {s.threshold}
+              </span>
+            </div>
+            <p className="mt-2 text-sm text-[color:var(--color-muted-foreground)]">{s.description}</p>
+          </GlassCard>
+        ))}
+      </section>
+
+      <section className="mt-14">
+        <GlassCard className="p-6">
+          <div className="font-heading text-lg font-semibold">Injection, not retraining</div>
+          <p className="mt-2 text-sm text-[color:var(--color-muted-foreground)]">
+            Matching rules are injected as structured context at prompt-time — no fine-tuning, no
+            model upload, works across Claude, GPT, Gemini, or local models. Scope-matched per task.
+            Primacy/recency positioning. Max 10 per session.
+          </p>
+        </GlassCard>
+      </section>
+    </div>
+  );
+}

--- a/marketing/app/layout.tsx
+++ b/marketing/app/layout.tsx
@@ -1,0 +1,94 @@
+import type { Metadata, Viewport } from "next";
+import "./globals.css";
+import { Header } from "@/components/Header";
+import { Footer } from "@/components/Footer";
+import { NoiseOverlay } from "@/components/NoiseOverlay";
+import { site } from "@/lib/site";
+
+export const metadata: Metadata = {
+  metadataBase: new URL(site.url),
+  title: {
+    default: `${site.name} — ${site.tagline}`,
+    template: `%s — ${site.name}`,
+  },
+  description: site.description,
+  applicationName: site.name,
+  keywords: [
+    "AI memory",
+    "correction learning",
+    "AI rules",
+    "LLM fine-tuning alternative",
+    "agent memory",
+    "open source AI SDK",
+    "procedural memory",
+  ],
+  authors: [{ name: site.name, url: site.url }],
+  creator: site.name,
+  openGraph: {
+    type: "website",
+    url: site.url,
+    title: `${site.name} — ${site.tagline}`,
+    description: site.description,
+    siteName: site.name,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${site.name} — ${site.tagline}`,
+    description: site.description,
+  },
+  alternates: {
+    canonical: site.url,
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
+};
+
+export const viewport: Viewport = {
+  themeColor: "#0b0b14",
+  colorScheme: "dark",
+};
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: site.name,
+  url: site.url,
+  logo: `${site.url}/favicon.svg`,
+  description: site.description,
+  sameAs: [site.social.github],
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" className="dark">
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"
+          rel="stylesheet"
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </head>
+      <body className="relative min-h-screen">
+        <NoiseOverlay />
+        <div className="relative z-10 flex min-h-screen flex-col">
+          <Header />
+          <main className="flex-1">{children}</main>
+          <Footer />
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/marketing/app/legal/privacy/page.tsx
+++ b/marketing/app/legal/privacy/page.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from "next";
+import { site } from "@/lib/site";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description: "How Gradata collects, uses, and protects your data.",
+  alternates: { canonical: `${site.url}/legal/privacy/` },
+  robots: { index: true, follow: true },
+};
+
+export default function PrivacyPage() {
+  return (
+    <article className="mx-auto max-w-3xl px-4 py-20 sm:px-6">
+      <header className="mb-10">
+        <div className="mb-4 text-xs uppercase tracking-widest text-[color:var(--color-muted-foreground)]">
+          Legal
+        </div>
+        <h1 className="font-heading text-4xl font-semibold tracking-tight">Privacy Policy</h1>
+        <p className="mt-3 text-sm text-[color:var(--color-muted-foreground)]">
+          Last updated: April 2026
+        </p>
+      </header>
+
+      <div className="prose-invert space-y-6 text-[color:var(--color-foreground)]/90">
+        <section>
+          <h2 className="font-heading text-xl font-semibold">Overview</h2>
+          <p className="mt-2 text-sm text-[color:var(--color-muted-foreground)]">
+            Gradata (&quot;we&quot;, &quot;us&quot;) provides an open source SDK and an optional
+            hosted cloud service. The SDK runs locally and stores your brain on your machine. The
+            cloud service stores data you explicitly sync.
+          </p>
+        </section>
+        <section>
+          <h2 className="font-heading text-xl font-semibold">Data we collect</h2>
+          <ul className="mt-2 space-y-1 text-sm text-[color:var(--color-muted-foreground)]">
+            <li>Account email and authentication metadata</li>
+            <li>Brains you choose to sync to our cloud</li>
+            <li>Billing information (processed by Stripe)</li>
+            <li>Basic product analytics (page views, feature usage)</li>
+          </ul>
+        </section>
+        <section>
+          <h2 className="font-heading text-xl font-semibold">Your rights</h2>
+          <p className="mt-2 text-sm text-[color:var(--color-muted-foreground)]">
+            You can export or delete your data at any time. For privacy requests, contact{" "}
+            <a href="mailto:privacy@gradata.ai" className="underline">privacy@gradata.ai</a>.
+          </p>
+        </section>
+        <section>
+          <p className="text-xs text-[color:var(--color-muted-foreground)]">
+            This is a stub. Full policy is being finalized. Questions in the interim go to{" "}
+            <a href="mailto:privacy@gradata.ai" className="underline">privacy@gradata.ai</a>.
+          </p>
+        </section>
+      </div>
+    </article>
+  );
+}

--- a/marketing/app/legal/terms/page.tsx
+++ b/marketing/app/legal/terms/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from "next";
+import { site } from "@/lib/site";
+
+export const metadata: Metadata = {
+  title: "Terms of Service",
+  description: "The terms that govern your use of Gradata.",
+  alternates: { canonical: `${site.url}/legal/terms/` },
+  robots: { index: true, follow: true },
+};
+
+export default function TermsPage() {
+  return (
+    <article className="mx-auto max-w-3xl px-4 py-20 sm:px-6">
+      <header className="mb-10">
+        <div className="mb-4 text-xs uppercase tracking-widest text-[color:var(--color-muted-foreground)]">
+          Legal
+        </div>
+        <h1 className="font-heading text-4xl font-semibold tracking-tight">Terms of Service</h1>
+        <p className="mt-3 text-sm text-[color:var(--color-muted-foreground)]">
+          Last updated: April 2026
+        </p>
+      </header>
+
+      <div className="space-y-6">
+        <section>
+          <h2 className="font-heading text-xl font-semibold">Acceptance</h2>
+          <p className="mt-2 text-sm text-[color:var(--color-muted-foreground)]">
+            By using Gradata, you agree to these terms. The open source SDK is licensed under
+            AGPL-3.0 — see the LICENSE file in the repository.
+          </p>
+        </section>
+        <section>
+          <h2 className="font-heading text-xl font-semibold">Acceptable use</h2>
+          <p className="mt-2 text-sm text-[color:var(--color-muted-foreground)]">
+            Don&apos;t use Gradata to violate laws, infringe rights, or attack others&apos; systems.
+            Don&apos;t reverse-engineer the hosted service beyond what AGPL-3.0 permits for the SDK.
+          </p>
+        </section>
+        <section>
+          <h2 className="font-heading text-xl font-semibold">Service availability</h2>
+          <p className="mt-2 text-sm text-[color:var(--color-muted-foreground)]">
+            The hosted cloud service is provided &quot;as-is&quot;. Enterprise plans include an
+            explicit SLA; see your order form.
+          </p>
+        </section>
+        <section>
+          <p className="text-xs text-[color:var(--color-muted-foreground)]">
+            This is a stub. Full terms are being finalized. Questions to{" "}
+            <a href="mailto:legal@gradata.ai" className="underline">legal@gradata.ai</a>.
+          </p>
+        </section>
+      </div>
+    </article>
+  );
+}

--- a/marketing/app/page.tsx
+++ b/marketing/app/page.tsx
@@ -1,0 +1,89 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Hero } from "@/components/Hero";
+import { KpiProofRow } from "@/components/KpiProofRow";
+import { GlassCard } from "@/components/GlassCard";
+import { site } from "@/lib/site";
+
+export const metadata: Metadata = {
+  title: `${site.name} — ${site.tagline}`,
+  description: site.description,
+  openGraph: {
+    title: `${site.name} — ${site.tagline}`,
+    description: site.description,
+    url: site.url,
+    type: "website",
+  },
+  alternates: { canonical: site.url },
+};
+
+export default function HomePage() {
+  return (
+    <>
+      <Hero />
+
+      <section className="mx-auto max-w-6xl px-4 py-16 sm:px-6">
+        <div className="mb-10 max-w-2xl">
+          <h2 className="font-heading text-3xl font-semibold tracking-tight sm:text-4xl">
+            Proof, not promises.
+          </h2>
+          <p className="mt-3 text-[color:var(--color-muted-foreground)]">
+            Every number below is from blind evaluations on our public stress-test cohort.
+            No self-grading, no cherry-picks.
+          </p>
+        </div>
+        <KpiProofRow />
+      </section>
+
+      <section className="mx-auto max-w-6xl px-4 py-16 sm:px-6">
+        <div className="grid gap-6 md:grid-cols-3">
+          <GlassCard className="p-6">
+            <div className="font-heading text-lg font-semibold">Captures every correction</div>
+            <p className="mt-2 text-sm text-[color:var(--color-muted-foreground)]">
+              Draft vs. final diffs flow into a single event stream. Nothing gets lost.
+            </p>
+          </GlassCard>
+          <GlassCard className="p-6">
+            <div className="font-heading text-lg font-semibold">Graduates lessons to rules</div>
+            <p className="mt-2 text-sm text-[color:var(--color-muted-foreground)]">
+              Instincts become patterns become rules as evidence compounds — scoped per task.
+            </p>
+          </GlassCard>
+          <GlassCard className="p-6">
+            <div className="font-heading text-lg font-semibold">Works with any model</div>
+            <p className="mt-2 text-sm text-[color:var(--color-muted-foreground)]">
+              BYO key. Claude, GPT, Gemini, local. The SDK is a thin layer on top.
+            </p>
+          </GlassCard>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-4 py-24 sm:px-6">
+        <GlassCard className="flex flex-col items-start gap-5 p-10 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="font-heading text-2xl font-semibold tracking-tight sm:text-3xl">
+              Ready to stop repeating yourself?
+            </h2>
+            <p className="mt-2 text-sm text-[color:var(--color-muted-foreground)]">
+              Free to start. BYO key. No credit card.
+            </p>
+          </div>
+          <div className="flex gap-3">
+            <a
+              href={`${site.appUrl}/signup`}
+              className="inline-flex items-center rounded-md bg-[color:var(--color-primary)] px-5 py-2.5 text-sm font-medium text-[color:var(--color-primary-foreground)] hover:opacity-90"
+            >
+              Start free
+            </a>
+            <Link
+              href="/pricing/"
+              className="inline-flex items-center rounded-md border border-[color:var(--color-border)] px-5 py-2.5 text-sm font-medium hover:bg-[color:var(--color-card)]"
+            >
+              See pricing
+            </Link>
+          </div>
+        </GlassCard>
+      </section>
+    </>
+  );
+}

--- a/marketing/app/pricing/page.tsx
+++ b/marketing/app/pricing/page.tsx
@@ -1,0 +1,107 @@
+import type { Metadata } from "next";
+import { PricingCard, type Plan } from "@/components/PricingCard";
+import { site } from "@/lib/site";
+
+export const metadata: Metadata = {
+  title: "Pricing",
+  description:
+    "Start free. Upgrade when you're ready for cloud sync, teams, or enterprise controls. BYO key.",
+  openGraph: {
+    title: "Pricing — Gradata",
+    description:
+      "Start free. Upgrade when you're ready for cloud sync, teams, or enterprise controls. BYO key.",
+    url: `${site.url}/pricing/`,
+    type: "website",
+  },
+  alternates: { canonical: `${site.url}/pricing/` },
+};
+
+const PLANS: Plan[] = [
+  {
+    name: "Free",
+    price: "$0",
+    priceSub: "/forever",
+    description: "The open source SDK. Local-only brain. BYO key.",
+    features: [
+      "pip install gradata",
+      "Local brain (SQLite + JSONL)",
+      "Correction capture + graduation",
+      "Works with any model",
+      "AGPL-3.0",
+    ],
+    cta: "Install the SDK",
+    ctaHref: site.docsUrl,
+  },
+  {
+    name: "Cloud",
+    price: "$29",
+    priceSub: "/month",
+    description: "Hosted brain, sync across machines, metrics dashboard.",
+    features: [
+      "Everything in Free",
+      "Hosted brain + sync",
+      "Metrics dashboard",
+      "Rule marketplace access",
+      "Email support",
+    ],
+    cta: "Start free trial",
+    ctaHref: `${site.appUrl}/signup?plan=cloud`,
+    featured: true,
+  },
+  {
+    name: "Team",
+    price: "$99",
+    priceSub: "/seat/month",
+    description: "Shared brains, role-based access, audit logs for up to 10 seats.",
+    features: [
+      "Everything in Cloud",
+      "Shared team brains",
+      "Role-based access control",
+      "Audit logs",
+      "Priority support",
+    ],
+    cta: "Start team trial",
+    ctaHref: `${site.appUrl}/signup?plan=team`,
+  },
+  {
+    name: "Enterprise",
+    price: "Custom",
+    description: "SSO/SAML, on-prem option, SLAs, and dedicated success.",
+    features: [
+      "Everything in Team",
+      "SSO / SAML",
+      "On-prem / VPC deployment",
+      "SLA + dedicated CSM",
+      "Security review + DPA",
+    ],
+    cta: "Contact sales",
+    ctaHref: "mailto:hello@gradata.ai?subject=Gradata%20Enterprise",
+  },
+];
+
+export default function PricingPage() {
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-20 sm:px-6">
+      <header className="mx-auto mb-14 max-w-2xl text-center">
+        <div className="mb-4 text-xs uppercase tracking-widest text-[color:var(--color-muted-foreground)]">
+          Pricing
+        </div>
+        <h1 className="font-heading text-4xl font-semibold tracking-tight sm:text-5xl">
+          Simple, honest pricing.
+        </h1>
+        <p className="mt-4 text-[color:var(--color-muted-foreground)]">
+          BYO model key. The SDK is free and open source forever. Pay only for hosted sync,
+          team collaboration, and enterprise controls.
+        </p>
+      </header>
+      <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-4">
+        {PLANS.map((plan) => (
+          <PricingCard key={plan.name} plan={plan} />
+        ))}
+      </div>
+      <p className="mt-10 text-center text-xs text-[color:var(--color-muted-foreground)]">
+        Prices in USD. Taxes may apply. Cancel anytime.
+      </p>
+    </div>
+  );
+}

--- a/marketing/app/robots.ts
+++ b/marketing/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+import { site } from "@/lib/site";
+
+export const dynamic = "force-static";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+      },
+    ],
+    sitemap: `${site.url}/sitemap.xml`,
+    host: site.url,
+  };
+}

--- a/marketing/app/sitemap.ts
+++ b/marketing/app/sitemap.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+import { site } from "@/lib/site";
+
+export const dynamic = "force-static";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+  const routes = ["", "/how-it-works", "/pricing", "/docs", "/legal/privacy", "/legal/terms"];
+  return routes.map((path) => ({
+    url: `${site.url}${path}/`.replace(/\/+$/, "/"),
+    lastModified: now,
+    changeFrequency: path === "" ? "weekly" : "monthly",
+    priority: path === "" ? 1.0 : 0.7,
+  }));
+}

--- a/marketing/next-env.d.ts
+++ b/marketing/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/marketing/next.config.ts
+++ b/marketing/next.config.ts
@@ -1,0 +1,12 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  output: "export",
+  images: {
+    unoptimized: true,
+  },
+  trailingSlash: true,
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/marketing/package.json
+++ b/marketing/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "gradata-marketing",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "^16.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.0.0",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^4.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/marketing/pnpm-lock.yaml
+++ b/marketing/pnpm-lock.yaml
@@ -1,0 +1,1058 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      next:
+        specifier: ^16.0.0
+        version: 16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4.0.0
+        version: 4.2.2
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.4.27(postcss@8.5.9)
+      postcss:
+        specifier: ^8.4.49
+        version: 8.5.9
+      tailwindcss:
+        specifier: ^4.0.0
+        version: 4.2.2
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+
+packages:
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
+
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@next/env@16.2.3':
+    resolution: {integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==}
+
+  '@next/swc-darwin-arm64@16.2.3':
+    resolution: {integrity: sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@16.2.3':
+    resolution: {integrity: sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@16.2.3':
+    resolution: {integrity: sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-musl@16.2.3':
+    resolution: {integrity: sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-linux-x64-gnu@16.2.3':
+    resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-musl@16.2.3':
+    resolution: {integrity: sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-win32-arm64-msvc@16.2.3':
+    resolution: {integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.2.3':
+    resolution: {integrity: sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@tailwindcss/node@4.2.2':
+    resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
+
+  '@tailwindcss/oxide-android-arm64@4.2.2':
+    resolution: {integrity: sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.2':
+    resolution: {integrity: sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.2.2':
+    resolution: {integrity: sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.2':
+    resolution: {integrity: sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
+    resolution: {integrity: sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
+    resolution: {integrity: sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
+    resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
+    resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
+    resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
+    resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
+    resolution: {integrity: sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
+    resolution: {integrity: sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.2.2':
+    resolution: {integrity: sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/postcss@4.2.2':
+    resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  autoprefixer@10.4.27:
+    resolution: {integrity: sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+
+  baseline-browser-mapping@2.10.18:
+    resolution: {integrity: sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  caniuse-lite@1.0.30001787:
+    resolution: {integrity: sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  electron-to-chromium@1.5.335:
+    resolution: {integrity: sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==}
+
+  enhanced-resolve@5.20.1:
+    resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
+    engines: {node: '>=10.13.0'}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  next@16.2.3:
+    resolution: {integrity: sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==}
+    engines: {node: '>=20.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
+  node-releases@2.0.37:
+    resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.9:
+    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
+  tailwindcss@4.2.2:
+    resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
+
+  tapable@2.3.2:
+    resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
+    engines: {node: '>=6'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+snapshots:
+
+  '@alloc/quick-lru@5.2.0': {}
+
+  '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.9.2
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@next/env@16.2.3': {}
+
+  '@next/swc-darwin-arm64@16.2.3':
+    optional: true
+
+  '@next/swc-darwin-x64@16.2.3':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@16.2.3':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@16.2.3':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@16.2.3':
+    optional: true
+
+  '@next/swc-linux-x64-musl@16.2.3':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@16.2.3':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.2.3':
+    optional: true
+
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
+
+  '@tailwindcss/node@4.2.2':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.20.1
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.2.2
+
+  '@tailwindcss/oxide-android-arm64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide@4.2.2':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.2.2
+      '@tailwindcss/oxide-darwin-arm64': 4.2.2
+      '@tailwindcss/oxide-darwin-x64': 4.2.2
+      '@tailwindcss/oxide-freebsd-x64': 4.2.2
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.2
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.2
+      '@tailwindcss/oxide-linux-arm64-musl': 4.2.2
+      '@tailwindcss/oxide-linux-x64-gnu': 4.2.2
+      '@tailwindcss/oxide-linux-x64-musl': 4.2.2
+      '@tailwindcss/oxide-wasm32-wasi': 4.2.2
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
+      '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
+
+  '@tailwindcss/postcss@4.2.2':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.2.2
+      '@tailwindcss/oxide': 4.2.2
+      postcss: 8.5.9
+      tailwindcss: 4.2.2
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
+  autoprefixer@10.4.27(postcss@8.5.9):
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001787
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.9
+      postcss-value-parser: 4.2.0
+
+  baseline-browser-mapping@2.10.18: {}
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.18
+      caniuse-lite: 1.0.30001787
+      electron-to-chromium: 1.5.335
+      node-releases: 2.0.37
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  caniuse-lite@1.0.30001787: {}
+
+  client-only@0.0.1: {}
+
+  csstype@3.2.3: {}
+
+  detect-libc@2.1.2: {}
+
+  electron-to-chromium@1.5.335: {}
+
+  enhanced-resolve@5.20.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.2
+
+  escalade@3.2.0: {}
+
+  fraction.js@5.3.4: {}
+
+  graceful-fs@4.2.11: {}
+
+  jiti@2.6.1: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  nanoid@3.3.11: {}
+
+  next@16.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@next/env': 16.2.3
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.18
+      caniuse-lite: 1.0.30001787
+      postcss: 8.4.31
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      styled-jsx: 5.1.6(react@19.2.5)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.3
+      '@next/swc-darwin-x64': 16.2.3
+      '@next/swc-linux-arm64-gnu': 16.2.3
+      '@next/swc-linux-arm64-musl': 16.2.3
+      '@next/swc-linux-x64-gnu': 16.2.3
+      '@next/swc-linux-x64-musl': 16.2.3
+      '@next/swc-win32-arm64-msvc': 16.2.3
+      '@next/swc-win32-x64-msvc': 16.2.3
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  node-releases@2.0.37: {}
+
+  picocolors@1.1.1: {}
+
+  postcss-value-parser@4.2.0: {}
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.9:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
+  react@19.2.5: {}
+
+  scheduler@0.27.0: {}
+
+  semver@7.7.4:
+    optional: true
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+    optional: true
+
+  source-map-js@1.2.1: {}
+
+  styled-jsx@5.1.6(react@19.2.5):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.5
+
+  tailwindcss@4.2.2: {}
+
+  tapable@2.3.2: {}
+
+  tslib@2.8.1: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1

--- a/marketing/postcss.config.mjs
+++ b/marketing/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;

--- a/marketing/public/_headers
+++ b/marketing/public/_headers
@@ -1,0 +1,16 @@
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), browsing-topics=()
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https:; connect-src 'self' https://app.gradata.ai https://api.gradata.ai; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
+
+/_next/static/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.svg
+  Cache-Control: public, max-age=86400
+
+/*.ico
+  Cache-Control: public, max-age=86400

--- a/marketing/public/_redirects
+++ b/marketing/public/_redirects
@@ -1,0 +1,8 @@
+# Redirect www to apex
+https://www.gradata.ai/*  https://gradata.ai/:splat  301!
+
+# Route app/dashboard traffic to app subdomain
+/app/*       https://app.gradata.ai/:splat  301
+/dashboard/* https://app.gradata.ai/:splat   301
+/signup      https://app.gradata.ai/signup   302
+/login       https://app.gradata.ai/login    302

--- a/marketing/public/favicon.svg
+++ b/marketing/public/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="6" fill="#0b0b14"/><rect x="7" y="7" width="18" height="18" rx="3" fill="none" stroke="#8b5cf6" stroke-width="2.5"/><path d="M12 16h8" stroke="#8b5cf6" stroke-width="2.5" stroke-linecap="round"/></svg>

--- a/marketing/src/components/CodeBlock.tsx
+++ b/marketing/src/components/CodeBlock.tsx
@@ -1,0 +1,31 @@
+import { cn } from "@/lib/cn";
+
+type CodeBlockProps = {
+  code: string;
+  language?: string;
+  className?: string;
+  caption?: string;
+};
+
+export function CodeBlock({ code, language, className, caption }: CodeBlockProps) {
+  return (
+    <figure className={cn("overflow-hidden rounded-xl border border-[color:var(--color-border)] bg-[oklch(0.1_0.01_270)]", className)}>
+      <div className="flex items-center justify-between border-b border-[color:var(--color-border)]/60 px-4 py-2 text-xs text-[color:var(--color-muted-foreground)]">
+        <div className="flex items-center gap-1.5">
+          <span className="h-2.5 w-2.5 rounded-full bg-[oklch(0.55_0.18_25)]" aria-hidden />
+          <span className="h-2.5 w-2.5 rounded-full bg-[oklch(0.7_0.15_90)]" aria-hidden />
+          <span className="h-2.5 w-2.5 rounded-full bg-[oklch(0.65_0.18_150)]" aria-hidden />
+        </div>
+        {language && <span className="font-mono tracking-wide">{language}</span>}
+      </div>
+      <pre className="overflow-x-auto px-4 py-4 text-sm leading-relaxed">
+        <code className="font-mono text-[color:var(--color-foreground)]">{code}</code>
+      </pre>
+      {caption && (
+        <figcaption className="border-t border-[color:var(--color-border)]/60 px-4 py-2 text-xs text-[color:var(--color-muted-foreground)]">
+          {caption}
+        </figcaption>
+      )}
+    </figure>
+  );
+}

--- a/marketing/src/components/Footer.tsx
+++ b/marketing/src/components/Footer.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+import { site } from "@/lib/site";
+
+export function Footer() {
+  const year = new Date().getFullYear();
+  return (
+    <footer className="mt-32 border-t border-[color:var(--color-border)]/60">
+      <div className="mx-auto grid max-w-6xl gap-10 px-4 py-14 sm:px-6 md:grid-cols-4">
+        <div className="md:col-span-2">
+          <div className="flex items-center gap-2 font-heading text-base font-semibold">
+            <span className="inline-block h-2.5 w-2.5 rounded-sm bg-[color:var(--color-primary)]" aria-hidden />
+            {site.name}
+          </div>
+          <p className="mt-3 max-w-xs text-sm text-[color:var(--color-muted-foreground)]">
+            {site.tagline}
+          </p>
+        </div>
+        <div>
+          <div className="mb-3 text-xs font-medium uppercase tracking-wider text-[color:var(--color-muted-foreground)]">
+            Product
+          </div>
+          <ul className="space-y-2 text-sm">
+            <li><Link href="/how-it-works/" className="hover:text-[color:var(--color-foreground)] text-[color:var(--color-muted-foreground)]">How it works</Link></li>
+            <li><Link href="/pricing/" className="hover:text-[color:var(--color-foreground)] text-[color:var(--color-muted-foreground)]">Pricing</Link></li>
+            <li><Link href="/docs/" className="hover:text-[color:var(--color-foreground)] text-[color:var(--color-muted-foreground)]">Docs</Link></li>
+          </ul>
+        </div>
+        <div>
+          <div className="mb-3 text-xs font-medium uppercase tracking-wider text-[color:var(--color-muted-foreground)]">
+            Company
+          </div>
+          <ul className="space-y-2 text-sm">
+            <li><Link href="/legal/privacy/" className="hover:text-[color:var(--color-foreground)] text-[color:var(--color-muted-foreground)]">Privacy</Link></li>
+            <li><Link href="/legal/terms/" className="hover:text-[color:var(--color-foreground)] text-[color:var(--color-muted-foreground)]">Terms</Link></li>
+            <li><a href={site.social.github} className="hover:text-[color:var(--color-foreground)] text-[color:var(--color-muted-foreground)]">GitHub</a></li>
+          </ul>
+        </div>
+      </div>
+      <div className="border-t border-[color:var(--color-border)]/60">
+        <div className="mx-auto flex max-w-6xl flex-col items-start justify-between gap-3 px-4 py-6 text-xs text-[color:var(--color-muted-foreground)] sm:flex-row sm:items-center sm:px-6">
+          <div>© {year} {site.name}. All rights reserved.</div>
+          <div className="flex items-center gap-4">
+            <a href={site.social.x} aria-label="X" className="hover:text-[color:var(--color-foreground)]">X</a>
+            <a href={site.social.linkedin} aria-label="LinkedIn" className="hover:text-[color:var(--color-foreground)]">LinkedIn</a>
+            <a href={site.social.github} aria-label="GitHub" className="hover:text-[color:var(--color-foreground)]">GitHub</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/marketing/src/components/GlassCard.tsx
+++ b/marketing/src/components/GlassCard.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/cn";
+
+type GlassCardProps = {
+  children: ReactNode;
+  className?: string;
+  as?: "div" | "section" | "article";
+};
+
+export function GlassCard({ children, className, as: Tag = "div" }: GlassCardProps) {
+  return (
+    <Tag
+      className={cn(
+        "relative rounded-xl border border-[color:var(--color-border)]",
+        "bg-[color:var(--color-card)]/60 backdrop-blur-xl",
+        "shadow-[0_1px_0_0_rgba(255,255,255,0.04)_inset,0_30px_80px_-30px_rgba(0,0,0,0.6)]",
+        className
+      )}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/marketing/src/components/Header.tsx
+++ b/marketing/src/components/Header.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import { site } from "@/lib/site";
+
+const nav = [
+  { href: "/", label: "Home" },
+  { href: "/how-it-works/", label: "How it works" },
+  { href: "/pricing/", label: "Pricing" },
+  { href: "/docs/", label: "Docs" },
+];
+
+export function Header() {
+  return (
+    <header className="sticky top-0 z-40 border-b border-[color:var(--color-border)]/60 bg-[color:var(--color-background)]/70 backdrop-blur-xl">
+      <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4 sm:px-6">
+        <Link href="/" className="flex items-center gap-2 font-heading text-base font-semibold tracking-tight">
+          <span className="inline-block h-2.5 w-2.5 rounded-sm bg-[color:var(--color-primary)]" aria-hidden />
+          {site.name}
+        </Link>
+        <nav className="hidden items-center gap-6 text-sm text-[color:var(--color-muted-foreground)] md:flex">
+          {nav.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="transition-colors hover:text-[color:var(--color-foreground)]"
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+        <div className="flex items-center gap-2">
+          <a
+            href={`${site.appUrl}/login`}
+            className="hidden rounded-md px-3 py-1.5 text-sm text-[color:var(--color-muted-foreground)] transition-colors hover:text-[color:var(--color-foreground)] sm:inline-block"
+          >
+            Sign in
+          </a>
+          <a
+            href={`${site.appUrl}/signup`}
+            className="inline-flex items-center rounded-md bg-[color:var(--color-primary)] px-3 py-1.5 text-sm font-medium text-[color:var(--color-primary-foreground)] transition-opacity hover:opacity-90"
+          >
+            Get started
+          </a>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/marketing/src/components/Hero.tsx
+++ b/marketing/src/components/Hero.tsx
@@ -1,0 +1,49 @@
+import { site } from "@/lib/site";
+import { CodeBlock } from "./CodeBlock";
+
+export function Hero() {
+  return (
+    <section className="relative overflow-hidden">
+      <div className="bg-gradient-radial absolute inset-0 z-0" aria-hidden />
+      <div className="relative z-10 mx-auto max-w-6xl px-4 pb-20 pt-20 sm:px-6 sm:pt-28">
+        <div className="mx-auto max-w-3xl text-center">
+          <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-card)]/50 px-3 py-1 text-xs text-[color:var(--color-muted-foreground)]">
+            <span className="inline-block h-1.5 w-1.5 rounded-full bg-[color:var(--color-accent)]" aria-hidden />
+            Open source SDK. AGPL-3.0.
+          </div>
+          <h1 className="font-heading text-4xl font-semibold tracking-tight sm:text-6xl">
+            AI that learns{" "}
+            <span className="text-[color:var(--color-primary)]">the corrections</span>{" "}
+            you keep making.
+          </h1>
+          <p className="mt-6 text-base text-[color:var(--color-muted-foreground)] sm:text-lg">
+            Stop re-teaching your AI the same things. Gradata captures every correction, graduates it into a rule, and makes sure it never happens again.
+          </p>
+          <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <a
+              href={`${site.appUrl}/signup`}
+              className="inline-flex w-full items-center justify-center rounded-md bg-[color:var(--color-primary)] px-5 py-2.5 text-sm font-medium text-[color:var(--color-primary-foreground)] transition-opacity hover:opacity-90 sm:w-auto"
+            >
+              Start free
+            </a>
+            <a
+              href="/how-it-works/"
+              className="inline-flex w-full items-center justify-center rounded-md border border-[color:var(--color-border)] px-5 py-2.5 text-sm font-medium text-[color:var(--color-foreground)] transition-colors hover:bg-[color:var(--color-card)] sm:w-auto"
+            >
+              How it works
+            </a>
+          </div>
+        </div>
+        <div className="mx-auto mt-14 max-w-xl">
+          <CodeBlock
+            language="bash"
+            code={`pip install gradata
+
+brain = Gradata()
+brain.correct(draft, final)   # every edit teaches your brain`}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/marketing/src/components/KpiProofRow.tsx
+++ b/marketing/src/components/KpiProofRow.tsx
@@ -1,0 +1,43 @@
+import { GlassCard } from "./GlassCard";
+
+type Kpi = {
+  value: string;
+  label: string;
+  sub?: string;
+};
+
+const DEFAULT_KPIS: Kpi[] = [
+  {
+    value: "70%",
+    label: "Win rate vs hand-written rules",
+    sub: "Blind test across 3,000 comparisons",
+  },
+  {
+    value: "93%",
+    label: "Fewer corrections after ~3 sessions",
+    sub: "Measured on S101 validation cohort",
+  },
+  {
+    value: "65%",
+    label: "Fewer tokens per task",
+    sub: "Scoped rule injection vs full context",
+  },
+];
+
+export function KpiProofRow({ kpis = DEFAULT_KPIS }: { kpis?: Kpi[] }) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-3">
+      {kpis.map((kpi) => (
+        <GlassCard key={kpi.label} className="p-6">
+          <div className="font-heading text-4xl font-semibold tracking-tight text-[color:var(--color-foreground)]">
+            {kpi.value}
+          </div>
+          <div className="mt-2 text-sm font-medium text-[color:var(--color-foreground)]">{kpi.label}</div>
+          {kpi.sub && (
+            <div className="mt-1 text-xs text-[color:var(--color-muted-foreground)]">{kpi.sub}</div>
+          )}
+        </GlassCard>
+      ))}
+    </div>
+  );
+}

--- a/marketing/src/components/NoiseOverlay.tsx
+++ b/marketing/src/components/NoiseOverlay.tsx
@@ -1,0 +1,15 @@
+export function NoiseOverlay() {
+  // Inline SVG noise — no external fetch, no JS
+  const svg = `<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.08 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>`;
+  const encoded = svg.replace(/#/g, "%23");
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none fixed inset-0 z-0 opacity-[0.035] mix-blend-screen"
+      style={{
+        backgroundImage: `url("data:image/svg+xml;utf8,${encoded}")`,
+        backgroundSize: "200px 200px",
+      }}
+    />
+  );
+}

--- a/marketing/src/components/PricingCard.tsx
+++ b/marketing/src/components/PricingCard.tsx
@@ -1,0 +1,62 @@
+import { GlassCard } from "./GlassCard";
+import { cn } from "@/lib/cn";
+
+type Plan = {
+  name: string;
+  price: string;
+  priceSub?: string;
+  description: string;
+  features: string[];
+  cta: string;
+  ctaHref: string;
+  featured?: boolean;
+};
+
+export function PricingCard({ plan }: { plan: Plan }) {
+  return (
+    <GlassCard
+      className={cn(
+        "flex flex-col p-6",
+        plan.featured && "ring-1 ring-[color:var(--color-primary)]/60"
+      )}
+    >
+      {plan.featured && (
+        <div className="mb-3 inline-flex w-max items-center rounded-full bg-[color:var(--color-primary)]/15 px-2 py-0.5 text-xs font-medium text-[color:var(--color-primary)]">
+          Most popular
+        </div>
+      )}
+      <div className="font-heading text-lg font-semibold">{plan.name}</div>
+      <div className="mt-2 flex items-baseline gap-1">
+        <div className="font-heading text-3xl font-semibold tracking-tight">{plan.price}</div>
+        {plan.priceSub && (
+          <div className="text-sm text-[color:var(--color-muted-foreground)]">{plan.priceSub}</div>
+        )}
+      </div>
+      <p className="mt-2 text-sm text-[color:var(--color-muted-foreground)]">{plan.description}</p>
+      <ul className="mt-5 flex-1 space-y-2 text-sm">
+        {plan.features.map((f) => (
+          <li key={f} className="flex items-start gap-2">
+            <span
+              className="mt-1 inline-block h-1.5 w-1.5 flex-none rounded-full bg-[color:var(--color-accent)]"
+              aria-hidden
+            />
+            <span className="text-[color:var(--color-foreground)]/90">{f}</span>
+          </li>
+        ))}
+      </ul>
+      <a
+        href={plan.ctaHref}
+        className={cn(
+          "mt-6 inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-opacity",
+          plan.featured
+            ? "bg-[color:var(--color-primary)] text-[color:var(--color-primary-foreground)] hover:opacity-90"
+            : "border border-[color:var(--color-border)] text-[color:var(--color-foreground)] hover:bg-[color:var(--color-card)]"
+        )}
+      >
+        {plan.cta}
+      </a>
+    </GlassCard>
+  );
+}
+
+export type { Plan };

--- a/marketing/src/lib/cn.ts
+++ b/marketing/src/lib/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(" ");
+}

--- a/marketing/src/lib/site.ts
+++ b/marketing/src/lib/site.ts
@@ -1,0 +1,14 @@
+export const site = {
+  name: "Gradata",
+  url: "https://gradata.ai",
+  appUrl: "https://app.gradata.ai",
+  docsUrl: "https://github.com/Gradata/gradata",
+  tagline: "AI that learns the corrections you keep making.",
+  description:
+    "Gradata captures every AI correction and makes sure it never happens again. Open source SDK with a learning pipeline that graduates lessons into rules.",
+  social: {
+    x: "#",
+    linkedin: "#",
+    github: "https://github.com/Gradata/gradata",
+  },
+} as const;

--- a/marketing/tsconfig.json
+++ b/marketing/tsconfig.json
@@ -1,0 +1,44 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "out",
+    ".next"
+  ]
+}

--- a/marketing/wrangler.toml
+++ b/marketing/wrangler.toml
@@ -1,0 +1,3 @@
+name = "gradata-website"
+compatibility_date = "2025-01-01"
+pages_build_output_dir = "out"

--- a/sdk/PYPI-SETUP.md
+++ b/sdk/PYPI-SETUP.md
@@ -1,0 +1,84 @@
+# PyPI Trusted Publisher Setup
+
+This repository publishes the `gradata` package to PyPI using **Trusted
+Publishing** (OIDC) rather than long-lived API tokens. The GitHub Actions
+workflow proves its identity to PyPI via GitHub's OIDC provider, so PyPI
+mints a short-lived token at publish time. There are no secrets to rotate.
+
+## One-time setup on PyPI (production)
+
+1. Sign in at https://pypi.org with an account that owns (or will own) the
+   `gradata` project. If the project does not yet exist, you will add it as a
+   **pending publisher** — PyPI promotes it to a real publisher on the first
+   successful upload.
+2. Go to **Your account → Publishing** (or the project's *Manage → Publishing*
+   tab if the project already exists).
+3. Click **Add a new pending publisher** and fill in:
+
+   | Field                 | Value                    |
+   |-----------------------|--------------------------|
+   | PyPI Project Name     | `gradata`                |
+   | Owner                 | `Gradata`                |
+   | Repository name       | `gradata`                |
+   | Workflow name         | `sdk-publish.yml`        |
+   | Environment name      | *(leave blank)*          |
+
+4. Save. PyPI now trusts the
+   `Gradata/gradata` repository's `sdk-publish.yml` workflow to publish the
+   `gradata` distribution.
+
+5. Push a `sdk-vX.Y.Z` tag (see [`RELEASE.md`](./RELEASE.md)). The first
+   successful run promotes the pending publisher to active.
+
+## One-time setup on TestPyPI (release candidates)
+
+Release candidates (tags like `sdk-v0.5.1rc1`) publish to TestPyPI. Mirror the
+same configuration there:
+
+1. Sign in at https://test.pypi.org.
+2. **Your account → Publishing → Add a new pending publisher** with the same
+   values as above — `gradata`, `Gradata/gradata`, `sdk-publish.yml`, no
+   environment.
+3. Push a pre-release tag (`sdk-v0.5.1rc1`) to validate.
+
+## Why Trusted Publishing
+
+- **No API tokens** in GitHub Secrets — nothing to leak, rotate, or revoke.
+- **Workflow-scoped** — only `sdk-publish.yml` on this repo can publish. A
+  compromised PR cannot exfiltrate a token because there is no token.
+- **Auditable** — every upload is linked to the specific workflow run on GitHub.
+
+See the PyPI docs:
+https://docs.pypi.org/trusted-publishers/
+
+## Required workflow permissions
+
+The workflow job that publishes **must** declare:
+
+```yaml
+permissions:
+  id-token: write  # OIDC — required for Trusted Publishing
+  contents: read
+```
+
+`sdk-publish.yml` in this repo already does this on the `publish-pypi` and
+`publish-testpypi` jobs. Do not remove these blocks.
+
+## Verifying setup
+
+After pushing your first real tag:
+
+1. Workflow page: https://github.com/Gradata/gradata/actions/workflows/sdk-publish.yml
+2. Expand the `publish-pypi` (or `publish-testpypi`) job and confirm the
+   `Publish to PyPI` step succeeded.
+3. PyPI project page: https://pypi.org/project/gradata/ — the new version
+   should appear within seconds of the step finishing.
+
+## Troubleshooting
+
+- **`invalid-publisher`** — the repo name, workflow filename, or environment
+  does not match the pending publisher. Double-check spelling and case.
+- **`403 Forbidden`** — the job is missing `id-token: write`. Add it under
+  `permissions:`.
+- **`File already exists`** — PyPI will not accept a re-upload of the same
+  version. Bump `pyproject.toml` and retag.

--- a/sdk/RELEASE.md
+++ b/sdk/RELEASE.md
@@ -1,0 +1,118 @@
+# Gradata SDK Release Process
+
+The Gradata SDK (`gradata` on PyPI) publishes automatically when a tag matching
+`sdk-v*` is pushed to GitHub. The workflow lives at
+[`.github/workflows/sdk-publish.yml`](../.github/workflows/sdk-publish.yml) and
+uses PyPI Trusted Publishing (OIDC) — no API tokens are stored in GitHub
+secrets.
+
+## Package layout
+
+- Package name on PyPI: **`gradata`**
+- Source of truth: `pyproject.toml` at the repository root
+- Source tree: `src/gradata/`
+- Build backend: `hatchling`
+- Build driver (CI + local): `uv build`
+
+## Prerequisites (one time)
+
+1. Configure the PyPI Trusted Publisher — see [`PYPI-SETUP.md`](./PYPI-SETUP.md).
+2. Configure the TestPyPI Trusted Publisher (same file) if you plan to publish
+   release candidates.
+
+## Cutting a release
+
+1. **Bump the version** in `pyproject.toml`:
+
+   ```toml
+   [project]
+   name = "gradata"
+   version = "0.5.1"
+   ```
+
+   The publish workflow fails fast if the git tag does not match this value.
+
+2. **Update `CHANGELOG.md`** with the changes under a new heading, e.g.
+   `## [0.5.1] - 2026-04-20`.
+
+3. **Commit** to the default branch (or merge via PR):
+
+   ```bash
+   git add pyproject.toml CHANGELOG.md
+   git commit -m "release: gradata 0.5.1"
+   git push origin main
+   ```
+
+4. **Tag and push**:
+
+   ```bash
+   git tag sdk-v0.5.1 -m "gradata v0.5.1"
+   git push origin sdk-v0.5.1
+   ```
+
+5. **Watch the workflow** at
+   https://github.com/Gradata/gradata/actions/workflows/sdk-publish.yml —
+   the `build` job validates + builds, then `publish-pypi` uploads via OIDC.
+
+6. **Verify**:
+
+   ```bash
+   pip install --upgrade gradata
+   python -c "import gradata; print(gradata.__version__)"
+   gradata --version
+   ```
+
+## Release candidates (TestPyPI)
+
+Any tag containing `rc`, `a`, `b`, `dev`, `alpha`, or `beta` is treated as a
+pre-release and publishes to **TestPyPI** instead of PyPI. The `pyproject.toml`
+version must still match.
+
+```bash
+# Bump pyproject.toml to 0.5.1rc1, commit, then:
+git tag sdk-v0.5.1rc1 -m "gradata v0.5.1rc1"
+git push origin sdk-v0.5.1rc1
+
+# Install from TestPyPI:
+pip install --index-url https://test.pypi.org/simple/ \
+            --extra-index-url https://pypi.org/simple/ \
+            --upgrade gradata==0.5.1rc1
+```
+
+## Idempotency
+
+Re-pushing the same tag (or pushing a tag whose version is already on the
+target index) does **not** error. The `build` job queries
+`pypi.org/pypi/gradata/json` (or the TestPyPI equivalent) and, if the version
+already exists, skips the publish job with a warning. Bump `pyproject.toml` and
+retag to actually ship.
+
+## Rolling back
+
+PyPI does not permit re-uploading a version number. If a broken release ships:
+
+1. Yank it on PyPI (Manage project → Releases → Yank).
+2. Bump to the next patch (e.g. `0.5.2`), fix, retag, publish.
+
+## Local dry run
+
+Before tagging, verify the build locally:
+
+```bash
+uv build
+ls dist/
+# Expect: gradata-<version>-py3-none-any.whl  gradata-<version>.tar.gz
+
+# Optional: install and smoke-test the wheel in a clean venv
+uv venv .venv-release
+source .venv-release/bin/activate   # Windows: .venv-release\Scripts\activate
+uv pip install dist/gradata-*.whl
+python -c "import gradata; print(gradata.__version__)"
+```
+
+## Test matrix (separate workflow)
+
+Every push or PR touching `src/gradata/**`, `tests/**`, or `pyproject.toml`
+triggers [`sdk-test.yml`](../.github/workflows/sdk-test.yml) on Python 3.11,
+3.12, and 3.13. The publish workflow does not gate on this — it runs its own
+test suite before building.


### PR DESCRIPTION
## Summary

Three follow-ups landed on the dashboard branch after PR #25 merged. Building on the production-deployed state.

### 1. Branded Supabase email templates (`f2cc259`)

6 inline-CSS table-layout HTML templates for Supabase's transactional emails — `cloud/supabase/email-templates/`:

- `confirm-signup.html` — Confirm your Gradata account
- `magic-link.html` — Sign in to Gradata
- `change-email.html` — Confirm your new email
- `reset-password.html` — Reset your Gradata password
- `invite-user.html` — You've been invited to a Gradata workspace
- `reauthentication.html` — Confirm it's you (with prominent OTP)

V3 Dark Cinematic styling (gradient CTA, `#0C1120` bg, system-ui fonts), email-client safe (no `<style>`, no flexbox, no external images), ~96-117 lines each. Uses Supabase template variables (`{{ .ConfirmationURL }}`, `{{ .Token }}`, `{{ .Email }}`, etc.). Companion `README.md` documents subjects, variables, and 5-step install in Supabase dashboard.

### 2. Privacy Policy + Terms of Service (`5a08cf5`)

Two public pages at `/legal/privacy` and `/legal/terms` (no auth required). Tied into the dashboard via:
- `<AuthLegalLinks />` shown on login/signup/forgot-password
- `<LegalFooter />` after children inside DashboardLayout

V3-themed using GlassCard. Plain-language, Gradata-specific copy:
- Sub-processors named: Supabase, Stripe, Cloudflare, Sentry
- Stripe pricing referenced ($29 Cloud, $99 Team)
- AGPL-3.0 for SDK called out separately from hosted-service Terms
- Delaware governing law (most common SaaS default)
- Liability cap = 12 months fees, $100 floor for free tier
- "Raw corrections never leave your device" reaffirmed

24 static routes total now (was 22).

### 3. Auto-deploy CI workflow (`18323ec`)

`.github/workflows/dashboard-source-maps.yml` — replaces the broken Cloudflare-native git-builder with a GitHub Action:

- Triggers on push to `main` touching `cloud/dashboard/**` (and `workflow_dispatch`)
- Skips on `[skip ci]` in commit message
- Builds with Sentry source-map upload (so prod stack traces become readable)
- Deploys `out/` via wrangler

Plus `cloud/dashboard/SOURCE-MAPS.md` (operations doc).

## Required GitHub Actions secrets

For the workflow to actually run successfully, set these in GitHub repo Settings → Secrets:

| Secret | Value |
|---|---|
| `SENTRY_AUTH_TOKEN` | Sentry user → Auth tokens → `project:write` + `project:releases` |
| `SENTRY_ORG` | `gradata` |
| `SENTRY_PROJECT` | `gradata-dashboard` |
| `CLOUDFLARE_API_TOKEN` | CF → API Tokens → `Cloudflare Pages: Edit` permission |
| `CLOUDFLARE_ACCOUNT_ID` | `d568e4421afe0100d09df9e4d29bef81` |
| `NEXT_PUBLIC_SUPABASE_URL` | `https://miqwilxheuxwafvmoajs.supabase.co` |
| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | from Supabase |
| `NEXT_PUBLIC_API_URL` | `https://gradata-production.up.railway.app/api/v1` (or `api.gradata.ai` once SSL fixed) |
| `NEXT_PUBLIC_SENTRY_DSN` | from Sentry project |

## Test plan

- [x] `pnpm build` succeeds, 24 static routes
- [x] `cloud/dashboard/app/legal/privacy` + `terms` render with V3 theme
- [x] Auth pages show small Privacy/Terms link pair below card
- [x] DashboardLayout renders LegalFooter under main content
- [x] Direct-deployed to https://382abd86.gradata-dashboard.pages.dev — visit `/legal/privacy` to verify
- [ ] Set the 9 GitHub secrets above so future pushes auto-deploy
- [ ] Paste the 6 email templates into Supabase dashboard

Generated with Gradata