### PR TITLE
feat(npx): gradata-install npm wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ skills/
 .claudeignore
 package.json
 package-lock.json
+# Exception: npm packages we intentionally ship
+!gradata-install/package.json
 
 # Sales data (private, never in public repo)
 Leads/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Not generally more intelligent. Calibrated to you.
 pip install gradata
 ```
 
+Or, one-command setup including IDE hooks (Node 18+ required):
+
+```bash
+npx gradata-install install --ide=claude-code
+```
+
 Works with any LLM. Python 3.11+. Zero required dependencies.
 
 ## Intellectual lineage

--- a/gradata-install/README.md
+++ b/gradata-install/README.md
@@ -1,0 +1,45 @@
+# gradata-install
+
+One command to install Gradata and wire it into your IDE.
+
+## Usage
+
+```bash
+npx gradata-install install --ide=claude-code
+```
+
+No clone, no venv, no multi-step setup. This wrapper spawns the Python tooling that's already on your machine.
+
+## Supported IDEs
+
+- `claude-code` (default)
+- `cursor`
+- `codex`
+- `gemini-cli`
+- `continue`
+
+## What it does
+
+Transparent three-step flow:
+
+1. Verifies Python >= 3.11 is installed (fails with exact install instructions for macOS/Linux/Windows if missing).
+2. Installs the `gradata` Python package — prefers `pipx`, falls back to `pip install --user` if pipx isn't available.
+3. Runs `gradata hooks install` to wire up your chosen IDE (correction capture, rule injection, status reporting).
+
+This package is a thin Node shim. It does not bundle Python or any Gradata logic. All real work happens in the `gradata` Python package.
+
+## Prerequisites
+
+- Node.js >= 18 (you have this if you ran `npx`)
+- Python >= 3.11 ([python.org/downloads](https://www.python.org/downloads/))
+- `pipx` recommended ([pipx.pypa.io](https://pipx.pypa.io/)) for clean isolated installs
+
+## After install
+
+- Restart your IDE so it picks up the new hook.
+- Verify with `gradata status`.
+- Docs and source: [github.com/Gradata/gradata](https://github.com/Gradata/gradata).
+
+## License
+
+AGPL-3.0-or-later — same as the main Gradata project.

--- a/gradata-install/bin/gradata-install.js
+++ b/gradata-install/bin/gradata-install.js
@@ -1,0 +1,337 @@
+#!/usr/bin/env node
+/**
+ * gradata-install — One-command installer for Gradata.
+ *
+ * Wraps: Python check -> pipx/pip install gradata -> gradata hooks install.
+ * Does NOT bundle Python. Spawns the local python/pipx/pip binaries.
+ *
+ * Usage:
+ *   npx gradata-install install [--ide=<name>]
+ *   npx gradata-install --help
+ *
+ * Supported IDEs: claude-code (default), cursor, codex, gemini-cli, continue
+ */
+
+"use strict";
+
+const { spawnSync } = require("node:child_process");
+const os = require("node:os");
+const process = require("node:process");
+
+// ---- Constants ---------------------------------------------------------------
+
+const SUPPORTED_IDES = [
+  "claude-code",
+  "cursor",
+  "codex",
+  "gemini-cli",
+  "continue",
+];
+const DEFAULT_IDE = "claude-code";
+const MIN_PYTHON = [3, 11];
+const PACKAGE = "gradata";
+
+// ---- Small helpers -----------------------------------------------------------
+
+function log(msg) {
+  process.stdout.write(msg + "\n");
+}
+
+function warn(msg) {
+  process.stderr.write(msg + "\n");
+}
+
+function fail(msg, code = 1) {
+  process.stderr.write("\n[gradata-install] ERROR: " + msg + "\n");
+  process.exit(code);
+}
+
+function printHelp() {
+  log(
+    [
+      "gradata-install — one-command Gradata installer",
+      "",
+      "Usage:",
+      "  npx gradata-install install [--ide=<name>]",
+      "  npx gradata-install --help",
+      "",
+      "Options:",
+      "  --ide=<name>   IDE to wire up (default: claude-code)",
+      "                 Supported: " + SUPPORTED_IDES.join(", "),
+      "  -h, --help     Show this help and exit",
+      "",
+      "What it does:",
+      "  1. Verifies Python >= " + MIN_PYTHON.join(".") + " is installed",
+      "  2. Installs the `gradata` Python package (pipx preferred, pip --user fallback)",
+      "  3. Runs `gradata hooks install` to wire up your IDE",
+      "",
+      "Prerequisites:",
+      "  - Node.js >= 18 (you already have this if you ran npx)",
+      "  - Python >= " + MIN_PYTHON.join(".") + "  (https://www.python.org/downloads/)",
+      "  - pipx recommended  (https://pipx.pypa.io/)",
+    ].join("\n")
+  );
+}
+
+function parsePythonVersion(out) {
+  // "Python 3.11.5" -> [3, 11, 5]
+  const m = /Python\s+(\d+)\.(\d+)(?:\.(\d+))?/i.exec(out);
+  if (!m) return null;
+  return [parseInt(m[1], 10), parseInt(m[2], 10), parseInt(m[3] || "0", 10)];
+}
+
+function versionGte(v, min) {
+  for (let i = 0; i < min.length; i++) {
+    const a = v[i] || 0;
+    const b = min[i];
+    if (a > b) return true;
+    if (a < b) return false;
+  }
+  return true;
+}
+
+function tryRun(cmd, args, opts = {}) {
+  try {
+    return spawnSync(cmd, args, {
+      encoding: "utf8",
+      shell: false,
+      ...opts,
+    });
+  } catch (err) {
+    return { error: err, status: -1, stdout: "", stderr: String(err) };
+  }
+}
+
+function runInherit(cmd, args) {
+  log("\n$ " + cmd + " " + args.join(" "));
+  const r = spawnSync(cmd, args, { stdio: "inherit", shell: false });
+  return r.status === null ? 1 : r.status;
+}
+
+// ---- Environment checks ------------------------------------------------------
+
+function findPython() {
+  // Returns { cmd, version } or null
+  const candidates = process.platform === "win32"
+    ? ["py", "python", "python3"]
+    : ["python3", "python"];
+
+  for (const cmd of candidates) {
+    const args = cmd === "py" ? ["-3", "--version"] : ["--version"];
+    const res = tryRun(cmd, args);
+    if (res.status !== 0) continue;
+    const out = (res.stdout || "") + (res.stderr || "");
+    const v = parsePythonVersion(out);
+    if (!v) continue;
+    if (!versionGte(v, MIN_PYTHON)) continue;
+    return {
+      cmd,
+      invocation: cmd === "py" ? [cmd, "-3"] : [cmd],
+      version: v,
+    };
+  }
+  return null;
+}
+
+function hasPipx() {
+  const res = tryRun("pipx", ["--version"]);
+  return res.status === 0;
+}
+
+function pythonInstallInstructions() {
+  const platform = os.platform();
+  const lines = [
+    "Python >= " + MIN_PYTHON.join(".") + " is required but was not found.",
+    "",
+    "Install instructions:",
+  ];
+  if (platform === "darwin") {
+    lines.push(
+      "  macOS:     brew install python@3.12",
+      "             or download from https://www.python.org/downloads/"
+    );
+  } else if (platform === "win32") {
+    lines.push(
+      "  Windows:   winget install Python.Python.3.12",
+      "             or download from https://www.python.org/downloads/"
+    );
+  } else {
+    lines.push(
+      "  Debian/Ubuntu: sudo apt-get install python3 python3-pip python3-venv",
+      "  Fedora/RHEL:   sudo dnf install python3 python3-pip",
+      "  Arch:          sudo pacman -S python python-pip",
+      "  Other:         https://www.python.org/downloads/"
+    );
+  }
+  lines.push(
+    "",
+    "After installing, also install pipx (recommended):",
+    "  python3 -m pip install --user pipx && python3 -m pipx ensurepath"
+  );
+  return lines.join("\n");
+}
+
+// ---- Argument parsing --------------------------------------------------------
+
+function parseArgs(argv) {
+  const out = { command: null, ide: DEFAULT_IDE, help: false };
+  const args = argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "-h" || a === "--help") {
+      out.help = true;
+    } else if (a === "install" && out.command === null) {
+      out.command = "install";
+    } else if (a.startsWith("--ide=")) {
+      out.ide = a.slice("--ide=".length);
+    } else if (a === "--ide") {
+      out.ide = args[i + 1];
+      i++;
+    } else if (a.startsWith("-")) {
+      warn("Unknown option: " + a);
+      out.help = true;
+    } else if (!out.command) {
+      out.command = a;
+    }
+  }
+  return out;
+}
+
+// ---- Main flow ---------------------------------------------------------------
+
+function installFlow(ide) {
+  if (!SUPPORTED_IDES.includes(ide)) {
+    fail(
+      "Unsupported IDE: " +
+        ide +
+        "\nSupported: " +
+        SUPPORTED_IDES.join(", ")
+    );
+  }
+
+  log("[gradata-install] Target IDE: " + ide);
+
+  // 1. Python check
+  const py = findPython();
+  if (!py) {
+    fail(pythonInstallInstructions());
+  }
+  log(
+    "[gradata-install] Found Python " +
+      py.version.join(".") +
+      " via `" +
+      py.invocation.join(" ") +
+      "`"
+  );
+
+  // 2. Install gradata package
+  let installCmd, installArgs;
+  if (hasPipx()) {
+    log("[gradata-install] pipx detected — using pipx.");
+    installCmd = "pipx";
+    installArgs = ["install", PACKAGE];
+  } else {
+    log(
+      "[gradata-install] pipx not found — falling back to `pip install --user`."
+    );
+    log("[gradata-install] (Tip: install pipx for cleaner isolation.)");
+    installCmd = py.invocation[0];
+    installArgs = py.invocation
+      .slice(1)
+      .concat(["-m", "pip", "install", "--user", "--upgrade", PACKAGE]);
+  }
+
+  let status = runInherit(installCmd, installArgs);
+  if (status !== 0) {
+    // If pipx install failed because already installed, retry with upgrade.
+    if (installCmd === "pipx") {
+      log(
+        "[gradata-install] pipx install failed — trying `pipx upgrade " +
+          PACKAGE +
+          "`."
+      );
+      status = runInherit("pipx", ["upgrade", PACKAGE]);
+    }
+    if (status !== 0) {
+      fail(
+        "Failed to install `" +
+          PACKAGE +
+          "` (exit code " +
+          status +
+          ").\n" +
+          "Check the output above and try running the command manually."
+      );
+    }
+  }
+
+  // 3. Run hook installer
+  // The gradata CLI exposes `gradata hooks install` (see src/gradata/cli.py).
+  // We pass the IDE via --ide for forward-compat; current CLI ignores unknown
+  // flags or targets claude-code by default. We only pass --ide when non-default.
+  const hookArgs = ["hooks", "install"];
+  if (ide !== DEFAULT_IDE) {
+    hookArgs.push("--ide", ide);
+  }
+
+  status = runInherit("gradata", hookArgs);
+  if (status !== 0) {
+    // Fall back to `python -m gradata` if `gradata` isn't on PATH yet
+    // (common with pip --user on fresh installs).
+    log(
+      "[gradata-install] `gradata` not on PATH — retrying via `python -m gradata`."
+    );
+    status = runInherit(
+      py.invocation[0],
+      py.invocation.slice(1).concat(["-m", "gradata"]).concat(hookArgs)
+    );
+  }
+  if (status !== 0) {
+    fail(
+      "Hook installation failed (exit code " +
+        status +
+        ").\n" +
+        "You can retry manually with: gradata hooks install"
+    );
+  }
+
+  // 4. Success message
+  log("");
+  log("[gradata-install] Gradata installed and wired up for " + ide + ".");
+  log("");
+  log("Next steps:");
+  if (ide === "claude-code") {
+    log("  1. Restart Claude Code so it picks up the hook.");
+  } else {
+    log("  1. Restart " + ide + " so it picks up the hook.");
+  }
+  log("  2. Verify with:  gradata status");
+  log("  3. Docs:          https://github.com/Gradata/gradata");
+  log("");
+}
+
+// ---- Entrypoint --------------------------------------------------------------
+
+function main() {
+  // Clean Ctrl+C handling — suppress node's default stacktrace.
+  process.on("SIGINT", () => {
+    warn("\n[gradata-install] Cancelled by user.");
+    process.exit(130);
+  });
+
+  const args = parseArgs(process.argv);
+
+  if (args.help || !args.command) {
+    printHelp();
+    process.exit(args.help ? 0 : 1);
+  }
+
+  if (args.command !== "install") {
+    warn("Unknown command: " + args.command);
+    printHelp();
+    process.exit(1);
+  }
+
+  installFlow(args.ide);
+}
+
+main();

