### PR TITLE
fix(license): get GitHub to recognize AGPL-3.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+LICENSE text eol=lf

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-SPDX-License-Identifier: AGPL-3.0-or-later
-Copyright (C) 2026 Gradata
 
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
@@ -636,8 +634,8 @@ the "copyright" line and a pointer to where the full notice is found.
     Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,


### PR DESCRIPTION
## Summary

GitHub currently reports this repo's license as `Other` / `NOASSERTION`:
```
$ gh api repos/Gradata/gradata --jq .license
{"key":"other","name":"Other","node_id":"MDc6TGljZW5zZTA=","spdx_id":"NOASSERTION","url":null}
```

## Root cause

GitHub detects licenses via `github/linguist`, which delegates to the **licensee** Ruby gem. Licensee requires the `LICENSE` file to match a canonical SPDX template within 0.95 similarity. Our file tanked the match for three reasons:

1. **Two prefix lines before the canonical text** (biggest offender):
   ```
   SPDX-License-Identifier: AGPL-3.0-or-later
   Copyright (C) 2026 Gradata
   ```
2. **CRLF line endings** (file was `ASCII text, with CRLF line terminators`)
3. **Word-wrap deviation** in the boilerplate block near the end (`published by\nthe` vs canonical `published\nby the`)

## Fix

- Replaced `LICENSE` with the exact canonical AGPL-3.0 text from `github/choosealicense.com` (LF endings, no BOM, no prefix, 662 lines).
- Added `.gitattributes` pinning `LICENSE text eol=lf` so Windows `core.autocrlf=true` cannot re-insert CRLF on checkout and break detection again.
- SPDX marker + dual-license preamble + copyright already live in `LICENSE-NOTICE.md`, so the legal notice is preserved.

## Test plan

- [ ] CI green
- [ ] Merge to main
- [ ] Verify `gh api repos/Gradata/gradata --jq .license` returns `{"key":"agpl-3.0","spdx_id":"AGPL-3.0"}`
- [ ] Verify GitHub repo sidebar shows "AGPL-3.0 license"

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>