### PR TITLE
feat(marketing): proof CTAs linking to /proof dashboard per sim24 pricing pushback

### DIFF
--- a/marketing/app/how-it-works/page.tsx
+++ b/marketing/app/how-it-works/page.tsx
@@ -99,6 +99,25 @@ next_draft = llm.generate(prompt, context=brain.context_for("reply"))`}
         ))}
       </section>
 
+      <section className="mt-8">
+        <GlassCard className="p-6">
+          <div className="font-heading text-lg font-semibold">See the ablation data</div>
+          <p className="mt-2 text-sm text-[color:var(--color-muted-foreground)]">
+            192 trials across Sonnet, DeepSeek, qwen14b, and Gemma4. Blind Haiku 4.5 judge.
+            Rules clean vs rules plus LLM meta-rules vs base. Min 2022 random-content control
+            regressed 3 to 10 percent on three of four models, so the lift tracks content, not format.
+          </p>
+          <div className="mt-4">
+            <a
+              href={site.proofUrl}
+              className="inline-flex items-center rounded-md border border-[color:var(--color-border)] px-4 py-2 text-sm font-medium text-[color:var(--color-foreground)] transition-colors hover:bg-[color:var(--color-card)]"
+            >
+              Read the A/B proof: Sonnet +7.8% preference
+            </a>
+          </div>
+        </GlassCard>
+      </section>
+
       <section className="mt-14">
         <GlassCard className="p-6">
           <div className="font-heading text-lg font-semibold">Injection, not retraining</div>

--- a/marketing/app/page.tsx
+++ b/marketing/app/page.tsx
@@ -33,6 +33,14 @@ export default function HomePage() {
           </p>
         </div>
         <KpiProofRow />
+        <div className="mt-8">
+          <a
+            href={site.proofUrl}
+            className="inline-flex items-center rounded-md border border-[color:var(--color-border)] px-5 py-2.5 text-sm font-medium text-[color:var(--color-foreground)] transition-colors hover:bg-[color:var(--color-card)]"
+          >
+            Read the A/B proof: Sonnet +7.8%, Gemma4 +9.5% correctness
+          </a>
+        </div>
       </section>
 
       <section className="mx-auto max-w-6xl px-4 py-16 sm:px-6">

--- a/marketing/src/components/Hero.tsx
+++ b/marketing/src/components/Hero.tsx
@@ -27,8 +27,14 @@ export function Hero() {
               Start free
             </a>
             <a
-              href="/how-it-works/"
+              href={site.proofUrl}
               className="inline-flex w-full items-center justify-center rounded-md border border-[color:var(--color-border)] px-5 py-2.5 text-sm font-medium text-[color:var(--color-foreground)] transition-colors hover:bg-[color:var(--color-card)] sm:w-auto"
+            >
+              See the 192-trial ablation
+            </a>
+            <a
+              href="/how-it-works/"
+              className="inline-flex w-full items-center justify-center rounded-md px-5 py-2.5 text-sm font-medium text-[color:var(--color-muted-foreground)] transition-colors hover:text-[color:var(--color-foreground)] sm:w-auto"
             >
               How it works
             </a>

--- a/marketing/src/lib/site.ts
+++ b/marketing/src/lib/site.ts
@@ -2,6 +2,7 @@ export const site = {
   name: "Gradata",
   url: "https://gradata.ai",
   appUrl: "https://app.gradata.ai",
+  proofUrl: "https://app.gradata.ai/proof",
   docsUrl: "https://github.com/Gradata/gradata",
   tagline: "AI that learns the corrections you keep making.",
   description:


### PR DESCRIPTION
## Summary
- Adds prominent proof CTAs across marketing surfacing the dashboard `/proof` route (shipped by PR #44).
- Three insertion points: Hero secondary button, landing page under KpiProofRow, how-it-works STAGES section.
- `proofUrl` centralised in `marketing/src/lib/site.ts`.

## Motivation
Sim24: ~40% of agents pushed back on $50/user/month pricing. Most-liked comment (VP Eng): "Hard to justify without proof." The `/proof` endpoint + dashboard route exists; marketing wasn't linking to it.

## Numbers used (ablation v4 closer)
- 192 trials, 4 models × 16 tasks × 3 iters, blind Haiku 4.5 judge
- Sonnet +7.8% preference adherence
- Gemma4 +9.5% correctness, +11.1% quality
- Min 2022 random-content control: -3 to -10% on 3 of 4 models

## Test plan
- [x] pnpm build passes, 10 static pages, 0 TS errors
- [ ] Visual check on preview deploy

Co-Authored-By: Gradata <noreply@gradata.ai>