### PR TITLE
fix(sdk): resolve 10 pyright type errors blocking CI

### DIFF
--- a/src/gradata/_embed.py
+++ b/src/gradata/_embed.py
@@ -219,7 +219,7 @@ def _cosine_distance(a: list[float], b: list[float]) -> float:
     """Cosine distance between two vectors. 0=identical, 1=opposite."""
     import math
 
-    dot = sum(x * y for x, y in zip(a, b))
+    dot = sum(x * y for x, y in zip(a, b, strict=False))
     norm_a = math.sqrt(sum(x * x for x in a))
     norm_b = math.sqrt(sum(x * x for x in b))
     if norm_a == 0 or norm_b == 0:

--- a/src/gradata/_types.py
+++ b/src/gradata/_types.py
@@ -174,6 +174,7 @@ class Lesson:
     climb_count: int = 0  # Total times this rule climbed (max 3)
     last_climb_session: int = 0  # Session when last climb occurred
     tree_level: int = 0  # Current depth: 0=leaf, 1=branch, 2=trunk
+    _contradiction_streak: int = 0  # Consecutive contradiction count (triggers self-correction)
 
     def __post_init__(self) -> None:
         self.confidence = round(max(0.0, min(1.0, self.confidence)), 2)

--- a/src/gradata/enhancements/behavioral_extractor.py
+++ b/src/gradata/enhancements/behavioral_extractor.py
@@ -647,7 +647,7 @@ def _extract_common_verbs(descriptions: list[str]) -> list[str]:
                 if word.startswith(prefix):
                     counts[prefix] = counts.get(prefix, 0) + 1
                     break
-    return sorted(counts, key=counts.get, reverse=True)[:3]
+    return sorted(counts, key=lambda k: counts[k], reverse=True)[:3]
 
 
 def _synthesize_summary(category: str, descriptions: list[str]) -> str:

--- a/src/gradata/enhancements/behavioral_extractor.py
+++ b/src/gradata/enhancements/behavioral_extractor.py
@@ -660,14 +660,14 @@ def _synthesize_summary(category: str, descriptions: list[str]) -> str:
 
 
 def detect_recurring_patterns(
-    lessons: list["Lesson"],
+    lessons: list[Lesson],
     min_corrections: int = 3,
 ) -> list[RecurringPattern]:
     """Detect patterns spanning multiple corrections in the same category."""
     if not lessons:
         return []
 
-    by_cat: dict[str, list["Lesson"]] = {}
+    by_cat: dict[str, list[Lesson]] = {}
     for lesson in lessons:
         cat = lesson.category.upper()
         by_cat.setdefault(cat, []).append(lesson)

