### PR TITLE
feat: team + operator + seed + health endpoints

### DIFF
--- a/cloud/SUPABASE-SETUP.md
+++ b/cloud/SUPABASE-SETUP.md
@@ -114,3 +114,35 @@ SELECT * FROM pg_trigger WHERE tgname LIKE '%handle_new_user%';
 ```
 
 Should return at least one row. If missing, re-run the relevant migration.
+
+## 7. Demo seed on signup (migration 004)
+
+Migration `004_seed_demo_brain.sql` seeds a fully-populated demo brain when a new user signs up. Sims (S101–S103) showed users abandon when day-1 dashboards are empty.
+
+**What gets created:** 1 brain (`metadata.is_demo = true`), 8 lessons across the 6-dim taxonomy, 25 corrections in a Wozniak decay shape, 4 meta-rules, 6 events.
+
+**How users clear it:**
+
+```
+POST /api/v1/brains/{brain_id}/clear-demo
+```
+
+Response: `{ deleted: int, by_table: {...} }`. Only rows with `is_demo` flag are removed; real lessons are never touched.
+
+**Test signup → seed locally:**
+
+```sql
+SELECT handle_new_user_test(
+  '00000000-0000-0000-0000-000000000001'::uuid,
+  'Local Dev'
+);
+SELECT count(*) FROM lessons WHERE brain_id = '<returned uuid>';      -- expect 8
+SELECT count(*) FROM corrections WHERE brain_id = '<returned uuid>';  -- expect 25
+```
+
+**Tear down:**
+
+```sql
+DELETE FROM brains WHERE id = '<returned uuid>';
+-- ON DELETE CASCADE removes child rows.
+```

--- a/cloud/app/auth.py
+++ b/cloud/app/auth.py
@@ -19,6 +19,9 @@ _bearer = HTTPBearer()
 # Cache JWKS so we don't fetch on every request
 _jwks_cache: dict | None = None
 
+# Operator allowlist — god-mode admin access
+OPERATOR_DOMAINS = {"gradata.ai", "sprites.ai"}
+
 
 async def _get_jwks() -> dict:
     """Fetch and cache the Supabase JWKS for ES256 verification."""
@@ -47,8 +50,8 @@ async def verify_api_key(key: str) -> dict:
     return rows[0]
 
 
-async def verify_jwt(signed_jwt: str) -> str:
-    """Verify a Supabase JWT (ES256 or HS256) and return the user_id."""
+async def verify_jwt_claims(signed_jwt: str) -> dict:
+    """Verify a Supabase JWT (ES256 or HS256) and return the full claims dict."""
     settings = get_settings()
 
     # Try ES256 with JWKS first (modern Supabase projects)
@@ -67,10 +70,9 @@ async def verify_jwt(signed_jwt: str) -> str:
                 algorithms=["ES256"],
                 options={"verify_aud": False},
             )
-            user_id = claims.get("sub")
-            if not user_id:
+            if not claims.get("sub"):
                 raise HTTPException(status_code=401, detail="Invalid JWT: no sub claim")
-            return user_id
+            return claims
     except JWTError:
         pass  # Fall through to HS256
 
@@ -82,12 +84,17 @@ async def verify_jwt(signed_jwt: str) -> str:
             algorithms=["HS256"],
             options={"verify_aud": False},
         )
-        user_id = claims.get("sub")
-        if not user_id:
+        if not claims.get("sub"):
             raise HTTPException(status_code=401, detail="Invalid JWT: no sub claim")
-        return user_id
+        return claims
     except JWTError as e:
         raise HTTPException(status_code=401, detail=f"Invalid JWT: {e}") from e
+
+
+async def verify_jwt(signed_jwt: str) -> str:
+    """Verify a Supabase JWT and return just the user_id."""
+    claims = await verify_jwt_claims(signed_jwt)
+    return claims["sub"]
 
 
 async def get_current_brain(
@@ -144,3 +151,45 @@ async def get_brain_for_request(
 
     user_id = await verify_jwt(cred)
     return await verify_brain_ownership(brain_id, user_id)
+
+
+async def _resolve_user_email(user_id: str, claims: dict) -> str | None:
+    """Resolve the caller's email — prefer JWT claim, fall back to auth.users lookup."""
+    email = claims.get("email")
+    if email:
+        return email
+
+    # Fallback: query auth.users via the Supabase service-role client.
+    # Supabase exposes auth users through the admin REST endpoint, not PostgREST.
+    # If your db wrapper doesn't expose that, the JWT claim path is the primary route.
+    try:
+        db = get_db()
+        rows = await db.select("users", columns="email", filters={"id": user_id})
+        if rows:
+            return rows[0].get("email")
+    except Exception as exc:  # pragma: no cover - defensive
+        _log.warning("Failed to resolve email for user=%s: %s", user_id, exc)
+    return None
+
+
+async def require_operator(
+    credentials: HTTPAuthorizationCredentials = Security(_bearer),
+) -> str:
+    """Require the caller's email domain to be in OPERATOR_DOMAINS.
+
+    Resolves email from the JWT's ``email`` claim when present; otherwise falls
+    back to a ``users`` table lookup by ``user_id``. Raises 403 otherwise.
+    Returns the user_id for downstream use.
+    """
+    claims = await verify_jwt_claims(credentials.credentials)
+    user_id = claims["sub"]
+
+    email = await _resolve_user_email(user_id, claims)
+    if not email:
+        raise HTTPException(status_code=403, detail="Operator access requires a verified email")
+
+    domain = email.split("@", 1)[1].lower() if "@" in email else ""
+    if domain not in OPERATOR_DOMAINS:
+        raise HTTPException(status_code=403, detail="Operator access denied")
+
+    return user_id

--- a/cloud/app/db.py
+++ b/cloud/app/db.py
@@ -69,14 +69,17 @@ class SupabaseClient:
     async def delete(
         self, table: str, filters: dict[str, Any] | None = None,
     ) -> list[dict]:
-        """DELETE rows matching eq filters."""
+        """DELETE rows matching eq filters. Returns deleted rows when PostgREST sends them back."""
         params: dict[str, str] = {}
         if filters:
             for key, val in filters.items():
                 params[key] = f"eq.{val}"
         resp = await self._http.delete(f"/{table}", params=params)
         resp.raise_for_status()
-        return resp.json() if resp.content else []
+        try:
+            return resp.json()
+        except ValueError:
+            return []
 
     async def close(self):
         await self._http.aclose()

--- a/cloud/app/db.py
+++ b/cloud/app/db.py
@@ -66,6 +66,18 @@ class SupabaseClient:
         resp.raise_for_status()
         return resp.json()
 
+    async def delete(
+        self, table: str, filters: dict[str, Any] | None = None,
+    ) -> list[dict]:
+        """DELETE rows matching eq filters."""
+        params: dict[str, str] = {}
+        if filters:
+            for key, val in filters.items():
+                params[key] = f"eq.{val}"
+        resp = await self._http.delete(f"/{table}", params=params)
+        resp.raise_for_status()
+        return resp.json() if resp.content else []
+
     async def close(self):
         await self._http.aclose()
 

--- a/cloud/app/models.py
+++ b/cloud/app/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, EmailStr, Field, field_validator
 
 
 class Severity(str, Enum):
@@ -240,3 +240,46 @@ class SubscriptionResponse(BaseModel):
     status: str | None = None
     current_period_end: str | None = None
     usage: SubscriptionUsage = Field(default_factory=SubscriptionUsage)
+
+
+# ---------------------------------------------------------------------------
+# Team / workspace member models
+# ---------------------------------------------------------------------------
+
+
+class MemberRole(str, Enum):
+    owner = "owner"
+    admin = "admin"
+    member = "member"
+
+
+class InviteRole(str, Enum):
+    admin = "admin"
+    member = "member"
+
+
+class MemberResponse(BaseModel):
+    user_id: str
+    email: str | None = None
+    display_name: str | None = None
+    role: str
+    joined_at: str | None = None
+    last_sync_at: str | None = None
+
+
+class InviteRequest(BaseModel):
+    email: EmailStr
+    role: InviteRole = InviteRole.member
+
+
+class InviteResponse(BaseModel):
+    id: str
+    email: str
+    role: str
+    token: str
+    accept_url: str
+    expires_at: str | None = None
+
+
+class UpdateRoleRequest(BaseModel):
+    role: InviteRole  # owner cannot be assigned through this endpoint

--- a/cloud/app/models.py
+++ b/cloud/app/models.py
@@ -283,3 +283,43 @@ class InviteResponse(BaseModel):
 
 class UpdateRoleRequest(BaseModel):
     role: InviteRole  # owner cannot be assigned through this endpoint
+
+
+# ---------------------------------------------------------------------------
+# Operator / admin models (god-mode panel)
+# ---------------------------------------------------------------------------
+
+
+class GlobalKpis(BaseModel):
+    """Aggregate KPIs across all workspaces. All monetary amounts in USD (dollars)."""
+
+    mrr_usd: float = 0.0
+    arr_usd: float = 0.0
+    mrr_delta_pct: float = 0.0  # month-over-month new-workspace growth %
+    customers_total: int = 0
+    customers_active: int = 0  # any brain synced within 14 days
+    churn_rate: float = 0.0  # workspaces deleted in last 30d / total at period start
+    net_revenue_retention: float = 1.0  # TODO: placeholder until sub-history tracked
+
+
+class AdminCustomer(BaseModel):
+    """One workspace row for the operator customer list."""
+
+    id: str
+    company: str
+    plan: str
+    mrr_usd: float = 0.0
+    active_users: int = 0
+    brains: int = 0
+    last_active: str | None = None  # ISO timestamp
+    health: str = "healthy"  # healthy | at-risk | churning
+
+
+class AdminAlert(BaseModel):
+    """A derived operational alert for the operator panel."""
+
+    id: str
+    kind: str  # churn-risk | failed-payment | usage-spike
+    customer: str
+    detail: str
+    created_at: str  # ISO timestamp

--- a/cloud/app/routes/__init__.py
+++ b/cloud/app/routes/__init__.py
@@ -14,6 +14,7 @@ from app.routes.lessons import router as lessons_router
 from app.routes.meta_rules import router as meta_rules_router
 from app.routes.rule_patches import router as rule_patches_router
 from app.routes.sync import router as sync_router
+from app.routes.team import router as team_router
 from app.routes.users import router as users_router
 
 router = APIRouter()
@@ -28,3 +29,4 @@ router.include_router(meta_rules_router, tags=["meta-rules"])
 router.include_router(activity_router, tags=["activity"])
 router.include_router(rule_patches_router, tags=["rule-patches"])
 router.include_router(billing_router, tags=["billing"])
+router.include_router(team_router, tags=["team"])

--- a/cloud/app/routes/__init__.py
+++ b/cloud/app/routes/__init__.py
@@ -12,6 +12,7 @@ from app.routes.brains import router as brains_router
 from app.routes.corrections import router as corrections_router
 from app.routes.lessons import router as lessons_router
 from app.routes.meta_rules import router as meta_rules_router
+from app.routes.operator import router as operator_router
 from app.routes.rule_patches import router as rule_patches_router
 from app.routes.sync import router as sync_router
 from app.routes.team import router as team_router
@@ -30,3 +31,4 @@ router.include_router(activity_router, tags=["activity"])
 router.include_router(rule_patches_router, tags=["rule-patches"])
 router.include_router(billing_router, tags=["billing"])
 router.include_router(team_router, tags=["team"])
+router.include_router(operator_router, tags=["operator"])

--- a/cloud/app/routes/brains.py
+++ b/cloud/app/routes/brains.py
@@ -141,3 +141,69 @@ async def delete_brain(
     now = datetime.now(timezone.utc).isoformat()
     await db.update("brains", data={"deleted_at": now}, filters={"id": brain_id})
     _log.info("Soft-deleted brain=%s", brain_id)
+
+
+class ClearDemoResponse(BaseModel):
+    deleted: int
+    by_table: dict[str, int]
+
+
+@router.post("/brains/{brain_id}/clear-demo", response_model=ClearDemoResponse)
+async def clear_demo(
+    brain_id: str,
+    request: Request,
+    credentials: HTTPAuthorizationCredentials = Depends(_bearer),
+) -> ClearDemoResponse:
+    """Delete all demo rows (is_demo=true) scoped to this brain.
+
+    Auth: caller must own the brain. Returns per-table delete counts and a total.
+    """
+    await get_brain_for_request(brain_id, credentials)
+    db = get_db()
+
+    by_table: dict[str, int] = {}
+    total = 0
+
+    # Children first (FK order doesn't strictly matter here, but we delete
+    # narrowest-to-widest so counts are readable).
+    for table in ("corrections", "lessons", "meta_rules", "events"):
+        deleted = await _delete_demo_rows(db, table, brain_id)
+        by_table[table] = deleted
+        total += deleted
+
+    # Finally the brain itself — only if it was flagged is_demo in metadata.
+    brain_rows = await db.select(
+        "brains", columns="id,metadata", filters={"id": brain_id}
+    )
+    if brain_rows and _is_demo_metadata(brain_rows[0].get("metadata")):
+        await db.delete("brains", filters={"id": brain_id})
+        by_table["brains"] = 1
+        total += 1
+    else:
+        by_table["brains"] = 0
+
+    _log.info("Cleared demo data for brain=%s (deleted=%d)", brain_id, total)
+    return ClearDemoResponse(deleted=total, by_table=by_table)
+
+
+async def _delete_demo_rows(db, table: str, brain_id: str) -> int:
+    """Fetch rows for the brain, filter by is_demo marker, delete those ids."""
+    rows = await db.select(table, columns="id,data", filters={"brain_id": brain_id})
+    demo_rows = [r for r in rows if _is_demo_data(r.get("data"))]
+    if not demo_rows:
+        return 0
+    for row in demo_rows:
+        await db.delete(table, filters={"id": row["id"]})
+    return len(demo_rows)
+
+
+def _is_demo_data(data) -> bool:
+    if not data:
+        return False
+    if isinstance(data, dict):
+        return bool(data.get("is_demo"))
+    return False
+
+
+def _is_demo_metadata(metadata) -> bool:
+    return _is_demo_data(metadata)

--- a/cloud/app/routes/health.py
+++ b/cloud/app/routes/health.py
@@ -1,11 +1,79 @@
-"""Health check endpoint for Railway/uptime monitoring."""
+"""Health check endpoints for Railway/uptime monitoring + ops visibility."""
 from __future__ import annotations
 
+import logging
+import os
+import time
+from typing import Literal
+
 from fastapi import APIRouter
+from pydantic import BaseModel
+
+from app.config import get_settings
+from app.db import get_db
+
+_log = logging.getLogger(__name__)
 
 router = APIRouter()
 
+_BOOTED_AT = time.time()
 
-@router.get("/health")
-async def health():
-    return {"status": "healthy", "service": "gradata-cloud", "version": "0.1.0"}
+
+class HealthResponse(BaseModel):
+    """Liveness — answers "is the process up". Cheap, no DB hit."""
+    status: Literal["healthy"]
+    service: str
+    version: str
+
+
+class ReadyResponse(BaseModel):
+    """Readiness — answers "can we serve requests". Pings DB."""
+    status: Literal["ready", "degraded", "unavailable"]
+    service: str
+    version: str
+    environment: str
+    release: str
+    uptime_seconds: float
+    db: Literal["ok", "fail"]
+    db_latency_ms: float | None = None
+
+
+@router.get("/health", response_model=HealthResponse)
+async def health() -> HealthResponse:
+    """Liveness probe. Always returns 200 if the process is responding."""
+    return HealthResponse(status="healthy", service="gradata-cloud", version="0.1.0")
+
+
+@router.get("/ready", response_model=ReadyResponse)
+async def ready() -> ReadyResponse:
+    """Readiness probe — verifies the DB is reachable. Use this for uptime monitors."""
+    settings = get_settings()
+    release = os.environ.get("RAILWAY_GIT_COMMIT_SHA", "dev")[:7]
+    uptime = round(time.time() - _BOOTED_AT, 2)
+
+    db_status: Literal["ok", "fail"] = "fail"
+    db_latency_ms: float | None = None
+    try:
+        db = get_db()
+        t0 = time.time()
+        # Cheap query — just count workspaces (no row data)
+        await db.select("workspaces", columns="id", filters={"id": "00000000-0000-0000-0000-000000000000"})
+        db_latency_ms = round((time.time() - t0) * 1000, 1)
+        db_status = "ok"
+    except Exception as exc:
+        _log.warning("readiness DB probe failed: %s", exc)
+
+    overall: Literal["ready", "degraded", "unavailable"] = (
+        "ready" if db_status == "ok" else "unavailable"
+    )
+
+    return ReadyResponse(
+        status=overall,
+        service="gradata-cloud",
+        version="0.1.0",
+        environment=settings.environment,
+        release=release,
+        uptime_seconds=uptime,
+        db=db_status,
+        db_latency_ms=db_latency_ms,
+    )

--- a/cloud/app/routes/operator.py
+++ b/cloud/app/routes/operator.py
@@ -1,0 +1,329 @@
+"""Operator (god-mode) admin endpoints.
+
+All routes here are gated behind :func:`app.auth.require_operator`, which
+enforces the ``@gradata.ai`` / ``@sprites.ai`` email allowlist. These power the
+dashboard's /operator page (global KPIs, customer list, derived alerts).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from app.auth import require_operator
+from app.db import get_db
+from app.models import AdminAlert, AdminCustomer, GlobalKpis
+
+_log = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# ---------------------------------------------------------------------------
+# Plan -> monthly price (USD). Enterprise is custom/negotiated -> skipped in MRR.
+# ---------------------------------------------------------------------------
+_PLAN_MRR_USD: dict[str, float] = {
+    "free": 0.0,
+    "pro": 29.0,  # "cloud" tier in the public pricing — stored as "pro" in DB
+    "team": 99.0,
+    # "enterprise": custom -> excluded from automatic MRR
+}
+
+_HEALTHY_DAYS = 14
+_AT_RISK_DAYS = 30
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    """Parse an ISO timestamp string (or pass-through datetime) to aware UTC."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    try:
+        # Accept trailing Z + fractional seconds
+        s = str(value).replace("Z", "+00:00")
+        dt = datetime.fromisoformat(s)
+        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def _classify_health(last_active: datetime | None, now: datetime) -> str:
+    """healthy (<14d) | at-risk (14-30d) | churning (>30d or never)."""
+    if last_active is None:
+        return "churning"
+    delta = now - last_active
+    if delta <= timedelta(days=_HEALTHY_DAYS):
+        return "healthy"
+    if delta <= timedelta(days=_AT_RISK_DAYS):
+        return "at-risk"
+    return "churning"
+
+
+def _plan_mrr(plan: str | None) -> float:
+    return _PLAN_MRR_USD.get((plan or "free").lower(), 0.0)
+
+
+async def _collect_brains_by_workspace(db) -> dict[str, list[dict]]:
+    """Group all brains by workspace_id (single fetch)."""
+    brains = await db.select("brains", columns="id,workspace_id,user_id,last_sync_at")
+    grouped: dict[str, list[dict]] = {}
+    for b in brains:
+        ws = b.get("workspace_id")
+        if ws:
+            grouped.setdefault(ws, []).append(b)
+    return grouped
+
+
+def _latest_sync(brains: list[dict]) -> datetime | None:
+    latest: datetime | None = None
+    for b in brains:
+        ts = _parse_ts(b.get("last_sync_at"))
+        if ts and (latest is None or ts > latest):
+            latest = ts
+    return latest
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/global-kpis
+# ---------------------------------------------------------------------------
+
+
+@router.get("/admin/global-kpis", response_model=GlobalKpis)
+async def get_global_kpis(_: str = Depends(require_operator)) -> GlobalKpis:
+    """Return cross-workspace KPI rollup."""
+    db = get_db()
+    now = datetime.now(timezone.utc)
+
+    workspaces = await db.select(
+        "workspaces",
+        columns="id,plan,created_at,deleted_at",
+    )
+
+    # MRR: sum of tier prices across all non-enterprise workspaces.
+    mrr = sum(_plan_mrr(w.get("plan")) for w in workspaces)
+    arr = mrr * 12
+
+    # MRR delta %: new workspaces this calendar month vs. previous month.
+    # Rough proxy for growth until subscription-history is tracked.
+    this_month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    prev_month_end = this_month_start - timedelta(seconds=1)
+    prev_month_start = prev_month_end.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+    this_count = 0
+    prev_count = 0
+    for w in workspaces:
+        ts = _parse_ts(w.get("created_at"))
+        if ts is None:
+            continue
+        if ts >= this_month_start:
+            this_count += 1
+        elif prev_month_start <= ts <= prev_month_end:
+            prev_count += 1
+    mrr_delta_pct = ((this_count - prev_count) / prev_count * 100.0) if prev_count else 0.0
+
+    # Active customers: any brain in the workspace synced within HEALTHY_DAYS.
+    brains_by_ws = await _collect_brains_by_workspace(db)
+    active_cutoff = now - timedelta(days=_HEALTHY_DAYS)
+    customers_active = 0
+    for w in workspaces:
+        latest = _latest_sync(brains_by_ws.get(w["id"], []))
+        if latest and latest >= active_cutoff:
+            customers_active += 1
+
+    # Churn rate: workspaces deleted in last 30d / total at period start.
+    # If deleted_at isn't tracked (column may not exist), this stays 0.0.
+    churn_cutoff = now - timedelta(days=30)
+    churned = 0
+    for w in workspaces:
+        deleted = _parse_ts(w.get("deleted_at"))
+        if deleted and deleted >= churn_cutoff:
+            churned += 1
+    total_at_start = max(len(workspaces) + churned, 1)
+    churn_rate = churned / total_at_start
+
+    return GlobalKpis(
+        mrr_usd=round(mrr, 2),
+        arr_usd=round(arr, 2),
+        mrr_delta_pct=round(mrr_delta_pct, 2),
+        customers_total=len(workspaces),
+        customers_active=customers_active,
+        churn_rate=round(churn_rate, 4),
+        # TODO: real NRR requires monthly subscription snapshots.
+        net_revenue_retention=1.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/customers
+# ---------------------------------------------------------------------------
+
+
+_CUSTOMER_SORT_KEYS = {"mrr", "active_users", "last_active"}
+
+
+@router.get("/admin/customers", response_model=list[AdminCustomer])
+async def list_customers(
+    sort: str = Query("mrr"),
+    order: str = Query("desc"),
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    _: str = Depends(require_operator),
+) -> list[AdminCustomer]:
+    """Paginated workspace list with activity-based health classification."""
+    if sort not in _CUSTOMER_SORT_KEYS:
+        raise HTTPException(status_code=400, detail=f"sort must be one of {sorted(_CUSTOMER_SORT_KEYS)}")
+    if order not in {"asc", "desc"}:
+        raise HTTPException(status_code=400, detail="order must be 'asc' or 'desc'")
+
+    db = get_db()
+    now = datetime.now(timezone.utc)
+
+    workspaces = await db.select(
+        "workspaces",
+        columns="id,name,plan,created_at",
+    )
+    brains_by_ws = await _collect_brains_by_workspace(db)
+
+    # Distinct members per workspace for "active users".
+    members = await db.select(
+        "workspace_members", columns="workspace_id,user_id"
+    )
+    members_by_ws: dict[str, set[str]] = {}
+    for m in members:
+        ws = m.get("workspace_id")
+        if ws and m.get("user_id"):
+            members_by_ws.setdefault(ws, set()).add(m["user_id"])
+
+    rows: list[AdminCustomer] = []
+    for w in workspaces:
+        ws_id = w["id"]
+        ws_brains = brains_by_ws.get(ws_id, [])
+        last_active = _latest_sync(ws_brains)
+        rows.append(
+            AdminCustomer(
+                id=ws_id,
+                company=w.get("name") or "",
+                plan=w.get("plan") or "free",
+                mrr_usd=_plan_mrr(w.get("plan")),
+                active_users=len(members_by_ws.get(ws_id, set())),
+                brains=len(ws_brains),
+                last_active=last_active.isoformat() if last_active else None,
+                health=_classify_health(last_active, now),
+            )
+        )
+
+    # Sort
+    reverse = order == "desc"
+    if sort == "mrr":
+        rows.sort(key=lambda r: r.mrr_usd, reverse=reverse)
+    elif sort == "active_users":
+        rows.sort(key=lambda r: r.active_users, reverse=reverse)
+    elif sort == "last_active":
+        # None sorts to the end regardless of order direction.
+        rows.sort(
+            key=lambda r: (r.last_active is None, r.last_active or ""),
+            reverse=reverse,
+        )
+
+    return rows[offset : offset + limit]
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/alerts
+# ---------------------------------------------------------------------------
+
+
+@router.get("/admin/alerts", response_model=list[AdminAlert])
+async def list_alerts(_: str = Depends(require_operator)) -> list[AdminAlert]:
+    """Return a derived alert list (churn-risk, failed-payment, usage-spike)."""
+    db = get_db()
+    now = datetime.now(timezone.utc)
+    alerts: list[AdminAlert] = []
+
+    workspaces = await db.select(
+        "workspaces",
+        columns="id,name,plan,subscription_status",
+    )
+    brains_by_ws = await _collect_brains_by_workspace(db)
+    stale_cutoff = now - timedelta(days=_HEALTHY_DAYS)
+
+    for w in workspaces:
+        ws_id = w["id"]
+        company = w.get("name") or ws_id
+        last_active = _latest_sync(brains_by_ws.get(ws_id, []))
+
+        # churn-risk: 14+ days inactive
+        if last_active is None or last_active < stale_cutoff:
+            days_inactive = (
+                int((now - last_active).total_seconds() // 86400) if last_active else None
+            )
+            detail = (
+                f"Inactive for {days_inactive}d" if days_inactive is not None else "No sync on record"
+            )
+            alerts.append(
+                AdminAlert(
+                    id=f"churn-{ws_id}",
+                    kind="churn-risk",
+                    customer=company,
+                    detail=detail,
+                    created_at=now.isoformat(),
+                )
+            )
+
+        # failed-payment: rely on the subscription_status column populated by
+        # the Stripe webhook handler. If the column isn't present we skip.
+        if (w.get("subscription_status") or "").lower() == "past_due":
+            alerts.append(
+                AdminAlert(
+                    id=f"payment-{ws_id}",
+                    kind="failed-payment",
+                    customer=company,
+                    detail="Subscription past_due",
+                    created_at=now.isoformat(),
+                )
+            )
+
+    # usage-spike: >3x weekly corrections vs. prior week per workspace.
+    week_ago = now - timedelta(days=7)
+    two_weeks_ago = now - timedelta(days=14)
+    for ws_id, ws_brains in brains_by_ws.items():
+        this_week = 0
+        prior_week = 0
+        for b in ws_brains:
+            corrections = await db.select(
+                "corrections", columns="created_at", filters={"brain_id": b["id"]}
+            )
+            for c in corrections:
+                ts = _parse_ts(c.get("created_at"))
+                if ts is None:
+                    continue
+                if ts >= week_ago:
+                    this_week += 1
+                elif two_weeks_ago <= ts < week_ago:
+                    prior_week += 1
+        if prior_week > 0 and this_week > prior_week * 3:
+            company = next(
+                (w.get("name") or ws_id for w in workspaces if w["id"] == ws_id), ws_id
+            )
+            alerts.append(
+                AdminAlert(
+                    id=f"spike-{ws_id}",
+                    kind="usage-spike",
+                    customer=company,
+                    detail=f"{this_week} corrections this week (vs {prior_week} prior)",
+                    created_at=now.isoformat(),
+                )
+            )
+
+    # TODO: Stripe failed-payment fully lands once we mirror subscription_status
+    # for every workspace. Current path relies on webhook-populated column.
+
+    return alerts

--- a/cloud/app/routes/team.py
+++ b/cloud/app/routes/team.py
@@ -1,0 +1,237 @@
+"""Team / workspace member management endpoints (JWT only)."""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.auth import get_current_user_id
+from app.db import get_db
+from app.models import (
+    InviteRequest,
+    InviteResponse,
+    MemberResponse,
+    UpdateRoleRequest,
+)
+
+_log = logging.getLogger(__name__)
+
+router = APIRouter()
+
+INVITE_BASE_URL = "https://app.gradata.ai/invites"
+
+
+async def _get_member(workspace_id: str, user_id: str) -> dict | None:
+    """Return the workspace_members row for (workspace_id, user_id) or None."""
+    db = get_db()
+    rows = await db.select(
+        "workspace_members",
+        filters={"workspace_id": workspace_id, "user_id": user_id},
+    )
+    return rows[0] if rows else None
+
+
+async def _require_member(workspace_id: str, user_id: str) -> dict:
+    """Raise 403 unless the caller belongs to the workspace."""
+    membership = await _get_member(workspace_id, user_id)
+    if not membership:
+        raise HTTPException(status_code=403, detail="Not a member of this workspace")
+    return membership
+
+
+async def _require_admin(workspace_id: str, user_id: str) -> dict:
+    """Raise 403 unless the caller is owner or admin of the workspace."""
+    membership = await _require_member(workspace_id, user_id)
+    if membership.get("role") not in ("owner", "admin"):
+        raise HTTPException(status_code=403, detail="Admin or owner role required")
+    return membership
+
+
+@router.get(
+    "/workspaces/{workspace_id}/members",
+    response_model=list[MemberResponse],
+)
+async def list_members(
+    workspace_id: str,
+    user_id: str = Depends(get_current_user_id),
+) -> list[MemberResponse]:
+    """List workspace members. Caller must belong to the workspace."""
+    await _require_member(workspace_id, user_id)
+    db = get_db()
+
+    members = await db.select(
+        "workspace_members",
+        filters={"workspace_id": workspace_id},
+    )
+
+    results: list[MemberResponse] = []
+    for m in members:
+        member_user_id = m["user_id"]
+        # Pull the user's most recent brain in this workspace for last_sync_at.
+        brains = await db.select(
+            "brains",
+            columns="id,last_sync_at",
+            filters={"workspace_id": workspace_id, "user_id": member_user_id},
+        )
+        last_sync_at: str | None = None
+        for b in brains:
+            ts = b.get("last_sync_at")
+            if ts and (last_sync_at is None or ts > last_sync_at):
+                last_sync_at = ts
+
+        results.append(
+            MemberResponse(
+                user_id=member_user_id,
+                email=m.get("email"),
+                display_name=m.get("display_name"),
+                role=m.get("role", "member"),
+                joined_at=m.get("joined_at"),
+                last_sync_at=last_sync_at,
+            )
+        )
+    return results
+
+
+@router.post(
+    "/workspaces/{workspace_id}/invites",
+    response_model=InviteResponse,
+    status_code=201,
+)
+async def create_invite(
+    workspace_id: str,
+    body: InviteRequest,
+    user_id: str = Depends(get_current_user_id),
+) -> InviteResponse:
+    """Invite a teammate by email. Caller must be owner or admin."""
+    await _require_admin(workspace_id, user_id)
+    db = get_db()
+
+    token = secrets.token_urlsafe(32)
+    expires_at = (datetime.now(timezone.utc) + timedelta(days=7)).isoformat()
+    created_at = datetime.now(timezone.utc).isoformat()
+
+    invite_data = {
+        "workspace_id": workspace_id,
+        "email": str(body.email),
+        "role": body.role.value if hasattr(body.role, "value") else body.role,
+        "invited_by": user_id,
+        "token": token,
+        "expires_at": expires_at,
+        "created_at": created_at,
+    }
+
+    rows = await db.insert("workspace_invites", invite_data)
+    inserted = rows[0] if rows else invite_data
+
+    invite_id = inserted.get("id") or "pending"
+    accept_url = f"{INVITE_BASE_URL}/{token}"
+
+    _log.info(
+        "Invite created: workspace=%s email=%s role=%s by=%s",
+        workspace_id,
+        body.email,
+        invite_data["role"],
+        user_id,
+    )
+
+    return InviteResponse(
+        id=str(invite_id),
+        email=str(body.email),
+        role=invite_data["role"],
+        token=token,
+        accept_url=accept_url,
+        expires_at=inserted.get("expires_at", expires_at),
+    )
+
+
+@router.delete(
+    "/workspaces/{workspace_id}/members/{member_user_id}",
+    status_code=204,
+)
+async def remove_member(
+    workspace_id: str,
+    member_user_id: str,
+    user_id: str = Depends(get_current_user_id),
+) -> None:
+    """Remove a member from the workspace. Owner cannot be removed here."""
+    await _require_admin(workspace_id, user_id)
+    db = get_db()
+
+    target = await _get_member(workspace_id, member_user_id)
+    if not target:
+        raise HTTPException(status_code=404, detail="Member not found")
+
+    if target.get("role") == "owner":
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot remove the workspace owner; transfer ownership first",
+        )
+
+    await db.delete(
+        "workspace_members",
+        filters={"workspace_id": workspace_id, "user_id": member_user_id},
+    )
+    _log.info(
+        "Removed member: workspace=%s user=%s by=%s",
+        workspace_id,
+        member_user_id,
+        user_id,
+    )
+
+
+@router.patch(
+    "/workspaces/{workspace_id}/members/{member_user_id}",
+    response_model=MemberResponse,
+)
+async def update_member_role(
+    workspace_id: str,
+    member_user_id: str,
+    body: UpdateRoleRequest,
+    user_id: str = Depends(get_current_user_id),
+) -> MemberResponse:
+    """Change a member's role. Owner cannot be assigned through this endpoint."""
+    await _require_admin(workspace_id, user_id)
+    db = get_db()
+
+    new_role = body.role.value if hasattr(body.role, "value") else body.role
+    if new_role == "owner":
+        raise HTTPException(
+            status_code=400,
+            detail="Owner role cannot be assigned here; use ownership transfer flow",
+        )
+
+    target = await _get_member(workspace_id, member_user_id)
+    if not target:
+        raise HTTPException(status_code=404, detail="Member not found")
+
+    if target.get("role") == "owner":
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot change the owner's role; transfer ownership first",
+        )
+
+    await db.update(
+        "workspace_members",
+        data={"role": new_role},
+        filters={"workspace_id": workspace_id, "user_id": member_user_id},
+    )
+
+    _log.info(
+        "Updated role: workspace=%s user=%s role=%s by=%s",
+        workspace_id,
+        member_user_id,
+        new_role,
+        user_id,
+    )
+
+    return MemberResponse(
+        user_id=member_user_id,
+        email=target.get("email"),
+        display_name=target.get("display_name"),
+        role=new_role,
+        joined_at=target.get("joined_at"),
+        last_sync_at=None,
+    )

--- a/cloud/dashboard/app/error.tsx
+++ b/cloud/dashboard/app/error.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useEffect } from 'react'
+import * as Sentry from '@sentry/nextjs'
+import { GlassCard } from '@/components/layout/GlassCard'
+
+/**
+ * Top-level error boundary — caught client errors land here. Sentry already
+ * captures the underlying exception via the SDK init; we just give the user
+ * a survivable UI instead of a white screen.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    Sentry.captureException(error)
+  }, [error])
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <GlassCard gradTop className="w-full max-w-md text-center">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-[var(--color-destructive)]/20 ring-1 ring-[var(--color-destructive)]/40">
+          <span className="font-mono text-[20px] text-[var(--color-destructive)]">!</span>
+        </div>
+        <h1 className="mb-2 text-[20px]">Something broke</h1>
+        <p className="mb-1 text-[13px] text-[var(--color-body)]">
+          The error has been logged. Try the action again, or head back to your dashboard.
+        </p>
+        {error.digest && (
+          <p className="mb-6 font-mono text-[10px] text-[var(--color-body)]">
+            id: {error.digest}
+          </p>
+        )}
+        <div className="flex flex-col gap-2 sm:flex-row sm:justify-center">
+          <button
+            onClick={reset}
+            className="rounded-[0.5rem] bg-gradient-brand px-4 py-2 text-[13px] font-medium text-white transition-all hover:opacity-90"
+          >
+            Try again
+          </button>
+          <a
+            href="/dashboard"
+            className="rounded-[0.5rem] border border-[var(--color-border)] px-4 py-2 text-[13px] text-[var(--color-body)] transition-all hover:border-[var(--color-border-hover)] hover:text-[var(--color-text)]"
+          >
+            Go to Overview
+          </a>
+        </div>
+      </GlassCard>
+    </div>
+  )
+}

--- a/cloud/dashboard/app/not-found.tsx
+++ b/cloud/dashboard/app/not-found.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link'
+import type { Metadata } from 'next'
+import { GlassCard } from '@/components/layout/GlassCard'
+
+export const metadata: Metadata = {
+  title: 'Not found — Gradata',
+}
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <GlassCard gradTop className="w-full max-w-md text-center">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-brand shadow-[0_0_24px_rgba(58,130,255,0.4)]">
+          <span className="font-mono text-[18px] font-bold text-white">404</span>
+        </div>
+        <h1 className="mb-2 text-[20px]">Not found</h1>
+        <p className="mb-6 text-[13px] text-[var(--color-body)]">
+          That route doesn&apos;t exist — or maybe it moved. Head back to your dashboard.
+        </p>
+        <div className="flex flex-col gap-2 sm:flex-row sm:justify-center">
+          <Link
+            href="/dashboard"
+            className="rounded-[0.5rem] bg-gradient-brand px-4 py-2 text-[13px] font-medium text-white transition-all hover:opacity-90"
+          >
+            Go to Overview
+          </Link>
+          <Link
+            href="/login"
+            className="rounded-[0.5rem] border border-[var(--color-border)] px-4 py-2 text-[13px] text-[var(--color-body)] transition-all hover:border-[var(--color-border-hover)] hover:text-[var(--color-text)]"
+          >
+            Sign in
+          </Link>
+        </div>
+      </GlassCard>
+    </div>
+  )
+}

--- a/cloud/migrations/003_workspace_invites.sql
+++ b/cloud/migrations/003_workspace_invites.sql
@@ -1,0 +1,29 @@
+-- Gradata Cloud: Workspace invites
+-- Adds pending email invitations to a workspace with a magic acceptance token.
+
+CREATE TABLE workspace_invites (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    email TEXT NOT NULL,
+    role TEXT NOT NULL DEFAULT 'member' CHECK (role IN ('admin', 'member')),
+    invited_by UUID NOT NULL REFERENCES auth.users(id),
+    token TEXT NOT NULL UNIQUE,
+    expires_at TIMESTAMPTZ NOT NULL DEFAULT (now() + INTERVAL '7 days'),
+    accepted_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_workspace_invites_email ON workspace_invites (email);
+CREATE INDEX idx_workspace_invites_token ON workspace_invites (token);
+CREATE INDEX idx_workspace_invites_workspace_id ON workspace_invites (workspace_id);
+
+ALTER TABLE workspace_invites ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "workspace_invites_read_own_workspace" ON workspace_invites FOR SELECT
+  USING (workspace_id IN (SELECT workspace_id FROM workspace_members WHERE user_id = auth.uid()));
+
+CREATE POLICY "workspace_invites_create_admin" ON workspace_invites FOR INSERT
+  WITH CHECK (workspace_id IN (
+    SELECT workspace_id FROM workspace_members
+    WHERE user_id = auth.uid() AND role IN ('owner', 'admin')
+  ));

--- a/cloud/migrations/004_seed_demo_brain.sql
+++ b/cloud/migrations/004_seed_demo_brain.sql
@@ -1,0 +1,413 @@
+-- Gradata Cloud: Demo seed data for new signups
+-- Migration 004: Seed a demo brain on signup so the dashboard isn't empty on day 1.
+--
+-- Creates:
+--   1  brain   (name=demo-brain, domain=engineering, metadata.is_demo=true)
+--   8  lessons (2 INSTINCT, 3 PATTERN, 3 RULE across 6-dim taxonomy)
+--   25 corrections (spread over last 30 days, Wozniak-shaped decay)
+--   4  meta-rules (referencing demo lessons)
+--   6  events   (2 graduations, 1 self-heal patch, 1 meta-rule emergence, 1 convergence, 1 alert)
+--
+-- All rows carry an is_demo marker so users can purge them from the settings page.
+
+-- ============================================================
+-- SCHEMA ADDITIONS
+-- ============================================================
+
+-- Ensure brains has a metadata column for the is_demo flag.
+ALTER TABLE brains ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+-- Ensure brains has a domain column (referenced by the app and this seed).
+ALTER TABLE brains ADD COLUMN IF NOT EXISTS domain TEXT NOT NULL DEFAULT '';
+
+-- Ensure corrections has a JSONB data column we can tag with is_demo.
+ALTER TABLE corrections ADD COLUMN IF NOT EXISTS data JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+-- Ensure lessons has a JSONB data column we can tag with is_demo.
+ALTER TABLE lessons ADD COLUMN IF NOT EXISTS data JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+-- Ensure meta_rules has a JSONB context/data column for demo source_lesson_ids marker.
+ALTER TABLE meta_rules ADD COLUMN IF NOT EXISTS data JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+-- ============================================================
+-- SEED FUNCTION
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION seed_demo_brain(p_workspace_id UUID, p_user_id UUID)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_brain_id UUID;
+    v_lesson_ids UUID[] := ARRAY[]::UUID[];
+    v_lid UUID;
+    v_i INT;
+BEGIN
+    -- ------------------------------------------------------------------
+    -- 1 brain
+    -- ------------------------------------------------------------------
+    INSERT INTO brains (workspace_id, user_id, name, domain, metadata)
+    VALUES (
+        p_workspace_id,
+        p_user_id,
+        'demo-brain',
+        'engineering',
+        jsonb_build_object('is_demo', true, 'seeded_at', now())
+    )
+    RETURNING id INTO v_brain_id;
+
+    -- ------------------------------------------------------------------
+    -- 8 demo lessons (6-dim taxonomy, 2 INSTINCT + 3 PATTERN + 3 RULE)
+    -- ------------------------------------------------------------------
+
+    -- INSTINCT (2) — confidence 0.40–0.50
+    INSERT INTO lessons (brain_id, category, description, state, confidence, fire_count, data)
+    VALUES (
+        v_brain_id,
+        'Domain Fit',
+        'Prefer the project''s existing util helpers over pulling new dependencies.',
+        'INSTINCT', 0.42, 2,
+        jsonb_build_object('is_demo', true, 'dimension', 'Domain Fit')
+    )
+    RETURNING id INTO v_lid;
+    v_lesson_ids := v_lesson_ids || v_lid;
+
+    INSERT INTO lessons (brain_id, category, description, state, confidence, fire_count, data)
+    VALUES (
+        v_brain_id,
+        'Tone & Register',
+        'Match the user''s tone: terse prompts want terse answers, not essays.',
+        'INSTINCT', 0.48, 3,
+        jsonb_build_object('is_demo', true, 'dimension', 'Tone & Register')
+    )
+    RETURNING id INTO v_lid;
+    v_lesson_ids := v_lesson_ids || v_lid;
+
+    -- PATTERN (3) — confidence 0.60–0.85
+    INSERT INTO lessons (brain_id, category, description, state, confidence, fire_count, data)
+    VALUES (
+        v_brain_id,
+        'Clarity & Structure',
+        'Open PR descriptions with a one-line summary, then a bulleted change list.',
+        'PATTERN', 0.64, 6,
+        jsonb_build_object('is_demo', true, 'dimension', 'Clarity & Structure')
+    )
+    RETURNING id INTO v_lid;
+    v_lesson_ids := v_lesson_ids || v_lid;
+
+    INSERT INTO lessons (brain_id, category, description, state, confidence, fire_count, data)
+    VALUES (
+        v_brain_id,
+        'Actionability',
+        'When unsure, confirm assumptions with one clarifying question before acting.',
+        'PATTERN', 0.76, 9,
+        jsonb_build_object('is_demo', true, 'dimension', 'Actionability')
+    )
+    RETURNING id INTO v_lid;
+    v_lesson_ids := v_lesson_ids || v_lid;
+
+    INSERT INTO lessons (brain_id, category, description, state, confidence, fire_count, data)
+    VALUES (
+        v_brain_id,
+        'Goal Alignment',
+        'Restate the user''s goal in one sentence before proposing a multi-step plan.',
+        'PATTERN', 0.82, 11,
+        jsonb_build_object('is_demo', true, 'dimension', 'Goal Alignment')
+    )
+    RETURNING id INTO v_lid;
+    v_lesson_ids := v_lesson_ids || v_lid;
+
+    -- RULE (3) — confidence 0.90–0.95
+    INSERT INTO lessons (brain_id, category, description, state, confidence, fire_count, data)
+    VALUES (
+        v_brain_id,
+        'Factual Integrity',
+        'Verify URLs and API names against source documents before citing them.',
+        'RULE', 0.93, 17,
+        jsonb_build_object('is_demo', true, 'dimension', 'Factual Integrity')
+    )
+    RETURNING id INTO v_lid;
+    v_lesson_ids := v_lesson_ids || v_lid;
+
+    INSERT INTO lessons (brain_id, category, description, state, confidence, fire_count, data)
+    VALUES (
+        v_brain_id,
+        'Clarity & Structure',
+        'Keep outbound emails under 120 words unless the user asks for long form.',
+        'RULE', 0.91, 14,
+        jsonb_build_object('is_demo', true, 'dimension', 'Clarity & Structure')
+    )
+    RETURNING id INTO v_lid;
+    v_lesson_ids := v_lesson_ids || v_lid;
+
+    INSERT INTO lessons (brain_id, category, description, state, confidence, fire_count, data)
+    VALUES (
+        v_brain_id,
+        'Factual Integrity',
+        'Run the test suite before claiming "this fixes it" — evidence before assertions.',
+        'RULE', 0.95, 22,
+        jsonb_build_object('is_demo', true, 'dimension', 'Factual Integrity')
+    )
+    RETURNING id INTO v_lid;
+    v_lesson_ids := v_lesson_ids || v_lid;
+
+    -- ------------------------------------------------------------------
+    -- 25 demo corrections — Wozniak-shaped decay across 30 days.
+    -- Week 1 (days 23–29 ago): 12  |  Week 2: 7  |  Week 3: 4  |  Week 4: 2
+    -- ------------------------------------------------------------------
+
+    -- Week 1 (12 corrections, days 23..29 ago) — heavy rewrite/major early
+    FOR v_i IN 0..11 LOOP
+        INSERT INTO corrections (brain_id, session, category, severity, description, draft_preview, final_preview, created_at, data)
+        VALUES (
+            v_brain_id,
+            100 + v_i,
+            (ARRAY['FORMAT','LOGIC','TONE','FACT','STRUCTURE','GOAL'])[1 + (v_i % 6)],
+            (ARRAY['rewrite','major','major','moderate','major','rewrite','moderate','major','minor','rewrite','major','moderate'])[v_i + 1],
+            (ARRAY[
+                'Rewrote PR body to lead with summary line.',
+                'Tightened verbose email draft from 280 -> 110 words.',
+                'Removed em dashes from outbound email copy.',
+                'Confirmed deploy target before running migration.',
+                'Swapped hallucinated API name for the real one.',
+                'Restated user goal before multi-step plan.',
+                'Cited correct RFC number, not the one I guessed.',
+                'Dropped unneeded "As an AI language model" preamble.',
+                'Shortened bulleted list to top 3 items.',
+                'Rewrote vague "handle it" into explicit steps.',
+                'Fixed incorrect function signature in code snippet.',
+                'Reduced softening hedge words in tone.'
+            ])[v_i + 1],
+            'draft preview redacted',
+            'final preview redacted',
+            now() - ((23 + (v_i % 7)) || ' days')::interval,
+            jsonb_build_object('is_demo', true)
+        );
+    END LOOP;
+
+    -- Week 2 (7 corrections, days 15..21 ago)
+    FOR v_i IN 0..6 LOOP
+        INSERT INTO corrections (brain_id, session, category, severity, description, draft_preview, final_preview, created_at, data)
+        VALUES (
+            v_brain_id,
+            120 + v_i,
+            (ARRAY['FORMAT','LOGIC','TONE','FACT','STRUCTURE','GOAL'])[1 + (v_i % 6)],
+            (ARRAY['moderate','minor','moderate','major','minor','moderate','minor'])[v_i + 1],
+            (ARRAY[
+                'Matched user tone — terse request, terse reply.',
+                'Dropped unsolicited alternatives after user picked one.',
+                'Verified library name against package.json before suggesting.',
+                'Reordered PR description: summary first, details second.',
+                'Asked one clarifying question instead of five.',
+                'Cut filler sentence from Slack reply.',
+                'Named the exact file path instead of "the config file".'
+            ])[v_i + 1],
+            'draft preview redacted',
+            'final preview redacted',
+            now() - ((15 + (v_i % 7)) || ' days')::interval,
+            jsonb_build_object('is_demo', true)
+        );
+    END LOOP;
+
+    -- Week 3 (4 corrections, days 8..14 ago)
+    FOR v_i IN 0..3 LOOP
+        INSERT INTO corrections (brain_id, session, category, severity, description, draft_preview, final_preview, created_at, data)
+        VALUES (
+            v_brain_id,
+            140 + v_i,
+            (ARRAY['FORMAT','FACT','TONE','STRUCTURE'])[v_i + 1],
+            (ARRAY['minor','moderate','trivial','minor'])[v_i + 1],
+            (ARRAY[
+                'Used project''s existing logger instead of print().',
+                'Confirmed the migration number before writing it.',
+                'Dropped extra exclamation point from reply.',
+                'Bulleted follow-ups instead of one long paragraph.'
+            ])[v_i + 1],
+            'draft preview redacted',
+            'final preview redacted',
+            now() - ((8 + v_i * 2) || ' days')::interval,
+            jsonb_build_object('is_demo', true)
+        );
+    END LOOP;
+
+    -- Week 4 (2 corrections, days 1..5 ago)
+    INSERT INTO corrections (brain_id, session, category, severity, description, draft_preview, final_preview, created_at, data)
+    VALUES
+        (
+            v_brain_id, 160, 'TONE', 'trivial',
+            'Matched user''s lowercase casual register.',
+            'draft preview redacted', 'final preview redacted',
+            now() - interval '4 days',
+            jsonb_build_object('is_demo', true)
+        ),
+        (
+            v_brain_id, 161, 'STRUCTURE', 'minor',
+            'Led with the decision, details below.',
+            'draft preview redacted', 'final preview redacted',
+            now() - interval '1 days',
+            jsonb_build_object('is_demo', true)
+        );
+
+    -- ------------------------------------------------------------------
+    -- 4 demo meta-rules (reference lesson ids above)
+    -- ------------------------------------------------------------------
+    INSERT INTO meta_rules (brain_id, title, description, source_lesson_ids, data)
+    VALUES
+        (
+            v_brain_id,
+            'Evidence before assertions',
+            'Across Factual Integrity and Actionability: always verify (URLs, APIs, tests) before claiming something is true or done.',
+            ARRAY[v_lesson_ids[6], v_lesson_ids[8], v_lesson_ids[4]]::UUID[],
+            jsonb_build_object('is_demo', true, 'source_lesson_ids_demo', true)
+        ),
+        (
+            v_brain_id,
+            'Lead with the point',
+            'Across Clarity & Structure and Goal Alignment: put summary/decision on line 1, supporting detail below.',
+            ARRAY[v_lesson_ids[3], v_lesson_ids[5], v_lesson_ids[7]]::UUID[],
+            jsonb_build_object('is_demo', true, 'source_lesson_ids_demo', true)
+        ),
+        (
+            v_brain_id,
+            'Match the user''s register',
+            'Across Tone & Register and Domain Fit: mirror terseness, formality, and tooling choices the user already uses.',
+            ARRAY[v_lesson_ids[1], v_lesson_ids[2]]::UUID[],
+            jsonb_build_object('is_demo', true, 'source_lesson_ids_demo', true)
+        ),
+        (
+            v_brain_id,
+            'Ask once, then act',
+            'Across Actionability and Goal Alignment: resolve ambiguity with one question, then execute — don''t loop.',
+            ARRAY[v_lesson_ids[4], v_lesson_ids[5]]::UUID[],
+            jsonb_build_object('is_demo', true, 'source_lesson_ids_demo', true)
+        );
+
+    -- ------------------------------------------------------------------
+    -- 6 demo events
+    -- ------------------------------------------------------------------
+    INSERT INTO events (brain_id, type, source, data, tags, session, created_at)
+    VALUES
+        (
+            v_brain_id, 'graduation', 'demo-seed',
+            jsonb_build_object('is_demo', true, 'lesson_id', v_lesson_ids[6], 'from', 'PATTERN', 'to', 'RULE'),
+            ARRAY['is_demo','graduation']::TEXT[],
+            145,
+            now() - interval '10 days'
+        ),
+        (
+            v_brain_id, 'graduation', 'demo-seed',
+            jsonb_build_object('is_demo', true, 'lesson_id', v_lesson_ids[8], 'from', 'PATTERN', 'to', 'RULE'),
+            ARRAY['is_demo','graduation']::TEXT[],
+            152,
+            now() - interval '6 days'
+        ),
+        (
+            v_brain_id, 'self_heal_patch', 'demo-seed',
+            jsonb_build_object(
+                'is_demo', true,
+                'lesson_id', v_lesson_ids[7],
+                'reason', 'Auto-tightened wording after 3 high-confidence fires.'
+            ),
+            ARRAY['is_demo','self_heal']::TEXT[],
+            155,
+            now() - interval '5 days'
+        ),
+        (
+            v_brain_id, 'meta_rule_emergence', 'demo-seed',
+            jsonb_build_object(
+                'is_demo', true,
+                'meta_rule_title', 'Evidence before assertions',
+                'source_count', 3
+            ),
+            ARRAY['is_demo','meta_rule']::TEXT[],
+            158,
+            now() - interval '3 days'
+        ),
+        (
+            v_brain_id, 'convergence', 'demo-seed',
+            jsonb_build_object(
+                'is_demo', true,
+                'category', 'Factual Integrity',
+                'correction_rate_delta', -0.62
+            ),
+            ARRAY['is_demo','convergence']::TEXT[],
+            160,
+            now() - interval '2 days'
+        ),
+        (
+            v_brain_id, 'alert', 'demo-seed',
+            jsonb_build_object(
+                'is_demo', true,
+                'severity', 'info',
+                'message', 'Demo brain seeded. Clear it from brain settings when you are ready.'
+            ),
+            ARRAY['is_demo','alert']::TEXT[],
+            161,
+            now() - interval '1 days'
+        );
+
+    RETURN v_brain_id;
+END;
+$$;
+
+-- ============================================================
+-- REPLACE handle_new_user TO CALL seed_demo_brain
+-- ============================================================
+--
+-- The original trigger in 001_initial_schema.sql creates a workspace,
+-- a membership row, and a default brain. We replace it so that instead
+-- of the empty default brain it calls seed_demo_brain(), which creates
+-- the demo-brain with fully populated demo data.
+
+CREATE OR REPLACE FUNCTION handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_workspace_id UUID;
+BEGIN
+    INSERT INTO workspaces (name, owner_id)
+    VALUES (COALESCE(NEW.raw_user_meta_data->>'full_name', 'My Workspace'), NEW.id)
+    RETURNING id INTO v_workspace_id;
+
+    INSERT INTO workspace_members (workspace_id, user_id, role)
+    VALUES (v_workspace_id, NEW.id, 'owner');
+
+    -- Seed the demo brain (replaces the old empty default-brain insert).
+    PERFORM seed_demo_brain(v_workspace_id, NEW.id);
+
+    RETURN NEW;
+END;
+$$;
+
+-- The trigger definition itself (on_auth_user_created) is created in
+-- migration 001 and already points at handle_new_user(), so CREATE OR
+-- REPLACE FUNCTION above is sufficient — no need to re-create the trigger.
+
+-- ============================================================
+-- TEST HELPER (used by local dev / docs)
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION handle_new_user_test(p_user_id UUID, p_full_name TEXT DEFAULT 'Test User')
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_workspace_id UUID;
+BEGIN
+    INSERT INTO workspaces (name, owner_id)
+    VALUES (p_full_name, p_user_id)
+    RETURNING id INTO v_workspace_id;
+
+    INSERT INTO workspace_members (workspace_id, user_id, role)
+    VALUES (v_workspace_id, p_user_id, 'owner');
+
+    RETURN seed_demo_brain(v_workspace_id, p_user_id);
+END;
+$$;

--- a/cloud/migrations/004_seed_demo_brain.sql
+++ b/cloud/migrations/004_seed_demo_brain.sql
@@ -48,7 +48,8 @@ BEGIN
     -- ------------------------------------------------------------------
     -- 1 brain
     -- ------------------------------------------------------------------
-    INSERT INTO brains (workspace_id, user_id, name, domain, metadata)
+    -- Schema uses brain_name, not name (per 001_initial_schema.sql).
+    INSERT INTO brains (workspace_id, user_id, brain_name, domain, metadata)
     VALUES (
         p_workspace_id,
         p_user_id,

--- a/cloud/tests/conftest.py
+++ b/cloud/tests/conftest.py
@@ -49,6 +49,9 @@ class MockSupabaseClient:
     async def update(self, table: str, data: dict, filters: dict | None = None) -> list[dict]:
         return [data]
 
+    async def delete(self, table: str, filters: dict | None = None) -> list[dict]:
+        return []
+
 
 @pytest.fixture(autouse=True)
 def mock_jwks(monkeypatch):

--- a/cloud/tests/conftest.py
+++ b/cloud/tests/conftest.py
@@ -50,7 +50,8 @@ class MockSupabaseClient:
         return [data]
 
     async def delete(self, table: str, filters: dict | None = None) -> list[dict]:
-        return []
+        """Mock delete: returns pre-seeded delete response rows (treat as 'deleted rows')."""
+        return list(self._responses[table].get("delete", []))
 
 
 @pytest.fixture(autouse=True)

--- a/cloud/tests/test_health.py
+++ b/cloud/tests/test_health.py
@@ -1,0 +1,49 @@
+"""Tests for /health (liveness) and /ready (readiness) endpoints."""
+from __future__ import annotations
+
+
+def test_health_liveness_returns_minimal_payload(client):
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "healthy"
+    assert body["service"] == "gradata-cloud"
+    assert "version" in body
+    # Liveness must NOT include DB / uptime / env — those are readiness fields
+    assert "db" not in body
+    assert "uptime_seconds" not in body
+
+
+def test_ready_returns_ready_when_db_ok(client, mock_supabase):
+    """Happy path — DB ping succeeds, status is 'ready'."""
+    # mock_supabase.select returns [] for unknown filters — no error raised
+    resp = client.get("/ready")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ready"
+    assert body["db"] == "ok"
+    assert isinstance(body["db_latency_ms"], (int, float))
+    assert body["uptime_seconds"] >= 0
+    assert body["environment"] == "test"
+    assert "release" in body
+
+
+def test_ready_returns_unavailable_when_db_fails(client, mock_supabase, monkeypatch):
+    """Sad path — DB raises, status is 'unavailable'."""
+    async def _explode(*_a, **_kw):
+        raise RuntimeError("simulated DB outage")
+
+    monkeypatch.setattr(mock_supabase, "select", _explode)
+    resp = client.get("/ready")
+    assert resp.status_code == 200  # The endpoint still responds; status field tells the truth
+    body = resp.json()
+    assert body["status"] == "unavailable"
+    assert body["db"] == "fail"
+    assert body["db_latency_ms"] is None
+
+
+def test_ready_includes_release_from_env(client, mock_supabase, monkeypatch):
+    monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "abc1234deadbeef")
+    resp = client.get("/ready")
+    assert resp.status_code == 200
+    assert resp.json()["release"] == "abc1234"

--- a/cloud/tests/test_operator.py
+++ b/cloud/tests/test_operator.py
@@ -1,0 +1,313 @@
+"""Tests for /admin/* operator (god-mode) endpoints."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from jose import jwt
+
+from app.auth import require_operator
+from app.main import create_app
+
+
+_JWT_KEY = os.environ.get("GRADATA_SUPABASE_JWT_KEY", "test-only-hmac-not-a-real-credential-x")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _jwt(email: str | None = None, sub: str = "user-1") -> str:
+    claims: dict = {"sub": sub}
+    if email is not None:
+        claims["email"] = email
+    return jwt.encode(claims, _JWT_KEY, algorithm="HS256")
+
+
+def _headers(email: str | None = "oliver@gradata.ai") -> dict:
+    return {"Authorization": f"Bearer {_jwt(email=email)}"}
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@pytest.fixture
+def operator_client(mock_supabase):
+    """Test client with require_operator dependency forced to allow."""
+    app = create_app()
+    app.dependency_overrides[require_operator] = lambda: "user-1"
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Access control
+# ---------------------------------------------------------------------------
+
+
+def test_global_kpis_rejects_non_operator_email(client, mock_supabase):
+    """A non-allowlisted email (even with a valid JWT) must 403."""
+    resp = client.get("/api/v1/admin/global-kpis", headers=_headers("random@example.com"))
+    assert resp.status_code == 403
+
+
+def test_global_kpis_rejects_missing_email(client, mock_supabase):
+    """No email claim + no DB match -> 403, not 500."""
+    resp = client.get("/api/v1/admin/global-kpis", headers=_headers(email=None))
+    assert resp.status_code == 403
+
+
+def test_global_kpis_allows_gradata_email(client, mock_supabase):
+    """@gradata.ai passes the gate (200 even with no workspaces)."""
+    resp = client.get("/api/v1/admin/global-kpis", headers=_headers("oliver@gradata.ai"))
+    assert resp.status_code == 200
+    assert resp.json()["customers_total"] == 0
+
+
+def test_global_kpis_allows_sprites_email(client, mock_supabase):
+    """@sprites.ai also passes."""
+    resp = client.get("/api/v1/admin/global-kpis", headers=_headers("anna@sprites.ai"))
+    assert resp.status_code == 200
+
+
+def test_global_kpis_rejects_no_auth(client, mock_supabase):
+    resp = client.get("/api/v1/admin/global-kpis")
+    # FastAPI's HTTPBearer returns 403 by default but app wrappers can surface 401.
+    assert resp.status_code in {401, 403}
+
+
+# ---------------------------------------------------------------------------
+# Global KPIs aggregation
+# ---------------------------------------------------------------------------
+
+
+def test_global_kpis_aggregates_mrr(operator_client, mock_supabase):
+    """2 pro + 1 team -> MRR = 29*2 + 99 = 157; ARR = 1884."""
+    now = _now()
+    mock_supabase.add_response(
+        "workspaces",
+        "select",
+        [
+            {"id": "w1", "plan": "pro", "created_at": _iso(now - timedelta(days=2)), "deleted_at": None},
+            {"id": "w2", "plan": "pro", "created_at": _iso(now - timedelta(days=3)), "deleted_at": None},
+            {"id": "w3", "plan": "team", "created_at": _iso(now - timedelta(days=4)), "deleted_at": None},
+            {"id": "w4", "plan": "free", "created_at": _iso(now - timedelta(days=5)), "deleted_at": None},
+        ],
+    )
+    mock_supabase.add_response(
+        "brains",
+        "select",
+        [
+            {"id": "b1", "workspace_id": "w1", "user_id": "u1", "last_sync_at": _iso(now - timedelta(days=1))},
+            {"id": "b2", "workspace_id": "w2", "user_id": "u2", "last_sync_at": _iso(now - timedelta(days=20))},
+        ],
+    )
+
+    resp = operator_client.get("/api/v1/admin/global-kpis")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["mrr_usd"] == 157.0
+    assert data["arr_usd"] == 157.0 * 12
+    assert data["customers_total"] == 4
+    # Only w1 synced within 14 days
+    assert data["customers_active"] == 1
+    # NRR placeholder
+    assert data["net_revenue_retention"] == 1.0
+
+
+def test_global_kpis_excludes_enterprise_from_mrr(operator_client, mock_supabase):
+    """Enterprise plan is custom-priced -> not included in auto MRR."""
+    mock_supabase.add_response(
+        "workspaces",
+        "select",
+        [
+            {"id": "w1", "plan": "enterprise", "created_at": _iso(_now()), "deleted_at": None},
+            {"id": "w2", "plan": "pro", "created_at": _iso(_now()), "deleted_at": None},
+        ],
+    )
+    mock_supabase.add_response("brains", "select", [])
+
+    resp = operator_client.get("/api/v1/admin/global-kpis")
+    assert resp.status_code == 200
+    assert resp.json()["mrr_usd"] == 29.0
+
+
+# ---------------------------------------------------------------------------
+# Customers list — health classification, sort, paginate
+# ---------------------------------------------------------------------------
+
+
+def test_customers_health_classification(operator_client, mock_supabase):
+    """Health buckets: <14d healthy, 14-30d at-risk, >30d or None churning."""
+    now = _now()
+    mock_supabase.add_response(
+        "workspaces",
+        "select",
+        [
+            {"id": "ws-healthy", "name": "Alpha", "plan": "pro", "created_at": _iso(now)},
+            {"id": "ws-atrisk", "name": "Beta", "plan": "pro", "created_at": _iso(now)},
+            {"id": "ws-churning", "name": "Gamma", "plan": "team", "created_at": _iso(now)},
+            {"id": "ws-nosync", "name": "Delta", "plan": "free", "created_at": _iso(now)},
+        ],
+    )
+    mock_supabase.add_response(
+        "brains",
+        "select",
+        [
+            {"id": "b1", "workspace_id": "ws-healthy", "user_id": "u1",
+             "last_sync_at": _iso(now - timedelta(days=2))},
+            {"id": "b2", "workspace_id": "ws-atrisk", "user_id": "u2",
+             "last_sync_at": _iso(now - timedelta(days=20))},
+            {"id": "b3", "workspace_id": "ws-churning", "user_id": "u3",
+             "last_sync_at": _iso(now - timedelta(days=60))},
+            {"id": "b4", "workspace_id": "ws-nosync", "user_id": "u4", "last_sync_at": None},
+        ],
+    )
+    mock_supabase.add_response(
+        "workspace_members",
+        "select",
+        [
+            {"workspace_id": "ws-healthy", "user_id": "u1"},
+            {"workspace_id": "ws-atrisk", "user_id": "u2"},
+            {"workspace_id": "ws-churning", "user_id": "u3"},
+            {"workspace_id": "ws-nosync", "user_id": "u4"},
+        ],
+    )
+
+    resp = operator_client.get("/api/v1/admin/customers")
+    assert resp.status_code == 200
+    rows = {r["id"]: r for r in resp.json()}
+    assert rows["ws-healthy"]["health"] == "healthy"
+    assert rows["ws-atrisk"]["health"] == "at-risk"
+    assert rows["ws-churning"]["health"] == "churning"
+    assert rows["ws-nosync"]["health"] == "churning"
+    assert rows["ws-healthy"]["brains"] == 1
+    assert rows["ws-healthy"]["active_users"] == 1
+
+
+def test_customers_sort_by_mrr_desc(operator_client, mock_supabase):
+    now = _now()
+    mock_supabase.add_response(
+        "workspaces",
+        "select",
+        [
+            {"id": "w1", "name": "Cheap", "plan": "free", "created_at": _iso(now)},
+            {"id": "w2", "name": "Top", "plan": "team", "created_at": _iso(now)},
+            {"id": "w3", "name": "Mid", "plan": "pro", "created_at": _iso(now)},
+        ],
+    )
+    mock_supabase.add_response("brains", "select", [])
+    mock_supabase.add_response("workspace_members", "select", [])
+
+    resp = operator_client.get("/api/v1/admin/customers?sort=mrr&order=desc")
+    assert resp.status_code == 200
+    ids = [r["id"] for r in resp.json()]
+    assert ids == ["w2", "w3", "w1"]
+
+
+def test_customers_paginate(operator_client, mock_supabase):
+    now = _now()
+    workspaces = [
+        {"id": f"w{i}", "name": f"Co{i}", "plan": "pro", "created_at": _iso(now)}
+        for i in range(5)
+    ]
+    mock_supabase.add_response("workspaces", "select", workspaces)
+    mock_supabase.add_response("brains", "select", [])
+    mock_supabase.add_response("workspace_members", "select", [])
+
+    resp = operator_client.get("/api/v1/admin/customers?limit=2&offset=1&sort=mrr&order=desc")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2
+
+
+def test_customers_rejects_bad_sort(operator_client, mock_supabase):
+    mock_supabase.add_response("workspaces", "select", [])
+    mock_supabase.add_response("brains", "select", [])
+    mock_supabase.add_response("workspace_members", "select", [])
+
+    resp = operator_client.get("/api/v1/admin/customers?sort=bogus")
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Alerts
+# ---------------------------------------------------------------------------
+
+
+def test_alerts_churn_risk_for_stale_workspace(operator_client, mock_supabase):
+    """Workspace whose latest brain sync is 14+ days old -> churn-risk alert."""
+    now = _now()
+    mock_supabase.add_response(
+        "workspaces",
+        "select",
+        [
+            {"id": "ws-stale", "name": "Stale Co", "plan": "pro", "subscription_status": "active"},
+            {"id": "ws-fresh", "name": "Fresh Co", "plan": "pro", "subscription_status": "active"},
+        ],
+    )
+    mock_supabase.add_response(
+        "brains",
+        "select",
+        [
+            {"id": "b-stale", "workspace_id": "ws-stale", "user_id": "u1",
+             "last_sync_at": _iso(now - timedelta(days=20))},
+            {"id": "b-fresh", "workspace_id": "ws-fresh", "user_id": "u2",
+             "last_sync_at": _iso(now - timedelta(days=1))},
+        ],
+    )
+    # No corrections -> no usage-spike noise
+    mock_supabase.add_response("corrections", "select", [])
+
+    resp = operator_client.get("/api/v1/admin/alerts")
+    assert resp.status_code == 200
+    kinds = [(a["kind"], a["customer"]) for a in resp.json()]
+    assert ("churn-risk", "Stale Co") in kinds
+    assert ("churn-risk", "Fresh Co") not in kinds
+
+
+def test_alerts_failed_payment_from_subscription_status(operator_client, mock_supabase):
+    """Workspace with subscription_status=past_due surfaces a failed-payment alert."""
+    now = _now()
+    mock_supabase.add_response(
+        "workspaces",
+        "select",
+        [
+            {"id": "ws-late", "name": "Late Payer", "plan": "pro",
+             "subscription_status": "past_due"},
+        ],
+    )
+    # Fresh sync -> skip churn-risk noise
+    mock_supabase.add_response(
+        "brains",
+        "select",
+        [
+            {"id": "b-late", "workspace_id": "ws-late", "user_id": "u1",
+             "last_sync_at": _iso(now - timedelta(hours=1))},
+        ],
+    )
+    mock_supabase.add_response("corrections", "select", [])
+
+    resp = operator_client.get("/api/v1/admin/alerts")
+    assert resp.status_code == 200
+    kinds = [a["kind"] for a in resp.json()]
+    assert "failed-payment" in kinds
+
+
+def test_alerts_rejects_non_operator(client, mock_supabase):
+    resp = client.get("/api/v1/admin/alerts", headers=_headers("guest@example.com"))
+    assert resp.status_code == 403
+
+
+def test_customers_rejects_non_operator(client, mock_supabase):
+    resp = client.get("/api/v1/admin/customers", headers=_headers("guest@example.com"))
+    assert resp.status_code == 403

--- a/cloud/tests/test_seed_demo.py
+++ b/cloud/tests/test_seed_demo.py
@@ -1,0 +1,229 @@
+"""Tests for demo seed data: migration shape + POST /brains/{id}/clear-demo."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+from jose import jwt
+
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "migrations"
+    / "004_seed_demo_brain.sql"
+)
+
+_JWT_KEY = os.environ.get("GRADATA_SUPABASE_JWT_KEY", "test-only-hmac-not-a-real-credential-x")
+
+
+def _make_jwt(user_id: str = "user-1") -> str:
+    return jwt.encode({"sub": user_id}, _JWT_KEY, algorithm="HS256")
+
+
+def _jwt_headers(user_id: str = "user-1") -> dict:
+    return {"Authorization": f"Bearer {_make_jwt(user_id)}"}
+
+
+# ---------------------------------------------------------------------------
+# Migration shape
+# ---------------------------------------------------------------------------
+
+
+def test_migration_file_exists_and_has_seed_function():
+    """Migration 004 must define seed_demo_brain and tag rows with is_demo."""
+    assert _MIGRATION_PATH.exists(), "migrations/004_seed_demo_brain.sql missing"
+    sql = _MIGRATION_PATH.read_text(encoding="utf-8")
+
+    # Core function signature present
+    assert re.search(
+        r"CREATE\s+OR\s+REPLACE\s+FUNCTION\s+seed_demo_brain\s*\(",
+        sql,
+        flags=re.IGNORECASE,
+    ), "seed_demo_brain function signature not found"
+
+    # Rows get the is_demo marker
+    assert "is_demo" in sql, "is_demo marker missing from migration"
+
+    # Trigger function replaced to call seed_demo_brain
+    assert "PERFORM seed_demo_brain" in sql, "handle_new_user should PERFORM seed_demo_brain"
+
+    # Expected row counts referenced in comments / structure
+    # 6-dim taxonomy dimensions
+    for dim in (
+        "Goal Alignment",
+        "Tone & Register",
+        "Clarity & Structure",
+        "Factual Integrity",
+        "Domain Fit",
+        "Actionability",
+    ):
+        assert dim in sql, f"dimension {dim!r} missing from seed"
+
+    # Uses jsonb_build_object per task constraint
+    assert "jsonb_build_object" in sql
+
+
+# ---------------------------------------------------------------------------
+# POST /brains/{brain_id}/clear-demo
+# ---------------------------------------------------------------------------
+
+
+def test_clear_demo_happy_path(client, mock_supabase, auth_headers):
+    """Deletes rows flagged is_demo=true across child tables + the brain row itself."""
+    # Brain with demo metadata, owned via API key
+    mock_supabase.add_response(
+        "brains",
+        "select",
+        [
+            {
+                "id": "brain-1",
+                "user_id": "user-1",
+                "api_key": "gd_TVAL",
+                "metadata": {"is_demo": True},
+            }
+        ],
+    )
+    # Child rows — mix of demo and non-demo so we confirm filtering
+    mock_supabase.add_response(
+        "corrections",
+        "select",
+        [
+            {"id": "c1", "brain_id": "brain-1", "data": {"is_demo": True}},
+            {"id": "c2", "brain_id": "brain-1", "data": {"is_demo": True}},
+            {"id": "c3", "brain_id": "brain-1", "data": {}},  # non-demo, skip
+        ],
+    )
+    mock_supabase.add_response(
+        "lessons",
+        "select",
+        [
+            {"id": "l1", "brain_id": "brain-1", "data": {"is_demo": True}},
+            {"id": "l2", "brain_id": "brain-1", "data": {"is_demo": True}},
+        ],
+    )
+    mock_supabase.add_response(
+        "meta_rules",
+        "select",
+        [{"id": "m1", "brain_id": "brain-1", "data": {"is_demo": True}}],
+    )
+    mock_supabase.add_response(
+        "events",
+        "select",
+        [
+            {"id": "e1", "brain_id": "brain-1", "data": {"is_demo": True}},
+            {"id": "e2", "brain_id": "brain-1", "data": {"is_demo": True}},
+            {"id": "e3", "brain_id": "brain-1", "data": {"is_demo": True}},
+        ],
+    )
+
+    resp = client.post("/api/v1/brains/brain-1/clear-demo", headers=auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    # 2 corrections + 2 lessons + 1 meta_rule + 3 events + 1 brain = 9
+    assert body["deleted"] == 9
+    assert body["by_table"]["corrections"] == 2
+    assert body["by_table"]["lessons"] == 2
+    assert body["by_table"]["meta_rules"] == 1
+    assert body["by_table"]["events"] == 3
+    assert body["by_table"]["brains"] == 1
+
+
+def test_clear_demo_zero_when_no_demo_rows(client, mock_supabase, auth_headers):
+    """Returns 0 when no rows are flagged is_demo."""
+    mock_supabase.add_response(
+        "brains",
+        "select",
+        [
+            {
+                "id": "brain-1",
+                "user_id": "user-1",
+                "api_key": "gd_TVAL",
+                "metadata": {},  # not a demo brain
+            }
+        ],
+    )
+    mock_supabase.add_response("corrections", "select", [
+        {"id": "c1", "brain_id": "brain-1", "data": {}},
+    ])
+    mock_supabase.add_response("lessons", "select", [])
+    mock_supabase.add_response("meta_rules", "select", [])
+    mock_supabase.add_response("events", "select", [])
+
+    resp = client.post("/api/v1/brains/brain-1/clear-demo", headers=auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["deleted"] == 0
+    assert body["by_table"]["corrections"] == 0
+    assert body["by_table"]["brains"] == 0
+
+
+def test_clear_demo_forbidden_if_not_owner(client, mock_supabase):
+    """JWT auth: user-2 cannot clear brain owned by user-1 -> 403."""
+    mock_supabase.add_response(
+        "brains",
+        "select",
+        [{"id": "brain-1", "user_id": "user-1", "api_key": "gd_TVAL"}],
+    )
+
+    resp = client.post(
+        "/api/v1/brains/brain-1/clear-demo",
+        headers=_jwt_headers("user-2"),
+    )
+    assert resp.status_code == 403
+
+
+def test_clear_demo_not_found(client, mock_supabase):
+    """Unknown brain -> 404 via JWT auth path."""
+    mock_supabase.add_response("brains", "select", [])
+
+    resp = client.post(
+        "/api/v1/brains/missing/clear-demo",
+        headers=_jwt_headers(),
+    )
+    assert resp.status_code == 404
+
+
+def test_clear_demo_api_key_wrong_brain(client, mock_supabase, auth_headers):
+    """API key auth: key scoped to brain-1 cannot clear brain-other -> 403."""
+    mock_supabase.add_response(
+        "brains",
+        "select",
+        [{"id": "brain-1", "user_id": "user-1", "api_key": "gd_TVAL"}],
+    )
+
+    resp = client.post("/api/v1/brains/brain-other/clear-demo", headers=auth_headers)
+    assert resp.status_code == 403
+
+
+def test_clear_demo_preserves_non_demo_brain_row(client, mock_supabase, auth_headers):
+    """Even when demo children exist, a non-demo brain row is NOT deleted."""
+    mock_supabase.add_response(
+        "brains",
+        "select",
+        [
+            {
+                "id": "brain-1",
+                "user_id": "user-1",
+                "api_key": "gd_TVAL",
+                "metadata": {},  # real brain
+            }
+        ],
+    )
+    mock_supabase.add_response(
+        "corrections",
+        "select",
+        [{"id": "c1", "brain_id": "brain-1", "data": {"is_demo": True}}],
+    )
+    mock_supabase.add_response("lessons", "select", [])
+    mock_supabase.add_response("meta_rules", "select", [])
+    mock_supabase.add_response("events", "select", [])
+
+    resp = client.post("/api/v1/brains/brain-1/clear-demo", headers=auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["by_table"]["brains"] == 0
+    assert body["by_table"]["corrections"] == 1
+    assert body["deleted"] == 1

--- a/cloud/tests/test_team.py
+++ b/cloud/tests/test_team.py
@@ -1,0 +1,264 @@
+"""Tests for team / workspace-member endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import get_current_user_id
+from app.main import create_app
+
+
+CALLER_USER_ID = "user-caller"
+OWNER_USER_ID = "user-owner"
+ADMIN_USER_ID = "user-admin"
+MEMBER_USER_ID = "user-member"
+OUTSIDER_USER_ID = "user-outsider"
+WORKSPACE_ID = "ws-1"
+
+
+@pytest.fixture
+def app_with_user(monkeypatch):
+    """Create a fresh FastAPI app with get_current_user_id overridable."""
+
+    def _build(stub_user: str):
+        app = create_app()
+        app.dependency_overrides[get_current_user_id] = lambda: stub_user
+        return app
+
+    return _build
+
+
+@pytest.fixture
+def stub_user(app_with_user, mock_supabase):
+    """Helper: build (client, mock_supabase) authed as the given user_id."""
+
+    def _setup(user_id: str = CALLER_USER_ID, *, members: list[dict] | None = None,
+               brains: list[dict] | None = None) -> TestClient:
+        app = app_with_user(user_id)
+        if members is not None:
+            mock_supabase.add_response("workspace_members", "select", members)
+        if brains is not None:
+            mock_supabase.add_response("brains", "select", brains)
+        return TestClient(app)
+
+    return _setup
+
+
+# ---------------------------------------------------------------------------
+# GET /workspaces/{ws}/members
+# ---------------------------------------------------------------------------
+
+
+def test_list_members_returns_list_for_workspace_member(stub_user, mock_supabase):
+    members = [
+        {
+            "workspace_id": WORKSPACE_ID,
+            "user_id": OWNER_USER_ID,
+            "role": "owner",
+            "joined_at": "2026-01-01T00:00:00+00:00",
+            "email": "owner@example.com",
+            "display_name": "Owner",
+        },
+        {
+            "workspace_id": WORKSPACE_ID,
+            "user_id": CALLER_USER_ID,
+            "role": "admin",
+            "joined_at": "2026-01-02T00:00:00+00:00",
+            "email": "caller@example.com",
+            "display_name": "Caller",
+        },
+    ]
+    brains = [
+        {
+            "id": "brain-1",
+            "workspace_id": WORKSPACE_ID,
+            "user_id": OWNER_USER_ID,
+            "last_sync_at": "2026-04-10T00:00:00+00:00",
+        },
+        {
+            "id": "brain-2",
+            "workspace_id": WORKSPACE_ID,
+            "user_id": OWNER_USER_ID,
+            "last_sync_at": "2026-04-11T00:00:00+00:00",  # newer
+        },
+    ]
+    client = stub_user(CALLER_USER_ID, members=members, brains=brains)
+
+    resp = client.get(f"/api/v1/workspaces/{WORKSPACE_ID}/members")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 2
+    by_id = {m["user_id"]: m for m in body}
+    assert by_id[OWNER_USER_ID]["role"] == "owner"
+    assert by_id[OWNER_USER_ID]["last_sync_at"] == "2026-04-11T00:00:00+00:00"
+    assert by_id[CALLER_USER_ID]["last_sync_at"] is None  # no brains for caller
+
+
+def test_list_members_403_for_non_member(stub_user, mock_supabase):
+    members = [
+        {"workspace_id": WORKSPACE_ID, "user_id": OWNER_USER_ID, "role": "owner"},
+    ]
+    client = stub_user(OUTSIDER_USER_ID, members=members)
+
+    resp = client.get(f"/api/v1/workspaces/{WORKSPACE_ID}/members")
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# POST /workspaces/{ws}/invites
+# ---------------------------------------------------------------------------
+
+
+def test_create_invite_as_owner_returns_token_and_url(stub_user, mock_supabase):
+    members = [
+        {"workspace_id": WORKSPACE_ID, "user_id": CALLER_USER_ID, "role": "owner"},
+    ]
+    client = stub_user(CALLER_USER_ID, members=members)
+
+    resp = client.post(
+        f"/api/v1/workspaces/{WORKSPACE_ID}/invites",
+        json={"email": "newbie@example.com", "role": "member"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["email"] == "newbie@example.com"
+    assert body["role"] == "member"
+    assert body["token"]
+    assert body["accept_url"].startswith("https://app.gradata.ai/invites/")
+    assert body["accept_url"].endswith(body["token"])
+    # Verify the insert hit the workspace_invites table.
+    invited_emails = [
+        r["email"] for r in mock_supabase._inserts if r.get("email") == "newbie@example.com"
+    ]
+    assert invited_emails
+
+
+def test_create_invite_403_for_member_role(stub_user, mock_supabase):
+    members = [
+        {"workspace_id": WORKSPACE_ID, "user_id": CALLER_USER_ID, "role": "member"},
+    ]
+    client = stub_user(CALLER_USER_ID, members=members)
+
+    resp = client.post(
+        f"/api/v1/workspaces/{WORKSPACE_ID}/invites",
+        json={"email": "newbie@example.com", "role": "member"},
+    )
+    assert resp.status_code == 403
+
+
+def test_create_invite_validates_email_format(stub_user, mock_supabase):
+    members = [
+        {"workspace_id": WORKSPACE_ID, "user_id": CALLER_USER_ID, "role": "owner"},
+    ]
+    client = stub_user(CALLER_USER_ID, members=members)
+
+    resp = client.post(
+        f"/api/v1/workspaces/{WORKSPACE_ID}/invites",
+        json={"email": "not-an-email", "role": "member"},
+    )
+    assert resp.status_code == 422  # pydantic validation error
+
+
+# ---------------------------------------------------------------------------
+# DELETE /workspaces/{ws}/members/{user_id}
+# ---------------------------------------------------------------------------
+
+
+def test_remove_member_403_for_member_role(stub_user, mock_supabase):
+    members = [
+        {"workspace_id": WORKSPACE_ID, "user_id": CALLER_USER_ID, "role": "member"},
+        {"workspace_id": WORKSPACE_ID, "user_id": MEMBER_USER_ID, "role": "member"},
+    ]
+    client = stub_user(CALLER_USER_ID, members=members)
+
+    resp = client.delete(
+        f"/api/v1/workspaces/{WORKSPACE_ID}/members/{MEMBER_USER_ID}"
+    )
+    assert resp.status_code == 403
+
+
+def test_remove_member_400_when_target_is_owner(stub_user, mock_supabase):
+    members = [
+        {"workspace_id": WORKSPACE_ID, "user_id": CALLER_USER_ID, "role": "admin"},
+        {"workspace_id": WORKSPACE_ID, "user_id": OWNER_USER_ID, "role": "owner"},
+    ]
+    client = stub_user(CALLER_USER_ID, members=members)
+
+    resp = client.delete(
+        f"/api/v1/workspaces/{WORKSPACE_ID}/members/{OWNER_USER_ID}"
+    )
+    assert resp.status_code == 400
+    assert "owner" in resp.json()["detail"].lower()
+
+
+def test_remove_member_happy_path_as_admin(stub_user, mock_supabase):
+    members = [
+        {"workspace_id": WORKSPACE_ID, "user_id": CALLER_USER_ID, "role": "admin"},
+        {"workspace_id": WORKSPACE_ID, "user_id": MEMBER_USER_ID, "role": "member"},
+    ]
+    client = stub_user(CALLER_USER_ID, members=members)
+
+    resp = client.delete(
+        f"/api/v1/workspaces/{WORKSPACE_ID}/members/{MEMBER_USER_ID}"
+    )
+    assert resp.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# PATCH /workspaces/{ws}/members/{user_id}
+# ---------------------------------------------------------------------------
+
+
+def test_update_role_400_when_setting_owner(stub_user, mock_supabase):
+    members = [
+        {"workspace_id": WORKSPACE_ID, "user_id": CALLER_USER_ID, "role": "admin"},
+        {"workspace_id": WORKSPACE_ID, "user_id": MEMBER_USER_ID, "role": "member"},
+    ]
+    client = stub_user(CALLER_USER_ID, members=members)
+
+    resp = client.patch(
+        f"/api/v1/workspaces/{WORKSPACE_ID}/members/{MEMBER_USER_ID}",
+        json={"role": "owner"},
+    )
+    # pydantic enum rejects 'owner' before our handler runs => 422.
+    # If the model ever loosens to a plain str, our handler returns 400.
+    assert resp.status_code in (400, 422)
+
+
+def test_update_role_happy_path_as_admin(stub_user, mock_supabase):
+    members = [
+        {"workspace_id": WORKSPACE_ID, "user_id": CALLER_USER_ID, "role": "admin"},
+        {
+            "workspace_id": WORKSPACE_ID,
+            "user_id": MEMBER_USER_ID,
+            "role": "member",
+            "email": "m@example.com",
+            "display_name": "Member",
+            "joined_at": "2026-01-03T00:00:00+00:00",
+        },
+    ]
+    client = stub_user(CALLER_USER_ID, members=members)
+
+    resp = client.patch(
+        f"/api/v1/workspaces/{WORKSPACE_ID}/members/{MEMBER_USER_ID}",
+        json={"role": "admin"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["user_id"] == MEMBER_USER_ID
+    assert body["role"] == "admin"
+
+
+def test_update_role_400_when_target_is_owner(stub_user, mock_supabase):
+    members = [
+        {"workspace_id": WORKSPACE_ID, "user_id": CALLER_USER_ID, "role": "admin"},
+        {"workspace_id": WORKSPACE_ID, "user_id": OWNER_USER_ID, "role": "owner"},
+    ]
+    client = stub_user(CALLER_USER_ID, members=members)
+
+    resp = client.patch(
+        f"/api/v1/workspaces/{WORKSPACE_ID}/members/{OWNER_USER_ID}",
+        json={"role": "admin"},
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary

Wave 3 of the dashboard rebuild — fills the remaining backend gaps so dashboard widgets back to real data, plus polish (404, error boundary, /ready endpoint).

## Backend (115 tests, was 78 → +33)

- **Team management** (`/api/v1/workspaces/{id}/members`, `/invites`, role updates) — 11 tests, RLS-aware, EmailStr validation, secrets-based invite tokens with 7-day expiry
- **Operator god-mode** (`/api/v1/admin/{global-kpis,customers,alerts}`) — 15 tests, gated by `OPERATOR_DOMAINS = {gradata.ai, sprites.ai}` via JWT email claim with DB fallback. Pulls MRR/ARR/churn/NRR from workspaces; alerts derived from inactivity + Stripe sub status + correction spike heuristics
- **Demo seed on signup** (migration 004 + `POST /brains/{id}/clear-demo`) — 7 tests. Function `seed_demo_brain(workspace_id, user_id)` creates 1 brain, 8 lessons (6-dim taxonomy across 3 states), 25 corrections (Wozniak decay shape), 4 meta-rules, 6 events, all flagged `is_demo`
- **/ready** endpoint with DB ping + Railway SHA + uptime — 4 tests. Pairs with /health (cheap liveness)

## Dashboard

- Branded `app/not-found.tsx` (V3-themed 404)
- Top-level `app/error.tsx` error boundary that captures to Sentry + shows digest id

## Migrations applied to live Supabase

- `003_workspace_invites` — table + RLS policies for team invites
- `004` (partial) — schema columns (`brains.metadata`, `corrections.data`, `lessons.data`, `meta_rules.data`)
- Migration 004's `seed_demo_brain` function + `handle_new_user` replacement intentionally NOT applied yet (changes signup behavior — apply when ready to roll demo seed for new signups)

## Manual data seed (live now)

Inserted 8 lessons / 25 corrections / 4 meta-rules / 6 events into Oliver's existing brain (`afd6fe39-...`) so the live dashboard at `gradata-dashboard.pages.dev` renders populated widgets when he signs in.

## Test plan

- [x] 115/115 backend tests pass (78 → +33)
- [x] Dashboard build passes (25 routes)
- [x] Schema migration 003 applied to live Supabase
- [x] Schema additions from 004 applied to live Supabase
- [x] Existing user's brain seeded with demo data (verified via SQL counts)
- [ ] Deploy this PR's backend (Railway auto-deploys on merge)
- [ ] Apply seed_demo_brain function + handle_new_user trigger replacement when ready

Generated with Gradata