### PR TITLE
chore: contribution governance (DCO, CoC link, PR/issue templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,40 @@
+name: Bug report
+description: Report a defect in Gradata
+title: "[bug]: "
+labels: ["bug"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: One-line description of the bug.
+      placeholder: "brain.correct() raises KeyError on empty final"
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened, what you expected, and why it matters.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Minimal steps (or code snippet) to reproduce the issue.
+      placeholder: |
+        1. `pip install gradata==X.Y.Z`
+        2. Run the snippet below
+        3. Observe the traceback
+      render: bash
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      description: Python version, OS, Gradata version.
+      placeholder: "Python 3.12, macOS 14, gradata 0.5.2"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Propose a new capability or improvement
+title: "[feat]: "
+labels: ["enhancement"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: One-line description of the proposal.
+      placeholder: "Support Ollama as a first-class LLM provider"
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What you want and why. Link prior discussion if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: usecase
+    attributes:
+      label: Use case
+      description: Concrete scenario this unlocks. Who benefits, and how.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds or other approaches you ruled out (optional).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+# Pull Request
+
+## Summary
+
+<!-- One or two sentences: what this PR does and why it matters. -->
+
+## What Changed
+
+<!-- Bullet list of concrete changes. -->
+
+-
+-
+
+## Why
+
+<!-- Motivation, context, or linked discussion. -->
+
+## Test Plan
+
+- [ ] `pytest tests/ -x -q` passes locally
+- [ ] `pyright` / `tsc --noEmit` clean for the touched package
+- [ ] Added or updated tests for changed behavior
+- [ ] Manual verification steps (list below if any)
+
+## Related Issues
+
+<!-- e.g. Closes #123, Refs #456. Leave blank if none. -->
+
+## DCO Sign-off
+
+- [ ] All commits signed off (`git commit -s`). The DCO check must be green before merge.

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,25 @@
+name: DCO
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dco-check:
+    name: Verify Signed-off-by
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR commits
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Check DCO sign-off on every PR commit
+        uses: tim-actions/dco@v1.1.0
+        with:
+          commits: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+Contact: hello@gradata.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,44 +1,59 @@
 # Contributing to Gradata
 
-Thanks for your interest in contributing.
+Thanks for contributing. This guide is short on purpose — read it end to end before your first PR.
 
-## Development Setup
+## Quick Start
 
 ```bash
 git clone https://github.com/Gradata/gradata.git
 cd gradata
 pip install -e ".[dev]"
-pytest tests/
+pytest tests/ -x -q
 ```
 
-## Running Tests
+TypeScript packages (dashboard, marketing, hooks) live under their own directories with `package.json`; `npm install && npm test` inside each.
+
+## Branch Conventions
+
+Branch off `main`. Prefix by intent:
+
+- `feat/` — new capability
+- `fix/` — bug fix
+- `chore/` — tooling, infra, deps
+- `docs/` — documentation only
+
+One concern per PR. Rebase, don't merge, when updating from `main`.
+
+## Licensing
+
+Contributions are licensed under **AGPL-3.0-or-later**. By opening a PR you agree your changes may ship under that license. Dual-license details (including the commercial option) live in [docs/LICENSING.md](docs/LICENSING.md).
+
+## DCO Sign-off (required)
+
+Every commit must carry a `Signed-off-by:` trailer certifying the [Developer Certificate of Origin](https://developercertificate.org/). Use `-s`:
 
 ```bash
-pytest tests/ -x -q          # Full suite
-pytest tests/test_core.py -v  # Specific module
+git commit -s -m "fix: handle empty brain dir"
 ```
+
+The `dco` workflow blocks merges when any commit is missing the trailer. Fix with `git commit --amend -s` (single commit) or `git rebase --signoff main` (multiple).
+
+## PR Checklist
+
+Before requesting review:
+
+- [ ] `pytest tests/ -x -q` passes
+- [ ] `pyright` passes (Python); `tsc --noEmit` and `eslint .` pass (TypeScript)
+- [ ] Docs updated for any public API changes (README, docstrings, `docs/`)
+- [ ] All commits signed off (DCO)
+- [ ] PR description explains **why**, not just what
 
 ## Code Style
 
-- Python 3.11+, type hints required
-- Run `pyright` for type checking (target: zero errors)
-- Keep files under 500 lines
-- No unnecessary abstractions — YAGNI
-
-## Pull Requests
-
-1. Fork the repo and create a branch from `main`
-2. Write tests for new functionality (TDD preferred)
-3. Ensure all tests pass and pyright is clean
-4. Keep PRs focused — one feature or fix per PR
+- **Python**: 3.11+, type hints required. `ruff` for lint and format, `pyright` for types. Keep files under 500 lines.
+- **TypeScript**: strict `tsc`, `eslint` clean. Prefer functions over classes.
+- No unnecessary abstractions. YAGNI.
 
 ## Reporting Issues
 
-Open an issue on [GitHub](https://github.com/Gradata/gradata/issues). Include:
-- What you expected vs what happened
-- Steps to reproduce
-- Python version and OS
-
-## License
-
-By contributing, you agree that your contributions will be licensed under AGPL-3.0.
+Open an issue using one of the [issue templates](.github/ISSUE_TEMPLATE). Include your Python version, OS, and minimal repro.

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ gradata init ./my-brain
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+PRs welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md) for the quick-start, branch conventions, and PR checklist. Every commit must be signed off per the [Developer Certificate of Origin](https://developercertificate.org/) — `git commit -s` — and the DCO workflow enforces this on every PR. We follow the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 


### PR DESCRIPTION
## Summary

Pre-public-contributor hygiene. Adds DCO sign-off gate via `tim-actions/dco@v1.1.0`, links to Contributor Covenant v2.1, PR + issue templates, and a tightened CONTRIBUTING quick-start.

## What changed

- `CONTRIBUTING.md` — rewritten: quick-start, branch conventions (`feat/` `fix/` `chore/` `docs/`), AGPL-3.0 licensing pointer, DCO requirement, PR checklist, Python (ruff/pyright) + TypeScript (tsc/eslint) style
- `CODE_OF_CONDUCT.md` — one-sentence link to Contributor Covenant v2.1 (canonical URL, no pasted text)
- `.github/PULL_REQUEST_TEMPLATE.md` — summary, what/why, test plan checklist, DCO confirmation
- `.github/ISSUE_TEMPLATE/bug_report.yml` + `feature_request.yml` — minimal YAML form templates
- `.github/workflows/dco.yml` — required check; fails if any PR commit is missing `Signed-off-by:`
- `README.md` — Contributing section now references DCO + CoC

## Test plan

- [x] `pytest tests/ -x -q` — 2257 passed, 23 skipped
- [x] Commit on this PR is signed off (DCO check should pass on itself once merged into main)
- [ ] Reviewer confirms `tim-actions/dco@v1.1.0` workflow runs on this PR

No GitHub App install required. Branch protection rule to mark `DCO / Verify Signed-off-by` as required is a follow-up Oliver can flip in repo settings.