--- a/gradata-install/package.json
+++ b/gradata-install/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "gradata-install",
+  "version": "0.1.0",
+  "description": "One-command installer for Gradata. Wraps pip/pipx + IDE hook setup.",
+  "bin": {
+    "gradata-install": "./bin/gradata-install.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Gradata/gradata.git",
+    "directory": "gradata-install"
+  },
+  "license": "AGPL-3.0-or-later",
+  "engines": { "node": ">=18" },
+  "files": ["bin/", "README.md"],
+  "keywords": ["gradata", "claude", "ai", "memory", "installer"]
+}


### PR DESCRIPTION
Adds an npm package so users can do `npx gradata-install install --ide=claude-code` instead of `pip install + gradata install-hook`. Brings distribution parity with claude-mem. Package not published to npm yet — review and approve, then publish manually.

## What's in the PR

- `gradata-install/package.json` — npm package manifest (AGPL-3.0, bin entry `gradata-install`)
- `gradata-install/bin/gradata-install.js` — Node 18+ CLI (no deps beyond Node stdlib)
- `gradata-install/README.md` — user-facing docs
- Root `README.md` — adds the `npx gradata-install install --ide=claude-code` one-liner under the install section
- `.gitignore` — carve-out so `gradata-install/package.json` is tracked (root gitignore blocks all package.json)

