### PR TITLE
feat(correct): add applies_to= binding token per sim21 trust-crisis scenario

### DIFF
--- a/src/gradata/_core.py
+++ b/src/gradata/_core.py
@@ -82,6 +82,7 @@ def brain_correct(
     session: int | None = None, agent_type: str | None = None,
     approval_required: bool = False, dry_run: bool = False,
     min_severity: str = "as-is", scope: str | None = None,
+    applies_to: str | None = None,
 ) -> dict:
     """Record a correction: user edited draft into final version."""
     # Input validation
@@ -104,10 +105,18 @@ def brain_correct(
         if scope is not None and scope not in _valid_scopes:
             raise ValueError(f"Unsupported correction scope: {scope!r}. Must be one of {_valid_scopes}")
 
+    # Normalize free-form scope binding (sim21). Any truthy string is accepted;
+    # empty strings collapse to None so callers can pass through user input
+    # safely. Injection-side filtering on this token is a follow-up.
+    if applies_to is not None:
+        applies_to = str(applies_to).strip() or None
+
     # Route to cloud if connected
     if brain._cloud and brain._cloud.connected:
         try:
-            return brain._cloud.correct(draft, final, category, context, session)
+            return brain._cloud.correct(
+                draft, final, category, context, session, applies_to=applies_to
+            )
         except Exception as e:
             _log.warning("Cloud correct() failed, falling back to local: %s", e)
             brain._cloud.connected = False
@@ -158,6 +167,8 @@ def brain_correct(
     # Tag correction scope (default: domain)
     correction_scope = scope or "domain"
     scope_data["correction_scope"] = correction_scope
+    if applies_to:
+        scope_data["applies_to"] = applies_to
 
     data = {
         "draft_text": draft_redacted[:2000], "final_text": final_redacted[:2000],
@@ -170,17 +181,23 @@ def brain_correct(
         "lines_removed": diff.summary_stats.get("lines_removed", 0),
         "correction_scope": correction_scope,
     }
+    if applies_to:
+        data["applies_to"] = applies_to
     if scope_data:
         data["scope"] = scope_data
 
     tags = [f"category:{category or 'UNKNOWN'}", f"severity:{diff.severity}"]
     if diff.severity in ("major", "discarded"):
         tags.append("major_edit:true")
+    if applies_to:
+        tags.append(f"applies_to:{applies_to}")
 
     event = brain.emit("CORRECTION", "brain.correct", data, tags, session)
     event["diff"] = diff
     event["classifications"] = classifications
     event["correction_scope"] = correction_scope
+    if applies_to:
+        event["applies_to"] = applies_to
 
     # Auto-extract patterns
     try:
@@ -306,6 +323,8 @@ def brain_correct(
                         scope_dict = {}
                     # Always tag correction_scope on new lessons
                     scope_dict["correction_scope"] = correction_scope
+                    if applies_to:
+                        scope_dict["applies_to"] = applies_to
                     lesson_scope = _json.dumps(scope_dict)
 
                     init_conf = 0.0 if approval_required else INITIAL_CONFIDENCE

--- a/src/gradata/brain.py
+++ b/src/gradata/brain.py
@@ -373,8 +373,18 @@ class Brain(BrainInspectionMixin):
         dry_run: bool = False,
         min_severity: str = "as-is",
         scope: str | None = None,
+        applies_to: str | None = None,
     ) -> dict:
-        """Record a correction: user edited draft into final version."""
+        """Record a correction: user edited draft into final version.
+
+        ``applies_to`` is an optional free-form scope token (e.g.
+        ``"client:acme"``, ``"task:emails"``, ``"global"``) that binds the
+        correction to a specific context. When set, it is persisted on the
+        event and propagated to any lesson that graduates from this
+        correction's lineage. Injection-time filtering by ``applies_to``
+        is a follow-up — persistence only for now. A ``None`` value preserves
+        the existing global behaviour.
+        """
         self._rule_cache.invalidate()  # Correction invalidates cached rules
         from gradata._core import brain_correct
 
@@ -390,6 +400,7 @@ class Brain(BrainInspectionMixin):
             dry_run=dry_run,
             min_severity=min_severity,
             scope=scope,
+            applies_to=applies_to,
         )
 
     def record_correction(

--- a/src/gradata/cloud/client.py
+++ b/src/gradata/cloud/client.py
@@ -87,22 +87,29 @@ class CloudClient:
         category: str | None = None,
         context: dict | None = None,
         session: int | None = None,
+        applies_to: str | None = None,
     ) -> dict:
         """Send correction to cloud for server-side graduation.
 
         The cloud runs the full pipeline: diff -> classify -> extract
         patterns -> graduate -> update rules. Returns the same event
         dict format as local Brain.correct().
+
+        ``applies_to`` is an optional free-form scope token (e.g.
+        ``"client:acme"``) forwarded to the cloud payload for persistence.
         """
+        payload = {
+            "brain_id": self._brain_id,
+            "draft": draft[:2000],
+            "final": final[:2000],
+            "category": category,
+            "context": context,
+            "session": session,
+        }
+        if applies_to:
+            payload["applies_to"] = applies_to
         try:
-            return self._post("/brains/correct", {
-                "brain_id": self._brain_id,
-                "draft": draft[:2000],
-                "final": final[:2000],
-                "category": category,
-                "context": context,
-                "session": session,
-            })
+            return self._post("/brains/correct", payload)
         except Exception as e:
             logger.warning("Cloud correct() failed, falling back to local: %s", e)
             raise  # Let Brain.correct() catch and fall back

--- a/src/gradata/context_wrapper.py
+++ b/src/gradata/context_wrapper.py
@@ -174,12 +174,20 @@ class BrainContextState:
             with suppress(Exception):
                 self._brain.log_output(response, output_type="general")
 
-    def correct(self, draft: str | None = None, final: str = "") -> dict | None:
+    def correct(
+        self,
+        draft: str | None = None,
+        final: str = "",
+        *,
+        applies_to: str | None = None,
+    ) -> dict | None:
         """Record a correction (user edited the AI's output).
 
         Args:
             draft: The original AI output. If None, uses the last captured response.
             final: The user's edited version.
+            applies_to: Optional free-form scope token (e.g. ``"client:acme"``)
+                passed through to ``Brain.correct``. See Brain.correct docs.
 
         Returns:
             Correction event dict, or None if no brain.
@@ -196,7 +204,7 @@ class BrainContextState:
             return None
 
         try:
-            return self._brain.correct(draft, final)
+            return self._brain.correct(draft, final, applies_to=applies_to)
         except Exception as e:
             logger.warning("Correction failed: %s", e)
             return None

--- a/src/gradata/mcp_tools.py
+++ b/src/gradata/mcp_tools.py
@@ -43,6 +43,7 @@ def correct(
     *,
     category: str | None = None,
     brain_dir: str | Path | None = None,
+    applies_to: str | None = None,
 ) -> dict[str, Any]:
     """Log a correction: compute diff between draft and final, classify, store.
 
@@ -56,6 +57,10 @@ def correct(
             If not provided, auto-detected from the diff content.
         brain_dir: Optional brain directory path. If not provided, uses
             the default from _paths.
+        applies_to: Optional free-form scope token (e.g. ``"client:acme"``,
+            ``"task:emails"``) passed through to ``Brain.correct``. Persisted
+            on the correction event and any lesson created from it. See
+            ``Brain.correct`` for details.
 
     Returns:
         Dict with keys:
@@ -89,7 +94,7 @@ def correct(
             from gradata.brain import Brain
 
             brain = Brain(brain_dir)
-            brain.correct(draft, final)
+            brain.correct(draft, final, applies_to=applies_to)
             lesson_created = True
     except Exception:
         # Brain not available or not initialized -- still return diff results

--- a/tests/test_scope_tagging.py
+++ b/tests/test_scope_tagging.py
@@ -160,3 +160,70 @@ def test_non_one_off_can_graduate():
     active, graduated = graduate([lesson])
     # Should promote to PATTERN
     assert lesson.state == LessonState.PATTERN
+
+
+# ---------------------------------------------------------------------------
+# Free-form applies_to scope binding (sim21 ask)
+# ---------------------------------------------------------------------------
+
+def test_applies_to_persisted_on_event(tmp_path: Path):
+    """brain.correct(applies_to='client:acme') persists the token on the event."""
+    from tests.conftest import init_brain
+
+    brain = init_brain(tmp_path)
+    result = brain.correct(
+        "Dear Sir/Madam,",
+        "Hey Acme team,",
+        applies_to="client:acme",
+    )
+    assert result.get("applies_to") == "client:acme"
+    assert result["data"]["applies_to"] == "client:acme"
+    assert result["data"]["scope"]["applies_to"] == "client:acme"
+    assert "applies_to:client:acme" in result["tags"]
+
+
+def test_applies_to_none_is_backward_compatible(tmp_path: Path):
+    """Omitting applies_to leaves the event clear of the token (legacy behaviour)."""
+    from tests.conftest import init_brain
+
+    brain = init_brain(tmp_path)
+    result = brain.correct("bad output", "good output")
+    assert "applies_to" not in result
+    assert "applies_to" not in result.get("data", {})
+    assert not any(t.startswith("applies_to:") for t in result.get("tags", []))
+
+
+def test_applies_to_empty_string_collapses_to_none(tmp_path: Path):
+    """Empty / whitespace-only applies_to is normalised away."""
+    from tests.conftest import init_brain
+
+    brain = init_brain(tmp_path)
+    result = brain.correct("bad output", "good output", applies_to="   ")
+    assert "applies_to" not in result
+    assert "applies_to" not in result.get("data", {})
+
+
+def test_applies_to_propagates_to_lesson_scope_json(tmp_path: Path):
+    """applies_to appears in the new lesson's scope_json alongside correction_scope."""
+    from gradata.enhancements.self_improvement import parse_lessons
+    from tests.conftest import init_brain
+
+    brain = init_brain(tmp_path)
+    brain.correct(
+        "This is a completely wrong paragraph that needs total rewriting with different content.",
+        "Here is the corrected version with entirely new accurate information and proper formatting.",
+        applies_to="task:emails",
+    )
+
+    lessons_path = brain._find_lessons_path()
+    assert lessons_path and lessons_path.is_file(), "lessons.md not created"
+    text = lessons_path.read_text(encoding="utf-8")
+    lessons = parse_lessons(text)
+    tagged = [
+        l for l in lessons
+        if l.scope_json and "applies_to" in l.scope_json
+    ]
+    assert tagged, f"No lesson carried applies_to. scope_jsons={[l.scope_json for l in lessons]}"
+    scope_data = json.loads(tagged[0].scope_json)
+    assert scope_data.get("applies_to") == "task:emails"
+    assert scope_data.get("correction_scope") == "domain"  # default preserved


### PR DESCRIPTION
## Summary
Adds optional `applies_to: str | None = None` to `Brain.correct` and siblings, persisting the binding token alongside the correction event and the resulting lesson.

Persistence-only. Injection-side filtering is a follow-up that will touch `_types.py` and `inject_brain_rules.py`, so it waits for worktree-agent-a081f7ba.

## Motivation
Sim21 — #1 product gap (80%+ of posts): a single high-edit-distance correction graduates globally even when user meant it for one client. Users asked (~40 mentions) for scope-tagging at correction time.

## Key design decision: `applies_to`, not `scope`
`Brain.correct` already has a `scope` enum (`universal`/`domain`/`project`/`one_off`) governing graduation breadth — a different axis from sim21's ask. Reusing the name would silently break the existing `CorrectionScope` contract. So this PR adds `applies_to` for free-form binding tokens (`client:acme`, `task:emails`) and leaves `scope` untouched.

## Files changed (6)
- `src/gradata/brain.py`, `_core.py`, `context_wrapper.py`, `mcp_tools.py`, `cloud/client.py`
- `tests/test_scope_tagging.py` — 4 new round-trip tests

## Tests
- 2221 → 2225 pass, 23 skip unchanged
- `uv run ruff check` on all 5 edited source files: clean

## Follow-up needed (not in this PR)
- Injection filter (requires `_types.py` edit; conflicts with a081f7ba until it lands)
- Cloud endpoint doesn't yet consume `applies_to` in payload
- Index `applies_to` on hot path (JSON parse of `scope_json` is too slow for selection)
- Extend `record_correction` for symmetry

## Test plan
- [x] Full pytest suite green (2225 pass)
- [x] Ruff clean
- [ ] Cloud endpoint consumes `applies_to`

Co-Authored-By: Gradata <noreply@gradata.ai>