### PR TITLE
feat(jit): per-call rule injection hook with draft-relevance ranking

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -22,6 +22,16 @@
             "timeout": 8000
           }
         ]
+      },
+      {
+        "description": "Gradata: JIT rule injection scored against this draft (opt-in via GRADATA_JIT_ENABLED=1)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python -m gradata.hooks.jit_inject",
+            "timeout": 5000
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/src/gradata/hooks/jit_inject.py
+++ b/src/gradata/hooks/jit_inject.py
@@ -1,0 +1,227 @@
+"""UserPromptSubmit hook: just-in-time (JIT) rule injection.
+
+Session-start injection (`inject_brain_rules.py`) picks the top-N rules once
+for the whole session. JIT flips the axis: on every user prompt we score
+each graduated rule against the draft text and inject only the top-k that
+match THIS draft. Many-shot literature (Agarwal 2024) shows monotonic gains
+to ~1000 shots; context budgets cap us at 10-20 rules. JIT spends that
+budget on the most relevant rules per call instead of globally.
+
+Gated by env var ``GRADATA_JIT_ENABLED`` (default false) so the existing
+SessionStart behavior is untouched for anyone who hasn't opted in. When
+both are active they complement: SessionStart = broad priors, JIT = tight
+per-prompt overlay.
+
+Similarity is a cheap Jaccard on word unigrams: no embeddings dependency,
+deterministic, under 1 ms per rule for the rule-tier volumes we see in
+practice (~100s of graduated rules max). Cosine on embeddings is a future
+upgrade once the rule-wiki embedding pipeline lands.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+from pathlib import Path
+
+from gradata.hooks._base import extract_message, resolve_brain_dir, run_hook
+from gradata.hooks._profiles import Profile
+
+try:
+    from gradata.enhancements.self_improvement import parse_lessons
+except ImportError:
+    parse_lessons = None  # type: ignore[assignment]
+
+_log = logging.getLogger(__name__)
+
+HOOK_META = {
+    "event": "UserPromptSubmit",
+    "profile": Profile.STANDARD,
+    "timeout": 5000,
+}
+
+# Defaults. All tunable by env var so operators can sweep without a code change.
+DEFAULT_MAX_RULES = 5
+DEFAULT_MIN_CONFIDENCE = 0.60
+DEFAULT_MIN_SIMILARITY = 0.05
+MIN_DRAFT_LEN = 10
+
+# Tokens that appear in almost every draft and would swamp Jaccard similarity.
+# Kept tight on purpose: overfitting this list defeats the per-draft signal.
+_STOPWORDS = frozenset({
+    "a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "has",
+    "have", "i", "in", "is", "it", "its", "of", "on", "or", "that", "the",
+    "this", "to", "was", "were", "will", "with", "you", "your", "we", "our",
+})
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _tokenize(text: str) -> set[str]:
+    """Lowercase word-unigrams minus a small stopword list."""
+    return {t for t in _TOKEN_RE.findall(text.lower()) if t not in _STOPWORDS and len(t) > 2}
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    if not a or not b:
+        return 0.0
+    inter = len(a & b)
+    if inter == 0:
+        return 0.0
+    return inter / len(a | b)
+
+
+def _jit_enabled() -> bool:
+    raw = os.environ.get("GRADATA_JIT_ENABLED", "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return default
+
+
+def _float_env(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def rank_rules_for_draft(
+    lessons: list,
+    draft_text: str,
+    *,
+    k: int = DEFAULT_MAX_RULES,
+    min_confidence: float = DEFAULT_MIN_CONFIDENCE,
+    min_similarity: float = DEFAULT_MIN_SIMILARITY,
+) -> list[tuple[object, float]]:
+    """Score each lesson against draft_text and return top-k above threshold.
+
+    Returns a list of (lesson, similarity) tuples, highest first. A rule
+    must clear BOTH confidence and similarity floors to appear; we'd rather
+    inject zero rules than inject noise (same philosophy as the PR #45
+    source-filter gate).
+    """
+    if not draft_text or not lessons or k <= 0:
+        return []
+
+    draft_tokens = _tokenize(draft_text)
+    if not draft_tokens:
+        return []
+
+    scored: list[tuple[object, float]] = []
+    for lesson in lessons:
+        conf = getattr(lesson, "confidence", 0.0)
+        if conf < min_confidence:
+            continue
+        state = getattr(lesson.state, "name", "")
+        if state not in ("RULE", "PATTERN"):
+            continue
+        description = getattr(lesson, "description", "") or ""
+        category = getattr(lesson, "category", "") or ""
+        rule_tokens = _tokenize(f"{category} {description}")
+        sim = _jaccard(draft_tokens, rule_tokens)
+        if sim < min_similarity:
+            continue
+        # Blend similarity with a small confidence tie-break so two equally
+        # matched rules order by confidence.
+        scored.append((lesson, sim + 0.001 * conf))
+
+    scored.sort(key=lambda pair: pair[1], reverse=True)
+    return scored[:k]
+
+
+def _emit_event(brain_dir: str, payload: dict) -> None:
+    """Append a JIT_INJECTION event to events.jsonl. Silent on failure.
+
+    We write directly instead of going through Brain() because hooks run
+    as short-lived subprocesses and a full Brain init is ~100 ms of
+    overhead we'd pay on every user prompt.
+    """
+    try:
+        events_path = Path(brain_dir) / "events.jsonl"
+        line = json.dumps({
+            "type": "JIT_INJECTION",
+            "ts": time.time(),
+            **payload,
+        }, ensure_ascii=False)
+        with events_path.open("a", encoding="utf-8") as f:
+            f.write(line + "\n")
+    except OSError:
+        # Telemetry must never break the hook contract.
+        pass
+
+
+def main(data: dict) -> dict | None:
+    if not _jit_enabled():
+        return None
+    if parse_lessons is None:
+        return None
+
+    message = extract_message(data)
+    if not message or len(message) < MIN_DRAFT_LEN:
+        return None
+    if message.startswith("/"):
+        return None
+
+    brain_dir = resolve_brain_dir()
+    if not brain_dir:
+        return None
+
+    lessons_path = Path(brain_dir) / "lessons.md"
+    if not lessons_path.is_file():
+        return None
+
+    try:
+        text = lessons_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    lessons = parse_lessons(text)
+    if not lessons:
+        return None
+
+    k = _int_env("GRADATA_JIT_MAX_RULES", DEFAULT_MAX_RULES)
+    min_conf = _float_env("GRADATA_JIT_MIN_CONFIDENCE", DEFAULT_MIN_CONFIDENCE)
+    min_sim = _float_env("GRADATA_JIT_MIN_SIMILARITY", DEFAULT_MIN_SIMILARITY)
+
+    ranked = rank_rules_for_draft(
+        lessons,
+        message,
+        k=k,
+        min_confidence=min_conf,
+        min_similarity=min_sim,
+    )
+
+    _emit_event(brain_dir, {
+        "draft_len": len(message),
+        "candidates": len(lessons),
+        "injected": len(ranked),
+        "k": k,
+        "min_similarity": min_sim,
+    })
+
+    if not ranked:
+        return None
+
+    lines = [
+        f"[{r.state.name}:{r.confidence:.2f}] {r.category}: {r.description}"
+        for r, _sim in ranked
+    ]
+    rules_block = "<brain-rules-jit>\n" + "\n".join(lines) + "\n</brain-rules-jit>"
+    return {"result": rules_block}
+
+
+if __name__ == "__main__":
+    run_hook(main, HOOK_META)

--- a/src/gradata/hooks/jit_inject.py
+++ b/src/gradata/hooks/jit_inject.py
@@ -67,10 +67,7 @@ def _tokenize(text: str) -> set[str]:
 def _jaccard(a: set[str], b: set[str]) -> float:
     if not a or not b:
         return 0.0
-    inter = len(a & b)
-    if inter == 0:
-        return 0.0
-    return inter / len(a | b)
+    return len(a & b) / len(a | b)
 
 
 def _jit_enabled() -> bool:

--- a/tests/test_jit_inject.py
+++ b/tests/test_jit_inject.py
@@ -1,0 +1,216 @@
+"""Tests for just-in-time (JIT) rule injection hook."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gradata._types import Lesson, LessonState
+from gradata.hooks import jit_inject
+from gradata.hooks.jit_inject import (
+    _jaccard,
+    _tokenize,
+    main,
+    rank_rules_for_draft,
+)
+
+
+def _lesson(category: str, description: str, *, confidence: float = 0.92,
+            state: LessonState = LessonState.RULE) -> Lesson:
+    return Lesson(
+        date="2026-04-14",
+        state=state,
+        confidence=confidence,
+        category=category,
+        description=description,
+    )
+
+
+class TestTokenize:
+    def test_drops_stopwords(self) -> None:
+        toks = _tokenize("The cat sat on the mat")
+        assert "the" not in toks
+        assert "on" not in toks
+        assert "cat" in toks
+        assert "mat" in toks
+
+    def test_drops_short_tokens(self) -> None:
+        assert _tokenize("a b cd xyz") == {"xyz"}
+
+    def test_lowercases(self) -> None:
+        assert _tokenize("Pipedrive DEAL") == {"pipedrive", "deal"}
+
+
+class TestJaccard:
+    def test_identical_sets_score_one(self) -> None:
+        a = {"foo", "bar"}
+        assert _jaccard(a, a) == 1.0
+
+    def test_disjoint_sets_score_zero(self) -> None:
+        assert _jaccard({"foo"}, {"bar"}) == 0.0
+
+    def test_empty_sets_score_zero(self) -> None:
+        assert _jaccard(set(), {"foo"}) == 0.0
+        assert _jaccard({"foo"}, set()) == 0.0
+
+
+class TestRankRulesForDraft:
+    def test_high_similarity_rule_is_selected(self) -> None:
+        lessons = [
+            _lesson("PIPEDRIVE", "Never auto-tag CEOs on pipedrive deals"),
+            _lesson("PROSE", "Avoid em dashes in marketing prose"),
+        ]
+        draft = "Please update the pipedrive deal and tag the CEO"
+        ranked = rank_rules_for_draft(lessons, draft, k=5, min_similarity=0.05)
+        assert len(ranked) == 1
+        assert ranked[0][0].category == "PIPEDRIVE"
+
+    def test_low_similarity_rule_is_filtered(self) -> None:
+        lessons = [_lesson("UNRELATED", "spec grammar nouns verbs clauses")]
+        draft = "Deploy the kubernetes cluster to production"
+        ranked = rank_rules_for_draft(lessons, draft, min_similarity=0.05)
+        assert ranked == []
+
+    def test_k_cap_is_respected(self) -> None:
+        lessons = [
+            _lesson("ONE", "deploy kubernetes cluster production"),
+            _lesson("TWO", "kubernetes cluster deployment production"),
+            _lesson("THREE", "production cluster kubernetes deploy"),
+            _lesson("FOUR", "cluster deploy production kubernetes"),
+        ]
+        draft = "deploy the kubernetes production cluster today"
+        ranked = rank_rules_for_draft(lessons, draft, k=2, min_similarity=0.01)
+        assert len(ranked) == 2
+
+    def test_confidence_floor_excludes_instincts(self) -> None:
+        lessons = [
+            _lesson("LOWCONF", "kubernetes deploy production", confidence=0.40,
+                    state=LessonState.INSTINCT),
+            _lesson("HIGHCONF", "kubernetes deploy production", confidence=0.95),
+        ]
+        draft = "deploy kubernetes to production"
+        ranked = rank_rules_for_draft(lessons, draft, min_similarity=0.01)
+        assert len(ranked) == 1
+        assert ranked[0][0].category == "HIGHCONF"
+
+    def test_killed_and_archived_excluded(self) -> None:
+        lessons = [
+            _lesson("ARCHIVED", "kubernetes deploy", state=LessonState.ARCHIVED),
+            _lesson("KILLED", "kubernetes deploy", state=LessonState.KILLED),
+            _lesson("RULE", "kubernetes deploy"),
+        ]
+        ranked = rank_rules_for_draft(
+            lessons, "kubernetes deploy tomorrow", min_similarity=0.01,
+        )
+        assert len(ranked) == 1
+        assert ranked[0][0].category == "RULE"
+
+    def test_empty_draft_returns_empty(self) -> None:
+        lessons = [_lesson("X", "anything")]
+        assert rank_rules_for_draft(lessons, "") == []
+
+    def test_k_zero_returns_empty(self) -> None:
+        lessons = [_lesson("X", "kubernetes deploy")]
+        assert rank_rules_for_draft(lessons, "kubernetes deploy", k=0) == []
+
+    def test_ranked_by_similarity_desc(self) -> None:
+        lessons = [
+            _lesson("LOW", "kubernetes spec grammar nouns verbs clauses"),
+            _lesson("HIGH", "kubernetes deploy production today"),
+        ]
+        ranked = rank_rules_for_draft(
+            lessons, "deploy kubernetes to production today",
+            k=5, min_similarity=0.01,
+        )
+        assert ranked[0][0].category == "HIGH"
+        assert ranked[0][1] > ranked[1][1]
+
+
+class TestMainHookFlagOff:
+    def test_flag_off_returns_none(self, monkeypatch, tmp_path: Path) -> None:
+        monkeypatch.delenv("GRADATA_JIT_ENABLED", raising=False)
+        result = main({"prompt": "deploy the kubernetes cluster"})
+        assert result is None
+
+    def test_flag_explicit_false_returns_none(self, monkeypatch) -> None:
+        monkeypatch.setenv("GRADATA_JIT_ENABLED", "false")
+        result = main({"prompt": "deploy the kubernetes cluster"})
+        assert result is None
+
+
+class TestMainHookFlagOn:
+    @pytest.fixture
+    def brain(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("GRADATA_JIT_ENABLED", "1")
+        monkeypatch.setenv("GRADATA_HOOK_PROFILE", "standard")
+        monkeypatch.setenv("GRADATA_BRAIN_DIR", str(tmp_path))
+        lessons_md = tmp_path / "lessons.md"
+        lessons_md.write_text(
+            "[2026-04-14] [RULE:0.92] PIPEDRIVE: Never auto-tag CEOs on pipedrive deals\n"
+            "[2026-04-14] [RULE:0.91] PROSE: Avoid em dashes in marketing prose\n",
+            encoding="utf-8",
+        )
+        return tmp_path
+
+    def test_short_prompt_skipped(self, brain: Path) -> None:
+        assert main({"prompt": "hi"}) is None
+
+    def test_slash_command_skipped(self, brain: Path) -> None:
+        assert main({"prompt": "/foo bar baz pipedrive deal"}) is None
+
+    def test_relevant_prompt_injects(self, brain: Path) -> None:
+        result = main({"prompt": "Update the pipedrive deal for the CEO today"})
+        assert result is not None
+        assert "<brain-rules-jit>" in result["result"]
+        assert "PIPEDRIVE" in result["result"]
+        # PROSE rule is unrelated; must not appear.
+        assert "PROSE" not in result["result"]
+
+    def test_irrelevant_prompt_returns_none(self, brain: Path) -> None:
+        result = main({"prompt": "Deploy the kubernetes cluster to aws"})
+        assert result is None
+
+    def test_event_emitted_on_miss(self, brain: Path) -> None:
+        main({"prompt": "Deploy the kubernetes cluster to aws"})
+        events_path = brain / "events.jsonl"
+        assert events_path.exists()
+        lines = events_path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+        payload = json.loads(lines[0])
+        assert payload["type"] == "JIT_INJECTION"
+        assert payload["injected"] == 0
+        assert payload["candidates"] >= 1
+
+    def test_event_emitted_on_hit(self, brain: Path) -> None:
+        main({"prompt": "Update the pipedrive deal for the CEO today"})
+        events_path = brain / "events.jsonl"
+        lines = events_path.read_text(encoding="utf-8").strip().splitlines()
+        payload = json.loads(lines[0])
+        assert payload["injected"] == 1
+
+    def test_k_override_via_env(self, brain: Path, monkeypatch) -> None:
+        # Add more matching rules, cap k=1 via env
+        (brain / "lessons.md").write_text(
+            "[2026-04-14] [RULE:0.95] ONE: pipedrive deal ceo tagging rule\n"
+            "[2026-04-14] [RULE:0.94] TWO: pipedrive deal ceo naming rule\n"
+            "[2026-04-14] [RULE:0.93] THREE: pipedrive deal ceo update rule\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("GRADATA_JIT_MAX_RULES", "1")
+        result = main({"prompt": "Update the pipedrive deal for the CEO today"})
+        assert result is not None
+        # Exactly one rule line between the tags
+        body = result["result"]
+        rule_lines = [ln for ln in body.splitlines() if ln.startswith("[")]
+        assert len(rule_lines) == 1
+
+
+class TestJitEnvParsing:
+    @pytest.mark.parametrize("value,expected", [
+        ("1", True), ("true", True), ("TRUE", True), ("yes", True), ("on", True),
+        ("0", False), ("false", False), ("", False), ("no", False),
+    ])
+    def test_flag_parsing(self, monkeypatch, value: str, expected: bool) -> None:
+        monkeypatch.setenv("GRADATA_JIT_ENABLED", value)
+        assert jit_inject._jit_enabled() is expected


### PR DESCRIPTION
## Summary
Just-in-time rule injection as opt-in alternative to session-start bulk injection. Hooks `UserPromptSubmit` (composes with existing `context_inject`), ranks rules by Jaccard similarity to the draft, injects only top-k relevant rules.

## Files
- `src/gradata/hooks/jit_inject.py` (new) — `<brain-rules-jit>` output, configurable via env
- `tests/test_jit_inject.py` — 32 tests
- `hooks/hooks.json` — registers new `UserPromptSubmit` entry

## Config
- `GRADATA_JIT_ENABLED` (default false)
- `GRADATA_JIT_MAX_RULES` (5)
- `GRADATA_JIT_MIN_CONFIDENCE` (0.60)
- `GRADATA_JIT_MIN_SIMILARITY` (0.05)

## Tests
2289 pass (+32), ruff clean.

## Commits
- `5758ef3` feat(jit): per-call rule injection hook with draft-relevance ranking
- `8fa9a7e` refactor(jit): drop redundant zero-intersection branch in `_jaccard`

## Follow-up
Shared `parse_lessons` helper with `inject_brain_rules.py` — blocked by PR #45 NO-TOUCH, unblocks now that #45 is merged.

Co-Authored-By: Gradata <noreply@gradata.ai>