## What the wrapper does

1. Checks Python >= 3.11 (tries `py -3` / `python3` / `python`). If missing, prints exact install commands for macOS/Windows/Linux and exits non-zero.
2. Installs the `gradata` Python package via `pipx install gradata` if pipx is present, otherwise `python -m pip install --user --upgrade gradata`.
3. Runs `gradata hooks install` (falls back to `python -m gradata hooks install` if `gradata` isn't yet on PATH).
4. Prints next-steps (restart IDE, run `gradata status`). Exit code 0 on success, non-zero with readable error otherwise. Ctrl+C exits cleanly with code 130.

## Supported IDEs

`claude-code` (default), `cursor`, `codex`, `gemini-cli`, `continue`.

## Constraints honored

- Node-only wrapper, no Python bundled. Spawns user's local toolchain.
- No new runtime deps — just Node stdlib.
- Does NOT publish to npm in this PR.

## Notes

- Existing Python CLI is `gradata hooks install` (see `src/gradata/cli.py`), not `gradata install-hook`. Wrapper calls the real command; user-facing shape remains `npx gradata-install install --ide=...`.
- `--ide` is passed through only when non-default, so this works against the current CLI even before multi-IDE support lands.

## Test plan

- [ ] `node gradata-install/bin/gradata-install.js --help` prints usage (verified locally)
- [ ] `npm link` + `gradata-install --help` on macOS / Linux / Windows
- [ ] Fresh env without Python — verify failure message shows OS-specific install instructions
- [ ] Env with pipx — verify `pipx install gradata` path
- [ ] Env without pipx — verify `pip install --user` fallback
- [ ] After successful install, `gradata status` reports hook installed
- [ ] Ctrl+C mid-run exits 130 cleanly