### PR TITLE
docs(inspection): surface existing brain.rules/explain/export API per sim20+sim22 demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,7 @@ Memory systems remember what you said. Gradata learns how you think.
 - `brain.bus.on(event, handler)` — subscribe to any pipeline event
 - Events: `correction.created`, `lesson.graduated`, `meta_rule.created`, `session.ended`
 
-**Rule inspection + approval:**
-- `brain.rules()` / `brain.explain(rule_id)` / `brain.trace(rule_id)` — full provenance chain
-- `brain.pending_promotions()` — review what graduated this session
-- `brain.approve_promotion(id)` / `brain.reject_promotion(id)` — human veto power
+**Rule inspection + approval:** see [Inspection & Transparency API](#inspection--transparency-api) below.
 
 **Security:**
 - PII redaction before storage (credentials, emails, SSNs, credit cards)
@@ -209,6 +206,41 @@ Memory systems remember what you said. Gradata learns how you think.
 - MCP server for Claude Code, Cursor, Windsurf
 - Claude Code hooks: `gradata hooks install` — auto-captures corrections
 - Custom LLM providers: `GRADATA_LLM_PROVIDER=openai` or any OpenAI-compatible endpoint
+
+## Inspection & Transparency API
+
+Every graduated rule can be traced back to the corrections that created it. No opaque behavior. Git diff for AI preferences.
+
+```python
+from gradata import Brain
+
+brain = Brain("./my-brain")
+
+# List graduated rules (optionally filter by category or include all states)
+rules = brain.rules()
+rules = brain.rules(include_all=True, category="tone")
+
+# Trace a rule to the corrections that created it
+brain.explain("rule_abc123")
+# → {"rule_id": ..., "description": ..., "source_corrections": [...], "sessions": [...]}
+
+# Full provenance chain (rule → lesson → corrections → events)
+brain.trace("rule_abc123")
+
+# Export rules for review, diffing, or sharing
+brain.export_data(output_format="json")   # or "yaml"
+brain.export_rules(min_state="PATTERN")   # OpenSpace-compatible SKILL.md
+brain.export_rules_json(min_state="RULE") # flat sorted JSON array
+brain.export_skill(output_dir="./skills") # full skill directory
+brain.export_tree(format="obsidian", path="./vault")
+
+# Human veto: review what graduated, keep or demote
+brain.pending_promotions()                # rules in PATTERN/RULE state
+brain.approve_promotion("rule_abc123")    # endorse (persists reviewed flag)
+brain.reject_promotion("rule_abc123")     # demote back to INSTINCT
+```
+
+See [docs/sdk/brain.md](./docs/sdk/brain.md#inspection--transparency) for full signatures and return shapes.
 
 ## CLI
 

--- a/docs/sdk/brain.md
+++ b/docs/sdk/brain.md
@@ -285,6 +285,61 @@ Register a custom task type in the scope classifier.
 
 ---
 
+## Inspection & Transparency
+
+Every graduated rule can be traced back to the corrections that created it. These methods power `gradata review`, dashboards, audits, and third-party tooling.
+
+### `brain.rules(*, include_all=False, category=None)` → list[dict]
+
+List graduated rules. By default returns PATTERN and RULE state only.
+
+```python
+brain.rules()                              # graduated only
+brain.rules(include_all=True)              # include INSTINCT
+brain.rules(category="tone")               # filter by category
+```
+
+Each dict contains `id`, `description`, `category`, `state`, `confidence`, `applications`, and timestamps. Rule IDs are stable hashes derived from the lesson content, so they survive re-loads.
+
+### `brain.explain(rule_id)` → dict
+
+Trace a rule to the corrections that created it.
+
+```python
+brain.explain("rule_abc123")
+# → {"rule_id": ..., "description": ..., "source_corrections": [...], "sessions": [...]}
+```
+
+### `brain.trace(rule_id)` → dict
+
+Full provenance chain: rule → lesson → corrections → events. Heavier than `explain()`; use for audits.
+
+### `brain.export_data(*, output_format="json")` → str
+
+Export rules as JSON or YAML. For quick inspection, dashboards, or `git diff` of AI preferences.
+
+```python
+brain.export_data()                        # JSON string
+brain.export_data(output_format="yaml")    # YAML string
+```
+
+### `brain.pending_promotions()` → list[dict]
+
+List rules that have graduated this session and may warrant human review. Silent during normal work — intended to be called at session end.
+
+### `brain.approve_promotion(rule_id)` → dict
+
+Endorse a graduated rule. Persists a `reviewed` flag to the lessons file and emits `PROMOTION_APPROVED`. Returns `{"approved": True}` or `{"error": "..."}`.
+
+### `brain.reject_promotion(rule_id)` → dict
+
+Demote a graduated rule back to INSTINCT with confidence 0.40. Emits `PROMOTION_REJECTED`. Returns `{"rejected": True, "demoted_from": old_state}` or `{"error": "..."}`.
+
+!!! note
+    `review_pending()` / `approve_lesson()` / `reject_lesson()` operate on the _pre_-graduation approval queue (integer IDs, gated by `approval_required=True`). `pending_promotions()` / `approve_promotion()` / `reject_promotion()` operate on _already_-graduated rules (stable string IDs) as a post-hoc veto.
+
+---
+
 ## Export and share
 
 ### `brain.export(output_path=None, mode="full")` → Path
@@ -308,6 +363,22 @@ Install a brain package from another user, applying their graduated rules to thi
 ### `brain.export_rules(min_state="PATTERN", skill_name="")` → str
 
 Export rules as markdown for cross-platform agent hosts (see [Rule-to-Hook](rule-to-hook.md)).
+
+### `brain.export_rules_json(min_state="PATTERN")` → list[dict]
+
+Export graduated rules as a flat, sorted JSON-ready array. Useful for dashboards and external tooling.
+
+### `brain.export_skill(output_dir=None, min_state="PATTERN", skill_name="")` → Path
+
+Export graduated rules as a full [skill directory](https://github.com/openspace-ai/skills) (SKILL.md + metadata). Returns the path to the created directory.
+
+### `brain.export_skills(output_dir=None, min_state="PATTERN")` → list[str]
+
+Export graduated rules as one SKILL.md per category. Returns the list of files written.
+
+### `brain.export_tree(format="json", path="./export")` → Path
+
+Export the brain's rule tree in `"json"` or `"obsidian"` format.
 
 ### `brain.backfill_from_git(repo_path=".", lookback_days=90)`
 


### PR DESCRIPTION
## Summary
- README gets a discoverable "Inspection & Transparency API" section between Features and CLI.
- docs/sdk/brain.md gets a dedicated section with signatures and return shapes; fills four missing Export entries.
- Docs note distinguishing pre-graduation (`approve_lesson`) vs post-graduation (`approve_promotion`) approval APIs.

## Motivation
Rule transparency + inspectability was the #1 user demand across sim20 (30+ mentions) and sim22 (highest-liked comment at 30 likes: "Git diff for AI preferences"). The API already existed in `src/gradata/brain_inspection.py` and `src/gradata/brain.py` — users just couldn't find it.

## Changes
- README.md: +36/-4
- docs/sdk/brain.md: +70/-1
- No code changes.

## Follow-ups noted (out of scope for this PR)
1. Two parallel approval APIs is a UX hazard; rename candidate.
2. `docs/api/brain.md` is orphaned (not in mkdocs.yml nav); deletion candidate.
3. `brain.explain()`, `rules()`, `trace()`, `export_data()` docstrings are one-liners; thin.

## Test plan
- [x] uv run pytest tests/ -q → 2221 passed, 23 skipped

Co-Authored-By: Gradata <noreply@gradata.ai>