### PR TITLE
ci: auto-publish PyPI + npm on v*.*.* tags

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,54 @@
+name: Publish npm packages
+
+# Fires only on version tag push (e.g. v0.5.0, v1.2.3).
+# Publishes both the unscoped (gradata-install) and scoped (@gradata/install)
+# variants from the gradata-install/ package via matrix.
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+concurrency:
+  group: publish-npm-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish ${{ matrix.pkg_name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - pkg_name: gradata-install
+          - pkg_name: "@gradata/install"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Verify tag matches package.json version
+        working-directory: gradata-install
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "${TAG_VERSION}" != "${PKG_VERSION}" ]; then
+            echo "::error::Tag v${TAG_VERSION} does not match gradata-install/package.json version ${PKG_VERSION}."
+            exit 1
+          fi
+          echo "Version match: ${PKG_VERSION}"
+
+      - name: Rewrite package name for this matrix entry
+        working-directory: gradata-install
+        run: node -e "const f='package.json',p=require('./'+f);p.name='${{ matrix.pkg_name }}';require('fs').writeFileSync(f,JSON.stringify(p,null,2)+'\n');"
+
+      - name: Publish to npm
+        working-directory: gradata-install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,0 +1,46 @@
+name: Publish Python to PyPI
+
+# Fires only on version tag push (e.g. v0.5.0, v1.2.3).
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+concurrency:
+  group: publish-python-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build and publish gradata to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify tag matches pyproject.toml version
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          PY_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "${TAG_VERSION}" != "${PY_VERSION}" ]; then
+            echo "::error::Tag v${TAG_VERSION} does not match pyproject.toml version ${PY_VERSION}."
+            exit 1
+          fi
+          echo "Version match: ${PY_VERSION}"
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build twine
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload --non-interactive dist/*

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,52 @@
+# Releasing Gradata
+
+Releases are fully automated. Pushing a version tag fires two GitHub Actions
+workflows that publish to PyPI and npm:
+
+- `.github/workflows/publish-python.yml` → PyPI (`gradata`)
+- `.github/workflows/publish-npm.yml` → npm (`gradata-install` and `@gradata/install`)
+
+Both workflows trigger **only** on tags matching `v*.*.*` (e.g. `v0.5.0`).
+They will refuse to publish if the tag does not match the version declared in
+`pyproject.toml` / `gradata-install/package.json`.
+
+## Cut a release
+
+1. Bump versions in lock-step:
+   - `pyproject.toml` → `[project] version = "X.Y.Z"`
+   - `gradata-install/package.json` → `"version": "X.Y.Z"`
+2. Commit, open PR, merge to `main`.
+3. Tag and push:
+   ```bash
+   git checkout main && git pull
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+4. Watch the workflows at **Actions** → *Publish Python to PyPI* and
+   *Publish npm packages*.
+
+If a workflow fails because the tag version does not match the manifest,
+delete the tag (`git tag -d vX.Y.Z && git push origin :refs/tags/vX.Y.Z`),
+fix the manifest, and retag.
+
+## Required secrets
+
+Add at **Settings → Secrets and variables → Actions** on the repository:
+
+| Secret | Used by | Where to get it |
+|--------|---------|-----------------|
+| `PYPI_API_TOKEN` | `publish-python.yml` | https://pypi.org/manage/account/token/ — scope to the `gradata` project |
+| `NPM_TOKEN` | `publish-npm.yml` | https://www.npmjs.com/settings/<user>/tokens — *Automation* token, 2FA-compatible |
+
+No secret value ever appears in a workflow file; the jobs only reference
+`${{ secrets.PYPI_API_TOKEN }}` and `${{ secrets.NPM_TOKEN }}`.
+
+## Rotate tokens
+
+1. Create the replacement token at PyPI or npm (same scope).
+2. In GitHub **Settings → Secrets → Actions**, click the existing secret and
+   *Update* the value. The name stays the same, so no workflow edits needed.
+3. Revoke the old token at PyPI / npm.
+4. Push a throwaway pre-release tag (e.g. `v0.0.0-rc.verify`) on a fork or
+   re-run a prior release workflow to confirm the new token works, then
+   delete the test tag.


### PR DESCRIPTION
GitHub Actions workflows that auto-publish Python SDK to PyPI and npm wrapper to npm on version tag push. Requires PYPI_API_TOKEN + NPM_TOKEN secrets — setup instructions in docs/RELEASING.md.

## What ships
- `.github/workflows/publish-python.yml` — fires on `v*.*.*` tags, builds sdist+wheel via `python -m build`, uploads via `twine` using `PYPI_API_TOKEN`. Refuses to publish if tag version != pyproject.toml version.
- `.github/workflows/publish-npm.yml` — fires on `v*.*.*` tags, matrix publishes `gradata-install` (unscoped) and `@gradata/install` (scoped) from `gradata-install/` using `NPM_TOKEN`. Same version-match guard vs package.json.
- `docs/RELEASING.md` — release cut procedure, required secrets, token rotation.

## Notes
- Task spec mentioned `npm ci` in gradata-install/ — dropped in simplify pass because the package has no dependencies and no lockfile (`npm ci` would fail). Publishing only needs the files listed in package.json's `files` array.
- Workflows use pinned action versions (`@v4`, `@v5`), no secrets in YAML (only `${{ secrets.X }}` references), and are tag-push-only so this PR merge will not trigger a publish.
- Existing `sdk-release.yml` (Trusted Publisher on `v*`) will also fire on the same tag. Both are idempotent on already-published versions, but before the first real release we should decide whether to delete `sdk-release.yml` or keep these as the canonical path.

## Test plan
- [ ] Merge PR — no workflow fires (tag-push only)
- [ ] Add `PYPI_API_TOKEN` and `NPM_TOKEN` at Settings → Secrets → Actions
- [ ] Bump pyproject.toml + gradata-install/package.json to same version
- [ ] `git tag vX.Y.Z && git push origin vX.Y.Z` → verify both workflows go green and packages appear on PyPI / npm