### PR TITLE
feat(events): auto-detect and persist platform_source on correction events

### DIFF
--- a/src/gradata/_events.py
+++ b/src/gradata/_events.py
@@ -72,6 +72,16 @@ def emit(event_type: str, source: str, data: dict | None = None, tags: list | No
     if valid_from is None:
         valid_from = ts
 
+    # Enrich data dict with auto-detected platform source (env-var based).
+    # Keeps public API signatures untouched — callers get this for free.
+    data = dict(data) if data else {}
+    if "platform_source" not in data:
+        try:
+            from gradata._platform import detect_platform_source
+            data["platform_source"] = detect_platform_source()
+        except Exception:
+            data["platform_source"] = "raw-python"
+
     enriched_tags = tags or []
     try:
         from gradata._tag_taxonomy import enrich_tags, validate_tags

--- a/src/gradata/_events.py
+++ b/src/gradata/_events.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 # IMPORTANT: Use module reference (not value import) so set_brain_dir() updates propagate.
 # `from X import Y` copies the value at import time — subsequent set_brain_dir() won't update it.
 import gradata._paths as _p
+from gradata._platform import detect_platform_source
 
 if TYPE_CHECKING:
     from gradata._paths import BrainContext
@@ -74,13 +75,9 @@ def emit(event_type: str, source: str, data: dict | None = None, tags: list | No
 
     # Enrich data dict with auto-detected platform source (env-var based).
     # Keeps public API signatures untouched — callers get this for free.
+    # Always copy so we never mutate the caller's dict in place.
     data = dict(data) if data else {}
-    if "platform_source" not in data:
-        try:
-            from gradata._platform import detect_platform_source
-            data["platform_source"] = detect_platform_source()
-        except Exception:
-            data["platform_source"] = "raw-python"
+    data.setdefault("platform_source", detect_platform_source())
 
     enriched_tags = tags or []
     try:

--- a/src/gradata/_platform.py
+++ b/src/gradata/_platform.py
@@ -1,0 +1,65 @@
+"""Platform source detection.
+
+Auto-detects the runtime platform/IDE that an event originates from so
+downstream analytics can attribute learning signal to its source.
+
+Detection is environment-variable based (cheap, deterministic, no stack
+introspection). Known platforms:
+
+    claude-code   -> CLAUDECODE=1 (set by the Claude Code CLI)
+    cursor        -> CURSOR / CURSOR_TRACE_ID env var
+    windsurf      -> WINDSURF env var
+    openai-sdk    -> OPENAI_API_KEY is set and no IDE env var above
+    anthropic-sdk -> ANTHROPIC_API_KEY is set and no IDE env var above
+    mcp-server    -> GRADATA_MCP_SERVER=1 (set by our MCP entrypoint)
+    raw-python    -> fallback
+
+The detected string is attached to each event's data dict under the
+``platform_source`` key by ``_events.emit``. This does NOT change any
+public API signatures.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Ordered list: first match wins. More specific (IDE/agent surface) before
+# generic SDK presence.
+_PLATFORM_ENV_CHECKS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("claude-code", ("CLAUDECODE", "CLAUDE_CODE")),
+    ("cursor", ("CURSOR", "CURSOR_TRACE_ID")),
+    ("windsurf", ("WINDSURF", "WINDSURF_SESSION_ID")),
+    ("mcp-server", ("GRADATA_MCP_SERVER",)),
+)
+
+# SDK-presence checks run only when no IDE env var above matched.
+_SDK_ENV_CHECKS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("anthropic-sdk", ("ANTHROPIC_API_KEY",)),
+    ("openai-sdk", ("OPENAI_API_KEY",)),
+)
+
+
+def detect_platform_source() -> str:
+    """Return a short platform identifier for the current runtime.
+
+    Pure env-var sniff. Never raises. Safe to call on every event emit.
+    """
+    # Explicit override wins (tests + advanced users).
+    override = os.environ.get("GRADATA_PLATFORM_SOURCE")
+    if override:
+        return override.strip() or "raw-python"
+
+    for label, env_vars in _PLATFORM_ENV_CHECKS:
+        for var in env_vars:
+            if os.environ.get(var):
+                return label
+
+    for label, env_vars in _SDK_ENV_CHECKS:
+        for var in env_vars:
+            if os.environ.get(var):
+                return label
+
+    return "raw-python"
+
+
+__all__ = ["detect_platform_source"]

--- a/src/gradata/_platform.py
+++ b/src/gradata/_platform.py
@@ -9,9 +9,9 @@ introspection). Known platforms:
     claude-code   -> CLAUDECODE=1 (set by the Claude Code CLI)
     cursor        -> CURSOR / CURSOR_TRACE_ID env var
     windsurf      -> WINDSURF env var
-    openai-sdk    -> OPENAI_API_KEY is set and no IDE env var above
-    anthropic-sdk -> ANTHROPIC_API_KEY is set and no IDE env var above
     mcp-server    -> GRADATA_MCP_SERVER=1 (set by our MCP entrypoint)
+    anthropic-sdk -> ANTHROPIC_API_KEY is set and no IDE env var above
+    openai-sdk    -> OPENAI_API_KEY is set and no IDE env var above
     raw-python    -> fallback
 
 The detected string is attached to each event's data dict under the
@@ -23,20 +23,20 @@ from __future__ import annotations
 
 import os
 
-# Ordered list: first match wins. More specific (IDE/agent surface) before
-# generic SDK presence.
+# Ordered: first match wins. IDE / agent surfaces before generic SDK
+# presence so an IDE that also exports an API key still attributes to the
+# IDE.
 _PLATFORM_ENV_CHECKS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("claude-code", ("CLAUDECODE", "CLAUDE_CODE")),
     ("cursor", ("CURSOR", "CURSOR_TRACE_ID")),
     ("windsurf", ("WINDSURF", "WINDSURF_SESSION_ID")),
     ("mcp-server", ("GRADATA_MCP_SERVER",)),
-)
-
-# SDK-presence checks run only when no IDE env var above matched.
-_SDK_ENV_CHECKS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("anthropic-sdk", ("ANTHROPIC_API_KEY",)),
     ("openai-sdk", ("OPENAI_API_KEY",)),
 )
+
+_OVERRIDE_ENV: str = "GRADATA_PLATFORM_SOURCE"
+_FALLBACK: str = "raw-python"
 
 
 def detect_platform_source() -> str:
@@ -45,21 +45,15 @@ def detect_platform_source() -> str:
     Pure env-var sniff. Never raises. Safe to call on every event emit.
     """
     # Explicit override wins (tests + advanced users).
-    override = os.environ.get("GRADATA_PLATFORM_SOURCE")
+    override = os.environ.get(_OVERRIDE_ENV, "").strip()
     if override:
-        return override.strip() or "raw-python"
+        return override
 
     for label, env_vars in _PLATFORM_ENV_CHECKS:
-        for var in env_vars:
-            if os.environ.get(var):
-                return label
+        if any(os.environ.get(var) for var in env_vars):
+            return label
 
-    for label, env_vars in _SDK_ENV_CHECKS:
-        for var in env_vars:
-            if os.environ.get(var):
-                return label
-
-    return "raw-python"
+    return _FALLBACK
 
 
 __all__ = ["detect_platform_source"]

--- a/tests/test_platform_source.py
+++ b/tests/test_platform_source.py
@@ -1,0 +1,150 @@
+"""Tests for platform source auto-detection and event enrichment.
+
+Verifies:
+- `detect_platform_source()` returns expected labels for each env combo.
+- `_events.emit()` attaches the detected tag to every event's data dict.
+- Explicit override via GRADATA_PLATFORM_SOURCE is respected.
+- Enrichment does not collide with future `applies_to`-style scope metadata
+  that PR #57 will add on top of the same `data` dict.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gradata._platform import detect_platform_source
+
+# ---------------------------------------------------------------------------
+# detect_platform_source — unit tests via env monkeypatch
+# ---------------------------------------------------------------------------
+
+# Every platform-signalling env var we know about. Cleared before each test so
+# the ambient CI/dev environment doesn't contaminate results.
+_ALL_PLATFORM_ENV_VARS = (
+    "GRADATA_PLATFORM_SOURCE",
+    "CLAUDECODE",
+    "CLAUDE_CODE",
+    "CURSOR",
+    "CURSOR_TRACE_ID",
+    "WINDSURF",
+    "WINDSURF_SESSION_ID",
+    "GRADATA_MCP_SERVER",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_platform_env(monkeypatch):
+    for var in _ALL_PLATFORM_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+def test_default_fallback_is_raw_python():
+    assert detect_platform_source() == "raw-python"
+
+
+def test_claude_code_detected(monkeypatch):
+    monkeypatch.setenv("CLAUDECODE", "1")
+    assert detect_platform_source() == "claude-code"
+
+
+def test_cursor_detected(monkeypatch):
+    monkeypatch.setenv("CURSOR_TRACE_ID", "abc")
+    assert detect_platform_source() == "cursor"
+
+
+def test_windsurf_detected(monkeypatch):
+    monkeypatch.setenv("WINDSURF", "1")
+    assert detect_platform_source() == "windsurf"
+
+
+def test_mcp_server_detected(monkeypatch):
+    monkeypatch.setenv("GRADATA_MCP_SERVER", "1")
+    assert detect_platform_source() == "mcp-server"
+
+
+def test_anthropic_sdk_detected_when_no_ide(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    assert detect_platform_source() == "anthropic-sdk"
+
+
+def test_openai_sdk_detected_when_no_ide(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    assert detect_platform_source() == "openai-sdk"
+
+
+def test_ide_beats_sdk(monkeypatch):
+    """If CLAUDECODE and ANTHROPIC_API_KEY are both set, CLAUDECODE wins."""
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    assert detect_platform_source() == "claude-code"
+
+
+def test_explicit_override_wins(monkeypatch):
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("GRADATA_PLATFORM_SOURCE", "my-custom-host")
+    assert detect_platform_source() == "my-custom-host"
+
+
+def test_empty_override_falls_back(monkeypatch):
+    monkeypatch.setenv("GRADATA_PLATFORM_SOURCE", "   ")
+    assert detect_platform_source() == "raw-python"
+
+
+# ---------------------------------------------------------------------------
+# _events.emit — integration: platform_source rides along on the data dict
+# ---------------------------------------------------------------------------
+
+
+def test_emit_attaches_platform_source(fresh_brain, monkeypatch):
+    monkeypatch.setenv("CLAUDECODE", "1")
+    event = fresh_brain.emit("TEST_EVENT", "pytest", data={"foo": "bar"})
+    assert event["data"]["platform_source"] == "claude-code"
+    assert event["data"]["foo"] == "bar"  # caller data preserved
+
+
+def test_emit_attaches_platform_source_when_data_none(fresh_brain, monkeypatch):
+    monkeypatch.setenv("CURSOR", "1")
+    event = fresh_brain.emit("TEST_EVENT", "pytest")
+    assert event["data"]["platform_source"] == "cursor"
+
+
+def test_emit_caller_can_override_platform_source(fresh_brain, monkeypatch):
+    """Callers (e.g. replay / backfill tools) can set platform_source explicitly."""
+    monkeypatch.setenv("CLAUDECODE", "1")
+    event = fresh_brain.emit(
+        "TEST_EVENT", "pytest", data={"platform_source": "backfill"},
+    )
+    assert event["data"]["platform_source"] == "backfill"
+
+
+def test_emit_platform_source_is_raw_python_when_no_env(fresh_brain):
+    # Autouse fixture already stripped platform env vars.
+    event = fresh_brain.emit("TEST_EVENT", "pytest")
+    assert event["data"]["platform_source"] == "raw-python"
+
+
+def test_does_not_mutate_caller_data_dict(fresh_brain, monkeypatch):
+    """emit() must not add platform_source to the caller's dict in place."""
+    monkeypatch.setenv("CLAUDECODE", "1")
+    caller_data = {"foo": "bar"}
+    fresh_brain.emit("TEST_EVENT", "pytest", data=caller_data)
+    assert "platform_source" not in caller_data, "emit mutated caller's dict"
+
+
+def test_platform_source_coexists_with_scope_metadata(fresh_brain, monkeypatch):
+    """Simulates PR #57's applies_to riding on the same data dict.
+
+    Platform enrichment must not stomp on arbitrary scope/binding tokens a
+    caller has already attached (e.g. scope-tagging work).
+    """
+    monkeypatch.setenv("CLAUDECODE", "1")
+    event = fresh_brain.emit(
+        "CORRECTION", "brain.correct",
+        data={"applies_to": "scope:feature-xyz", "severity": "minor"},
+    )
+    assert event["data"]["platform_source"] == "claude-code"
+    assert event["data"]["applies_to"] == "scope:feature-xyz"
+    assert event["data"]["severity"] == "minor"


### PR DESCRIPTION
## Summary
Auto-detects the platform each correction came from (claude-code / cursor / windsurf / mcp-server / anthropic-sdk / openai-sdk / raw-python) via env-var sniff. Attaches `platform_source` to event data at `emit()` time. No signature changes to `correct()`.

## Files
- `src/gradata/_platform.py` (new) — `detect_platform_source()` with `GRADATA_PLATFORM_SOURCE` override
- `src/gradata/_events.py` — 1-line `data.setdefault("platform_source", detect_platform_source())` at emit
- `tests/test_platform_source.py` — 16 round-trip tests

## Tests
2273 pass (+16), ruff clean. Composes cleanly with `applies_to` from PR #57 (explicit test).

## Commits
- `a9021b7` feat(events): auto-detect and persist platform_source
- `737aa2b` refactor(platform): hoist detector import, collapse env tables, kill dead except

Co-Authored-By: Gradata <noreply@gradata.ai>