### PR TITLE
feat(plugin): Claude Code plugin for /plugin install gradata

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -1,0 +1,97 @@
+# Gradata — Claude Code Plugin
+
+AI that learns your judgment. Every correction you make becomes a rule that sharpens future output.
+
+## Prerequisites
+
+This plugin is a thin wrapper around the Gradata Python SDK. You must install the SDK first:
+
+```bash
+# Python 3.11+ required
+pipx install gradata
+```
+
+Verify the install before enabling the plugin:
+
+```bash
+python -m gradata --version
+```
+
+If `python` is not on your `PATH`, or maps to Python < 3.11, fix that first — the plugin's hooks shell out to `python -m gradata.hooks.*` and will fail silently otherwise.
+
+## Install
+
+```
+/plugin marketplace add Gradata/gradata
+/plugin install gradata
+```
+
+Claude Code will load four hooks on your next session:
+
+| Event            | Hook                               | What it does |
+| ---------------- | ---------------------------------- | ------------ |
+| SessionStart     | `gradata.hooks.inject_brain_rules` | Injects graduated rules into session context |
+| UserPromptSubmit | `gradata.hooks.context_inject`     | Injects brain context per user message |
+| PostToolUse      | `gradata.hooks.auto_correct`       | Captures Edit/Write corrections as lessons |
+| Stop             | `gradata.hooks.session_close`      | Emits SESSION_END + runs graduation sweep |
+
+## Configure
+
+Gradata stores its brain at `$GRADATA_BRAIN_DIR` if set, otherwise `./brain/` in the current working directory. To initialize a brain for the current project:
+
+```bash
+gradata init ./brain
+```
+
+To use a shared brain across projects:
+
+```bash
+export GRADATA_BRAIN_DIR=~/.gradata/default-brain
+gradata init "$GRADATA_BRAIN_DIR"
+```
+
+Full SDK docs: https://gradata.ai
+
+## Uninstall
+
+```
+/plugin uninstall gradata
+```
+
+This removes the hooks from your Claude Code session. Your brain data (corrections, lessons, rules) stays on disk at `$GRADATA_BRAIN_DIR`. To fully remove:
+
+```bash
+pipx uninstall gradata
+rm -rf ./brain         # or $GRADATA_BRAIN_DIR
+```
+
+## Troubleshooting
+
+**Nothing seems to happen.** The hooks fail silent by design so they never block Claude Code. Check:
+
+```bash
+python -m gradata.hooks.inject_brain_rules < /dev/null
+```
+
+If you see `ModuleNotFoundError: No module named 'gradata'`, `pipx install gradata` did not succeed or `python` is pointing at a different interpreter than the one pipx used. Run `pipx list` to see where Gradata lives, then ensure that interpreter is first on your `PATH`.
+
+**Corrections are not being captured.** Only `Edit` and `Write` tool calls trigger `auto_correct`. Plain chat edits (without a tool call) are not captured yet.
+
+**Rules are not being injected.** Rules only inject once they've graduated past the `PATTERN` threshold (0.60 confidence). Check graduation state:
+
+```bash
+gradata rules --all
+```
+
+New corrections start at `INSTINCT`. It takes repeated reinforcement before a rule reaches injection-eligible confidence.
+
+**`python` not found on Windows.** Install Python 3.11+ from python.org and check "Add to PATH" during install, or use `py -m gradata.hooks.inject_brain_rules` and alias `python=py` in your shell profile.
+
+**Where are my brain files?** Run `gradata doctor` — it prints the resolved brain directory, lesson count, and rule graduation histogram.
+
+## Links
+
+- SDK: https://pypi.org/project/gradata/
+- Source: https://github.com/Gradata/gradata
+- Docs: https://gradata.ai
+- License: AGPL-3.0-or-later

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "gradata",
+  "version": "0.1.0",
+  "description": "AI that learns your judgment. Corrections become rules.",
+  "author": {
+    "name": "Gradata",
+    "url": "https://gradata.ai"
+  },
+  "homepage": "https://gradata.ai",
+  "repository": "https://github.com/Gradata/gradata",
+  "license": "AGPL-3.0-or-later",
+  "keywords": [
+    "learning",
+    "corrections",
+    "rules",
+    "memory",
+    "personalization"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,24 @@ Gradata synthesizes research from Constitutional AI (Anthropic, 2022), Duolingo'
 
 ## Quick Start
 
+### Claude Code (recommended)
+
+```
+/plugin marketplace add Gradata/gradata
+/plugin install gradata
+```
+
+Requires `pipx install gradata` first (Python 3.11+). See [.claude-plugin/README.md](./.claude-plugin/README.md) for full setup and troubleshooting.
+
+### Python SDK (advanced)
+
+```bash
+pipx install gradata
+gradata install-hook --ide=claude-code
+```
+
+### Library usage
+
 ```python
 from gradata import Brain
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,53 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "description": "Gradata: inject graduated rules at session start",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python -m gradata.hooks.inject_brain_rules",
+            "timeout": 10000
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "description": "Gradata: inject brain context on user message",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python -m gradata.hooks.context_inject",
+            "timeout": 8000
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "description": "Gradata: capture corrections from edits",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python -m gradata.hooks.auto_correct",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "description": "Gradata: emit SESSION_END + run graduation sweep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python -m gradata.hooks.session_close",
+            "timeout": 15000
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Ships `.claude-plugin/plugin.json` + `hooks/hooks.json` so users can install Gradata via Claude Code's plugin marketplace. First-class distribution path matching claude-mem et al.

- `.claude-plugin/plugin.json` — manifest (name, version, author, homepage, repository, license, keywords) per Claude Code plugin schema
- `hooks/hooks.json` — wires SessionStart, UserPromptSubmit, PostToolUse (Edit|Write), Stop events to existing `gradata.hooks.*` modules. No new runtime code.
- `.claude-plugin/README.md` — prereqs (Python 3.11+, `pipx install gradata`), install, configure, uninstall, troubleshooting FAQ
- `README.md` — adds "Claude Code (recommended)" block at top of Quick Start

Hooks reuse `inject_brain_rules`, `context_inject`, `auto_correct`, `session_close` — the same modules `gradata install-hook --ide=claude-code` already installs into `~/.claude/settings.json`. Plugin is purely additive.

## Test plan

- [x] `pytest tests/ -x -q` passes (2070 passed, 23 skipped)
- [x] JSON validates for both `.claude-plugin/plugin.json` and `hooks/hooks.json`
- [ ] `claude --plugin-dir ./` loads plugin without error (manual, post-merge)
- [ ] `/plugin marketplace add Gradata/gradata` + `/plugin install gradata` round-trip on a clean machine (manual, after marketplace registration)
- [ ] Verify SessionStart hook injects `<brain-rules>` block when pipx gradata is present and brain has graduated rules

Generated with Gradata