### PR TITLE
chore: harden cloud-backup isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,9 @@ design-system/
 .gstack/
 .gitnexus
 .superpowers/
+
+# Hosted-service modules (live in separate private repo Gradata/gradata-cloud)
+gradata_cloud_backup/
+**/gradata_cloud_backup/
+**/*_cloud_backup/
+gradata-cloud-backup/

--- a/src/gradata/enhancements/__init__.py
+++ b/src/gradata/enhancements/__init__.py
@@ -35,7 +35,7 @@ AVAILABLE modules (open source, shipped in SDK):
   router_warmstart     -- Bootstrap Q-Learning router from vault data
   rule_to_hook         -- Deterministic rules auto-generate enforcement hooks
 
-CLOUD-ONLY modules (require gradata_cloud package):
+Hosted-tier modules (available when optional hosted-service is installed):
   agent_graduation     -- Agent/subagent behavioral graduation
 
 PLANNED modules (not yet implemented):

--- a/src/gradata/enhancements/contradiction_detector.py
+++ b/src/gradata/enhancements/contradiction_detector.py
@@ -17,7 +17,7 @@ If contradictions are found with confidence > 0.7, the lesson is flagged
 as PENDING_REVIEW instead of graduating automatically.
 
 OPEN SOURCE: Detection heuristics are open. Embedding-based semantic
-similarity is proprietary cloud-side (medium-term).
+similarity is available as an optional hosted-service enhancement.
 """
 
 from __future__ import annotations

--- a/src/gradata/enhancements/meta_rules.py
+++ b/src/gradata/enhancements/meta_rules.py
@@ -42,8 +42,8 @@ class MetaRule:
       - ``"deterministic"`` (default): produced by token-frequency / cluster
         heuristics. Empirically (2026-04-14 ablation) these regress
         correctness when injected into prompts. Excluded from injection.
-      - ``"llm_synth"``: produced by cloud-side LLM synthesis from the
-        source rules. Eligible for injection.
+      - ``"llm_synth"``: produced by an optional hosted-service LLM
+        synthesis from the source rules. Eligible for injection.
       - ``"human_curated"``: hand-written or human-edited principle. Always
         eligible for injection.
     """

--- a/src/gradata/enhancements/rule_integrity.py
+++ b/src/gradata/enhancements/rule_integrity.py
@@ -12,7 +12,7 @@ Backward compatible: when no secret key is configured (solo use),
 rules pass through unsigned and unverified.
 
 OPEN SOURCE: Signing algorithm is open. Key management and
-multi-tenant signing are proprietary cloud-side.
+multi-tenant signing are optional hosted-service enhancements.
 """
 
 from __future__ import annotations

--- a/src/gradata/enhancements/self_improvement.py
+++ b/src/gradata/enhancements/self_improvement.py
@@ -8,8 +8,8 @@ This is the open-source graduation engine. Corrections become procedural
 memory: confidence scoring, lesson parsing, FSRS-inspired graduation,
 adversarial validation, and formatting.
 
-The proprietary cloud version (gradata_cloud.graduation.self_improvement)
-adds FSRS-based scheduling and multi-brain optimization on top.
+An optional hosted-service enhancement adds FSRS-based scheduling and
+multi-brain optimization on top when available.
 """
 
 from __future__ import annotations

--- a/tests/test_severity_weighting.py
+++ b/tests/test_severity_weighting.py
@@ -5,7 +5,7 @@ Verifies that edit distance severity labels scale confidence
 updates instead of applying flat-rate penalties/bonuses.
 
 Tests work against whichever self_improvement module is available:
-- gradata_cloud.graduation.self_improvement (proprietary, CI)
+- gradata_cloud.graduation.self_improvement (optional hosted tier)
 - gradata.enhancements.self_improvement (packaged engine)
 - gradata._self_improvement stubs (open source, constants only)
 """


### PR DESCRIPTION
Defensive hardening per audit finding (YELLOW):

1. .gitignore now excludes gradata_cloud_backup/ and variants (defense in depth — folder doesn't exist locally but this prevents future accidents)
2. Docstring/comment phrasing softened at 8 sites that referenced 'proprietary cloud-side' modules. Import statements unchanged; behavior identical.

Action still required (Oliver): create private Gradata/gradata-cloud repo as the proper home for the guarded module namespace.