--- a/src/gradata/enhancements/meta_rules.py
+++ b/src/gradata/enhancements/meta_rules.py
@@ -582,7 +582,6 @@ def _call_llm_for_synthesis(
     Raises:
         RuntimeError: On any LLM failure (caller catches).
     """
-    from gradata.enhancements.llm_synthesizer import synthesise_principle_llm
 
     key, base, model = _resolve_llm_credentials()
     if not key or not base:

--- a/src/gradata/enhancements/pubsub_pipeline.py
+++ b/src/gradata/enhancements/pubsub_pipeline.py
@@ -8,7 +8,8 @@ block other stages. Used for async/background processing patterns.
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 _log = logging.getLogger(__name__)
 

--- a/src/gradata/enhancements/self_improvement.py
+++ b/src/gradata/enhancements/self_improvement.py
@@ -504,7 +504,7 @@ def _bayesian_blend_weight(total_observations: int) -> float:
     )
 
 
-def _bayesian_confidence(lesson: "Lesson") -> float:
+def _bayesian_confidence(lesson: Lesson) -> float:
     """Compute blended confidence from beta posterior + FSRS."""
     from gradata._stats import beta_posterior
 

--- a/src/gradata/rules/cache.py
+++ b/src/gradata/rules/cache.py
@@ -9,7 +9,7 @@ class RuleCache:
     """Caches applied rules by scope key. Invalidated on brain.correct()."""
 
     def __init__(self):
-        self._cache: dict[str, list] = {}
+        self._cache: dict[str, str] = {}
         self._dirty: bool = True
 
     @property
@@ -20,12 +20,12 @@ class RuleCache:
         self._dirty = True
         self._cache.clear()
 
-    def get(self, scope_key: str) -> list | None:
+    def get(self, scope_key: str) -> str | None:
         if self._dirty:
             return None
         return self._cache.get(scope_key)
 
-    def put(self, scope_key: str, rules: list):
+    def put(self, scope_key: str, rules: str):
         self._cache[scope_key] = rules
         self._dirty = False
 

--- a/src/gradata/rules/rule_engine.py
+++ b/src/gradata/rules/rule_engine.py
@@ -864,14 +864,10 @@ def format_rules_for_prompt(
         # Include few-shot examples only for low-confidence rules with misfires
         lesson = rule.lesson
         needs_reinforcement = lesson.confidence < 0.70 and getattr(lesson, "misfire_count", 0) > 1
-        if (
-            needs_reinforcement
-            and getattr(lesson, "example_draft", None) is not None
-            and getattr(lesson, "example_corrected", None) is not None
-        ):
-            lines.append(
-                f'   e.g. "{lesson.example_draft[:80]}" -> "{lesson.example_corrected[:80]}"'
-            )
+        example_draft = getattr(lesson, "example_draft", None)
+        example_corrected = getattr(lesson, "example_corrected", None)
+        if needs_reinforcement and example_draft is not None and example_corrected is not None:
+            lines.append(f'   e.g. "{example_draft[:80]}" -> "{example_corrected[:80]}"')
 
     lines.append("</brain-rules>")
     return "\n".join(lines)

--- a/src/gradata/rules/rule_graph.py
+++ b/src/gradata/rules/rule_graph.py
@@ -14,13 +14,9 @@ import json
 import logging
 import re
 import sqlite3
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    pass
 
 _log = logging.getLogger(__name__)
 
@@ -213,14 +209,12 @@ def detect_relationship(rule_a: dict, rule_b: dict) -> RuleRelationType | None:
             return RuleRelationType.GENERALIZES
 
     # 2. Contradiction detection (same category required)
-    if cat_a and cat_b and cat_a == cat_b:
-        if _has_contradiction(desc_a, desc_b):
-            return RuleRelationType.CONTRADICTS
+    if cat_a and cat_b and cat_a == cat_b and _has_contradiction(desc_a, desc_b):
+        return RuleRelationType.CONTRADICTS
 
     # 3. Reinforcement (same category + keyword overlap > 50%)
-    if cat_a and cat_b and cat_a == cat_b:
-        if _keyword_overlap(desc_a, desc_b) > 0.5:
-            return RuleRelationType.REINFORCES
+    if cat_a and cat_b and cat_a == cat_b and _keyword_overlap(desc_a, desc_b) > 0.5:
+        return RuleRelationType.REINFORCES
 
     return None
 
@@ -248,7 +242,7 @@ def store_relationship(
             rule_b_id,
             rel_type.value,
             confidence,
-            datetime.now(timezone.utc).isoformat(),
+            datetime.now(UTC).isoformat(),
         ),
     )
     conn.commit()

--- a/src/gradata/rules/rule_tree.py
+++ b/src/gradata/rules/rule_tree.py
@@ -314,7 +314,7 @@ class RuleTree:
 
         # Evaluate climbs: for each lesson, check if it fired in sibling paths
         evaluated: set[int] = set()
-        for path, lessons in session_fires.items():
+        for _path, lessons in session_fires.items():
             for lesson in lessons:
                 lid = id(lesson)
                 if lid in evaluated:
@@ -333,9 +333,10 @@ class RuleTree:
         if session_contradictions:
             for path, count in session_contradictions.items():
                 for lesson in list(self.nodes.get(path, [])):
-                    if count >= self.CONTRACT_MIN_CONTRADICTIONS:
-                        if self.evaluate_contract(lesson, count, current_session):
-                            contracted += 1
+                    if count >= self.CONTRACT_MIN_CONTRADICTIONS and self.evaluate_contract(
+                        lesson, count, current_session
+                    ):
+                        contracted += 1
 
         return {"climbed": climbed, "contracted": contracted, "unchanged": unchanged}
 


### PR DESCRIPTION
## Summary
- CI has been red on `main` for multiple sessions due to pyright (basic mode) errors in SDK — unrelated to recent cloud PRs.
- Fixes all 10 reported errors; 0 errors, 7 pre-existing warnings (missing optional imports), 2070 tests pass locally.
- Unblocks PR #28 so it can merge clean.

## Fixes
- `RuleCache` typed `dict[str, list]` but stores `str` (brain.py caches `format_rules_for_prompt` output). Changed signatures to `str`.
- `Lesson._contradiction_streak` set dynamically in self_improvement/rule_evolution but absent on dataclass. Added as field.
- `sorted(counts, key=counts.get, ...)` in behavioral_extractor fails overload resolution — wrapped with lambda.
- rule_engine.py example_draft/example_corrected — extracted to locals after None guard so pyright narrows Optional.

## Test plan
- [x] `pyright src/` — 0 errors locally (was 10)
- [x] `pytest tests/` — 2070 passed, 23 skipped
- [ ] CI green on this PR

Generated with Gradata