### PR TITLE
feat(dedup): fingerprint-based observation dedup with seen_count persistence

### DIFF
--- a/src/gradata/_core.py
+++ b/src/gradata/_core.py
@@ -192,31 +192,14 @@ def brain_correct(
         _log.warning("Pattern extraction failed: %s", e)
 
     # Observation dedup — suppress near-identical corrections inside a recent
-    # session window so 10 copies of the same correction don't inflate
-    # fire_count / confidence 10x. Default semantic: DROP within window.
+    # session window so repeat corrections don't inflate fire_count/confidence.
     # See gradata/enhancements/dedup.py for MERGE-vs-DROP policy notes.
-    is_observation_dup = False
-    try:
-        from gradata.enhancements.dedup import check_and_register
-        dedup_cat = (category or "UNKNOWN")
-        # Fingerprint on the (draft, final) pair so truly-identical
-        # corrections dedup but genuinely distinct corrections (even with
-        # the same summary/category) do NOT. This preserves graduation
-        # evidence while blocking confidence inflation from N-time repeats
-        # of the same correction.
-        dedup_text = f"{draft_redacted[:500]}||{final_redacted[:500]}"
-        if dedup_text:
-            dedup_info = check_and_register(
-                brain.db_path, dedup_text,
-                category=dedup_cat, session=session,
-            )
-            event["observation_fingerprint"] = dedup_info["fingerprint"]
-            event["observation_seen_count"] = dedup_info["seen_count"]
-            if dedup_info["is_duplicate"]:
-                is_observation_dup = True
-                event["observation_deduped"] = True
-    except Exception as e:
-        _log.debug("Observation dedup failed: %s", e)
+    from gradata.enhancements.dedup import annotate_event_with_dedup
+    is_observation_dup = annotate_event_with_dedup(
+        event, brain.db_path,
+        draft=draft_redacted, final=final_redacted,
+        category=category, session=session,
+    )
 
     # Close the loop: correction → lesson
     desc = ""  # Will be set if severity threshold is met

--- a/src/gradata/_core.py
+++ b/src/gradata/_core.py
@@ -191,6 +191,33 @@ def brain_correct(
     except Exception as e:
         _log.warning("Pattern extraction failed: %s", e)
 
+    # Observation dedup — suppress near-identical corrections inside a recent
+    # session window so 10 copies of the same correction don't inflate
+    # fire_count / confidence 10x. Default semantic: DROP within window.
+    # See gradata/enhancements/dedup.py for MERGE-vs-DROP policy notes.
+    is_observation_dup = False
+    try:
+        from gradata.enhancements.dedup import check_and_register
+        dedup_cat = (category or "UNKNOWN")
+        # Fingerprint on the (draft, final) pair so truly-identical
+        # corrections dedup but genuinely distinct corrections (even with
+        # the same summary/category) do NOT. This preserves graduation
+        # evidence while blocking confidence inflation from N-time repeats
+        # of the same correction.
+        dedup_text = f"{draft_redacted[:500]}||{final_redacted[:500]}"
+        if dedup_text:
+            dedup_info = check_and_register(
+                brain.db_path, dedup_text,
+                category=dedup_cat, session=session,
+            )
+            event["observation_fingerprint"] = dedup_info["fingerprint"]
+            event["observation_seen_count"] = dedup_info["seen_count"]
+            if dedup_info["is_duplicate"]:
+                is_observation_dup = True
+                event["observation_deduped"] = True
+    except Exception as e:
+        _log.debug("Observation dedup failed: %s", e)
+
     # Close the loop: correction → lesson
     desc = ""  # Will be set if severity threshold is met
     try:
@@ -204,7 +231,7 @@ def brain_correct(
             update_confidence,
         )
 
-        if _SEV_RANK.get(diff.severity, 0) >= _SEV_RANK.get(min_severity, 0):
+        if not is_observation_dup and _SEV_RANK.get(diff.severity, 0) >= _SEV_RANK.get(min_severity, 0):
             lessons_path = brain._find_lessons_path(create=True)
             if lessons_path:
                 existing_text = ""

--- a/src/gradata/enhancements/dedup.py
+++ b/src/gradata/enhancements/dedup.py
@@ -66,10 +66,15 @@ and cheap enough to compute on every ingestion.
 from __future__ import annotations
 
 import hashlib
+import logging
 import re
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
+
+from gradata._db import ensure_table, get_connection
+
+_log = logging.getLogger(__name__)
 
 _WS_RE = re.compile(r"\s+")
 _TRAILING_PUNCT_RE = re.compile(r"[.,;:!?]+$")
@@ -101,10 +106,8 @@ def _normalize_text(text: str) -> str:
     """
     if not text:
         return ""
-    s = text.strip().lower()
-    s = _WS_RE.sub(" ", s)
-    s = _TRAILING_PUNCT_RE.sub("", s)
-    return s.strip()
+    s = _WS_RE.sub(" ", text.strip().lower())
+    return _TRAILING_PUNCT_RE.sub("", s).strip()
 
 
 def _normalize_category(category: str | None) -> str:
@@ -120,23 +123,16 @@ def observation_fingerprint(text: str, category: str | None = None) -> str:
     design, since the same phrase can mean different things in different
     categories.
     """
-    norm_cat = _normalize_category(category)
-    norm_text = _normalize_text(text)
-    payload = f"{norm_cat}|{norm_text}".encode()
+    payload = f"{_normalize_category(category)}|{_normalize_text(text)}".encode()
     return hashlib.sha1(payload).hexdigest()
 
 
-def _ensure_table(conn: sqlite3.Connection) -> None:
-    conn.execute(_CREATE_SQL)
+def _open(db_path: str | Path) -> sqlite3.Connection:
+    """Open a connection with schema ensured. Caller owns the connection."""
+    conn = get_connection(db_path)
+    ensure_table(conn, _CREATE_SQL)
     conn.execute(_CREATE_IDX_LAST_SESSION)
     conn.commit()
-
-
-def _open(db_path: str | Path) -> sqlite3.Connection:
-    """Open a connection with table ensured. Caller owns the connection."""
-    conn = sqlite3.connect(str(db_path))
-    conn.execute("PRAGMA busy_timeout=5000")
-    _ensure_table(conn)
     return conn
 
 
@@ -263,7 +259,46 @@ def check_and_register(
     }
 
 
+def annotate_event_with_dedup(
+    event: dict,
+    db_path: str | Path,
+    *,
+    draft: str,
+    final: str,
+    category: str | None,
+    session: int | None,
+) -> bool:
+    """Single-seam ingestion hook used by `brain_correct`.
+
+    Fingerprints on the (draft, final) pair (first 500 chars each) so truly
+    identical corrections dedup but genuinely distinct ones do NOT. Mutates
+    ``event`` in place to add ``observation_fingerprint`` and
+    ``observation_seen_count``, plus ``observation_deduped`` when a hit is
+    inside the recent-session window.
+
+    Returns True if the observation was a duplicate (caller should skip the
+    lesson create/reinforce branch). Any error is swallowed and returns False
+    so dedup cannot break the ingestion path.
+    """
+    try:
+        dedup_text = f"{(draft or '')[:500]}||{(final or '')[:500]}"
+        info = check_and_register(
+            db_path, dedup_text,
+            category=(category or "UNKNOWN"), session=session,
+        )
+        event["observation_fingerprint"] = info["fingerprint"]
+        event["observation_seen_count"] = info["seen_count"]
+        if info["is_duplicate"]:
+            event["observation_deduped"] = True
+            return True
+        return False
+    except Exception as e:
+        _log.debug("Observation dedup failed: %s", e)
+        return False
+
+
 __all__ = [
+    "annotate_event_with_dedup",
     "check_and_register",
     "is_duplicate",
     "observation_fingerprint",

--- a/src/gradata/enhancements/dedup.py
+++ b/src/gradata/enhancements/dedup.py
@@ -1,0 +1,271 @@
+"""
+Observation Dedup — fingerprint-based near-duplicate suppression.
+================================================================
+SDK LAYER: Layer 1 (enhancements). Stdlib only.
+
+Problem
+-------
+Ten sessions that all contain "don't use em-dashes" should NOT produce ten
+lesson reinforcements and inflate confidence 10x. Each (category, normalized
+text) pair is the same **observation** and must be deduped before it flows
+into the fire_count / confidence pipeline.
+
+Public API
+----------
+    from gradata.enhancements.dedup import (
+        observation_fingerprint,
+        is_duplicate,
+        register_observation,
+    )
+
+    fp = observation_fingerprint("Don't use em-dashes.", category="FORMAT")
+    if is_duplicate(db_path, fp, recent_window_sessions=10):
+        # suppress — already seen in recent window
+        ...
+    else:
+        register_observation(db_path, fp, session=42)
+
+Semantics
+---------
+Default = **DROP** within the recent-session window. `seen_count` is tracked
+on the persisted row so MERGE semantics (bump fire_count by seen_count at
+window rollover) can be wired in later without losing evidence.
+
+MERGE vs DROP is a policy decision flagged for polyclaude — see the task brief
+for wt-observation-dedup. The current codebase cannot wire seen_count into
+`update_confidence` without editing `self_improvement.py`, which is off-limits
+for this worktree.
+
+Storage
+-------
+A single table in system.db:
+
+    observation_dedup(
+        fingerprint TEXT PRIMARY KEY,
+        category    TEXT NOT NULL,
+        first_session INTEGER NOT NULL,
+        last_session  INTEGER NOT NULL,
+        seen_count    INTEGER NOT NULL DEFAULT 1,
+        first_seen_ts TEXT NOT NULL,
+        last_seen_ts  TEXT NOT NULL
+    )
+
+Normalization
+-------------
+- lowercase
+- strip leading/trailing whitespace
+- collapse internal whitespace to a single space
+- drop trailing punctuation (. , ; : ! ?)
+- category is uppercased and prefixed to the hash input so the same phrasing
+  under different categories is NOT deduped together.
+
+Hash: sha1 of ``f"{CATEGORY}|{normalized_text}"`` — stable across processes
+and cheap enough to compute on every ingestion.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+_WS_RE = re.compile(r"\s+")
+_TRAILING_PUNCT_RE = re.compile(r"[.,;:!?]+$")
+
+_DEFAULT_WINDOW_SESSIONS = 10
+
+_CREATE_SQL = """
+CREATE TABLE IF NOT EXISTS observation_dedup (
+    fingerprint    TEXT PRIMARY KEY,
+    category       TEXT NOT NULL,
+    first_session  INTEGER NOT NULL,
+    last_session   INTEGER NOT NULL,
+    seen_count     INTEGER NOT NULL DEFAULT 1,
+    first_seen_ts  TEXT NOT NULL,
+    last_seen_ts   TEXT NOT NULL
+)
+"""
+
+_CREATE_IDX_LAST_SESSION = (
+    "CREATE INDEX IF NOT EXISTS idx_observation_dedup_last_session "
+    "ON observation_dedup(last_session)"
+)
+
+
+def _normalize_text(text: str) -> str:
+    """Canonical form used for fingerprinting.
+
+    Lowercase, trim, collapse whitespace, drop trailing punctuation.
+    """
+    if not text:
+        return ""
+    s = text.strip().lower()
+    s = _WS_RE.sub(" ", s)
+    s = _TRAILING_PUNCT_RE.sub("", s)
+    return s.strip()
+
+
+def _normalize_category(category: str | None) -> str:
+    return (category or "UNKNOWN").strip().upper() or "UNKNOWN"
+
+
+def observation_fingerprint(text: str, category: str | None = None) -> str:
+    """Return a stable sha1 fingerprint for (category, normalized text).
+
+    Two near-identical corrections (differing only in case, trailing
+    punctuation, or whitespace) produce the same fingerprint. Different
+    categories for the same text produce **different** fingerprints — by
+    design, since the same phrase can mean different things in different
+    categories.
+    """
+    norm_cat = _normalize_category(category)
+    norm_text = _normalize_text(text)
+    payload = f"{norm_cat}|{norm_text}".encode()
+    return hashlib.sha1(payload).hexdigest()
+
+
+def _ensure_table(conn: sqlite3.Connection) -> None:
+    conn.execute(_CREATE_SQL)
+    conn.execute(_CREATE_IDX_LAST_SESSION)
+    conn.commit()
+
+
+def _open(db_path: str | Path) -> sqlite3.Connection:
+    """Open a connection with table ensured. Caller owns the connection."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA busy_timeout=5000")
+    _ensure_table(conn)
+    return conn
+
+
+def is_duplicate(
+    db_path: str | Path,
+    fingerprint: str,
+    *,
+    current_session: int | None = None,
+    recent_window_sessions: int = _DEFAULT_WINDOW_SESSIONS,
+) -> bool:
+    """Return True if this fingerprint was seen inside the recent session window.
+
+    Window definition: the row's ``last_session`` is within
+    ``recent_window_sessions`` of ``current_session``. If no row exists for
+    this fingerprint, it's not a duplicate.
+
+    Edge cases:
+    - current_session=None => dedup against any prior sighting (window is
+      effectively open-ended). This is the safe default for non-session
+      callers.
+    - recent_window_sessions<=0 => same as None; any prior sighting counts.
+    """
+    conn = _open(db_path)
+    try:
+        row = conn.execute(
+            "SELECT last_session FROM observation_dedup WHERE fingerprint = ?",
+            (fingerprint,),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        return False
+    last_session = row[0]
+    if current_session is None or recent_window_sessions <= 0:
+        return True
+    # Window: inclusive lower bound at (current_session - window + 1)
+    return last_session >= current_session - recent_window_sessions + 1
+
+
+def register_observation(
+    db_path: str | Path,
+    fingerprint: str,
+    *,
+    category: str | None = None,
+    session: int | None = None,
+) -> dict:
+    """Record a sighting of ``fingerprint``. Returns a dict describing the outcome.
+
+    - If the fingerprint is new: inserts a row with seen_count=1.
+    - If already present: increments seen_count and updates last_session /
+      last_seen_ts.
+
+    Returns
+    -------
+    {"new": True/False, "seen_count": int, "fingerprint": str}
+    """
+    sess = int(session) if session is not None else 0
+    norm_cat = _normalize_category(category)
+    now = datetime.now(UTC).isoformat()
+
+    conn = _open(db_path)
+    try:
+        existing = conn.execute(
+            "SELECT seen_count, first_session FROM observation_dedup "
+            "WHERE fingerprint = ?",
+            (fingerprint,),
+        ).fetchone()
+        if existing is None:
+            conn.execute(
+                "INSERT INTO observation_dedup "
+                "(fingerprint, category, first_session, last_session, "
+                " seen_count, first_seen_ts, last_seen_ts) "
+                "VALUES (?, ?, ?, ?, 1, ?, ?)",
+                (fingerprint, norm_cat, sess, sess, now, now),
+            )
+            conn.commit()
+            return {"new": True, "seen_count": 1, "fingerprint": fingerprint}
+        new_count = int(existing[0]) + 1
+        conn.execute(
+            "UPDATE observation_dedup "
+            "SET seen_count = ?, last_session = ?, last_seen_ts = ? "
+            "WHERE fingerprint = ?",
+            (new_count, sess, now, fingerprint),
+        )
+        conn.commit()
+        return {"new": False, "seen_count": new_count, "fingerprint": fingerprint}
+    finally:
+        conn.close()
+
+
+def check_and_register(
+    db_path: str | Path,
+    text: str,
+    *,
+    category: str | None = None,
+    session: int | None = None,
+    recent_window_sessions: int = _DEFAULT_WINDOW_SESSIONS,
+) -> dict:
+    """Convenience: fingerprint + duplicate-check + register in one call.
+
+    This is the single hook point intended for the ingestion path.
+
+    Returns
+    -------
+    {
+        "fingerprint": str,
+        "is_duplicate": bool,     # was this a dup BEFORE this registration?
+        "seen_count": int,        # seen_count AFTER this registration
+        "new": bool,              # was this the first sighting ever?
+    }
+    """
+    fp = observation_fingerprint(text, category=category)
+    dup = is_duplicate(
+        db_path, fp,
+        current_session=session,
+        recent_window_sessions=recent_window_sessions,
+    )
+    reg = register_observation(db_path, fp, category=category, session=session)
+    return {
+        "fingerprint": fp,
+        "is_duplicate": dup,
+        "seen_count": reg["seen_count"],
+        "new": reg["new"],
+    }
+
+
+__all__ = [
+    "check_and_register",
+    "is_duplicate",
+    "observation_fingerprint",
+    "register_observation",
+]

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1,0 +1,205 @@
+"""Tests for observation dedup (gradata.enhancements.dedup).
+
+Covers:
+- Fingerprint stability and normalization
+- Category-awareness (same text, different category => different fp)
+- is_duplicate / register_observation round-trip
+- Window boundary behavior
+- check_and_register convenience
+- End-to-end: brain.correct() does NOT inflate fire_count / lesson count
+  when the same correction is submitted repeatedly in-window.
+"""
+from __future__ import annotations
+
+import pytest
+
+from gradata.enhancements.dedup import (
+    check_and_register,
+    is_duplicate,
+    observation_fingerprint,
+    register_observation,
+)
+
+# ---------------------------------------------------------------------------
+# Fingerprint
+# ---------------------------------------------------------------------------
+
+def test_fingerprint_is_stable():
+    fp1 = observation_fingerprint("Don't use em-dashes.", category="FORMAT")
+    fp2 = observation_fingerprint("Don't use em-dashes.", category="FORMAT")
+    assert fp1 == fp2
+    assert len(fp1) == 40  # sha1 hex
+
+
+def test_fingerprint_normalizes_case_whitespace_punct():
+    # case + trailing punct + extra whitespace all normalize together
+    fp1 = observation_fingerprint("Don't use em-dashes.", category="FORMAT")
+    fp2 = observation_fingerprint("  DON'T  USE  EM-DASHES!!  ", category="format")
+    fp3 = observation_fingerprint("don't use em-dashes", category="Format")
+    assert fp1 == fp2 == fp3
+
+
+def test_fingerprint_category_aware():
+    # Same text in different categories is NOT the same observation
+    fp_format = observation_fingerprint("be more specific", category="FORMAT")
+    fp_tone = observation_fingerprint("be more specific", category="TONE")
+    assert fp_format != fp_tone
+
+
+def test_fingerprint_text_differences_break_match():
+    # Genuinely different corrections must fingerprint differently
+    fp1 = observation_fingerprint("Don't use em-dashes.", category="FORMAT")
+    fp2 = observation_fingerprint("Always use bullet lists.", category="FORMAT")
+    assert fp1 != fp2
+
+
+# ---------------------------------------------------------------------------
+# Register / is_duplicate
+# ---------------------------------------------------------------------------
+
+def test_first_sighting_is_not_duplicate(tmp_path):
+    db = tmp_path / "dedup.db"
+    fp = observation_fingerprint("skip em dashes", category="FORMAT")
+    assert is_duplicate(db, fp, current_session=1) is False
+    result = register_observation(db, fp, category="FORMAT", session=1)
+    assert result["new"] is True
+    assert result["seen_count"] == 1
+
+
+def test_second_sighting_same_session_is_duplicate(tmp_path):
+    db = tmp_path / "dedup.db"
+    fp = observation_fingerprint("skip em dashes", category="FORMAT")
+    register_observation(db, fp, category="FORMAT", session=5)
+    # Second time: already in DB, same session => within window
+    assert is_duplicate(db, fp, current_session=5, recent_window_sessions=10) is True
+    result = register_observation(db, fp, category="FORMAT", session=5)
+    assert result["new"] is False
+    assert result["seen_count"] == 2
+
+
+def test_window_boundary_outside_window_is_not_duplicate(tmp_path):
+    db = tmp_path / "dedup.db"
+    fp = observation_fingerprint("skip em dashes", category="FORMAT")
+    # Register at session 1
+    register_observation(db, fp, category="FORMAT", session=1)
+    # Current session 20, window 10 => oldest-in-window is session 11.
+    # Last sighting at session 1 is OUTSIDE the window.
+    assert is_duplicate(db, fp, current_session=20, recent_window_sessions=10) is False
+
+
+def test_window_boundary_inside_window_is_duplicate(tmp_path):
+    db = tmp_path / "dedup.db"
+    fp = observation_fingerprint("skip em dashes", category="FORMAT")
+    register_observation(db, fp, category="FORMAT", session=12)
+    # Current session 20, window 10 => oldest-in-window session 11.
+    # Last sighting at session 12 is INSIDE the window.
+    assert is_duplicate(db, fp, current_session=20, recent_window_sessions=10) is True
+
+
+def test_window_exact_edge_is_duplicate(tmp_path):
+    db = tmp_path / "dedup.db"
+    fp = observation_fingerprint("skip em dashes", category="FORMAT")
+    register_observation(db, fp, category="FORMAT", session=11)
+    # current=20, window=10 => oldest-in-window is 11. sighting at 11 => inside
+    assert is_duplicate(db, fp, current_session=20, recent_window_sessions=10) is True
+
+
+def test_different_text_is_not_duplicate(tmp_path):
+    db = tmp_path / "dedup.db"
+    fp1 = observation_fingerprint("skip em dashes", category="FORMAT")
+    fp2 = observation_fingerprint("use bullet lists", category="FORMAT")
+    register_observation(db, fp1, category="FORMAT", session=1)
+    assert is_duplicate(db, fp2, current_session=1) is False
+
+
+def test_register_persists_seen_count(tmp_path):
+    db = tmp_path / "dedup.db"
+    fp = observation_fingerprint("skip em dashes", category="FORMAT")
+    for i in range(5):
+        register_observation(db, fp, category="FORMAT", session=i + 1)
+    # One logical observation, five sightings
+    import sqlite3
+    with sqlite3.connect(str(db)) as conn:
+        rows = list(
+            conn.execute("SELECT fingerprint, seen_count FROM observation_dedup")
+        )
+    assert len(rows) == 1
+    assert rows[0][0] == fp
+    assert rows[0][1] == 5
+
+
+def test_check_and_register_roundtrip(tmp_path):
+    db = tmp_path / "dedup.db"
+    first = check_and_register(
+        db, "Don't use em-dashes.", category="FORMAT", session=1,
+        recent_window_sessions=10,
+    )
+    assert first["is_duplicate"] is False
+    assert first["new"] is True
+    assert first["seen_count"] == 1
+
+    second = check_and_register(
+        db, "  DON'T  USE  EM-DASHES!!  ", category="format", session=2,
+        recent_window_sessions=10,
+    )
+    assert second["is_duplicate"] is True  # was already present before this register
+    assert second["new"] is False
+    assert second["seen_count"] == 2
+    assert second["fingerprint"] == first["fingerprint"]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via Brain.correct — the real-world harm we're preventing
+# ---------------------------------------------------------------------------
+
+def test_brain_correct_suppresses_duplicate_lesson_reinforcement(fresh_brain):
+    """Same correction applied 10 times must not inflate fire_count 10x."""
+    brain = fresh_brain
+
+    draft = "We can definitely maybe perhaps hit those KPIs — probably."
+    final = "We will hit those KPIs."
+
+    # First correction: creates a new lesson
+    result = brain.correct(draft, final, category="DRAFTING", session=1)
+    assert result.get("observation_deduped") is not True
+
+    # Nine more identical corrections, same session => all should dedup
+    dedup_hits = 0
+    for _ in range(9):
+        r = brain.correct(draft, final, category="DRAFTING", session=1)
+        if r.get("observation_deduped"):
+            dedup_hits += 1
+
+    assert dedup_hits == 9, (
+        f"Expected 9 dedup hits, got {dedup_hits}. "
+        "Dedup must suppress in-window duplicates."
+    )
+
+    # Lesson fire_count must NOT have been inflated by 10
+    final_lessons = brain._load_lessons() if hasattr(brain, "_load_lessons") else []
+    drafting_lessons = [l for l in final_lessons if l.category == "DRAFTING"]
+    assert len(drafting_lessons) >= 1
+    # fire_count should reflect the single non-dedup correction, not 10
+    for l in drafting_lessons:
+        assert l.fire_count <= 2, (
+            f"fire_count={l.fire_count} for lesson {l.description!r}. "
+            "Dedup should have prevented inflation."
+        )
+
+
+def test_brain_correct_annotates_fingerprint_and_seen_count(fresh_brain):
+    brain = fresh_brain
+    result = brain.correct(
+        "maybe we will maybe hit KPIs",
+        "We will hit KPIs.",
+        category="DRAFTING",
+        session=1,
+    )
+    assert "observation_fingerprint" in result
+    assert isinstance(result["observation_fingerprint"], str)
+    assert len(result["observation_fingerprint"]) == 40
+    assert result.get("observation_seen_count") == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
Dedupes near-identical correction observations within a rolling window so repeated corrections don't inflate confidence N-fold. **Policy: DROP** (not MERGE), validated via 5-perspective polyclaude council (unanimous HIGH). `seen_count` is persisted either way so the policy is reversible via a backfill worker.

## Council verdict (observation-dedup council, 2026-04-15)
Unanimous DROP across SRE, Statistician, Red-Team, Product/UX, Pipeline-Architect:
- Repeated identical corrections violate IID, inflate confidence under any principled update
- MERGE reopens the gap #10 sybil vector
- User repetition = frustration, not endorsement
- DROP lets aeb38fc0 + gap #5 rebuild land against a clean baseline

## Files
- `src/gradata/enhancements/dedup.py` (new) — fingerprint, `is_duplicate`, `register_observation`, `annotate_event_with_dedup`
- `src/gradata/_core.py` — single 7-line hook at the ingestion seam
- `tests/test_dedup.py` — 14 tests

## Tests
2271 pass (+14), ruff clean.

## Commits
- `771cf66` feat(dedup): fingerprint-based observation dedup
- `8ca5457` refactor(dedup): extract hook helper, reuse `_db.get_connection`

## Follow-up flagged
- `observation_dedup` DDL should move to `_migrations._BASE_TABLES` once this worktree's NO-TOUCH list expires

Co-Authored-By: Gradata <noreply@gradata.ai>