### PR TITLE
feat(daemon): background worker queue with job dedup and graceful shutdown

### DIFF
--- a/src/gradata/_workers.py
+++ b/src/gradata/_workers.py
@@ -1,0 +1,530 @@
+"""
+Background Worker Queue — off-the-hot-path job runner.
+======================================================
+
+Provides a minimal, durable (SQLite-backed) job queue plus a worker
+thread pool that drains it. Heavy operations (meta-rule synthesis,
+decay application, event consolidation, DP export) enqueue jobs here
+instead of running inline during ``brain.correct()`` or session-end.
+
+Design
+------
+* Storage:     ``worker_jobs`` table in the brain's ``system.db``.
+* Dedup:       ``(type, payload_hash)`` — same job enqueued twice while
+               the first is still pending runs only once.
+* Semantics:   at-least-once. Handlers should be idempotent.
+* Dispatch:    one or more worker threads poll for ``pending`` rows,
+               claim with an ``UPDATE ... status='running'``, run the
+               handler, then mark ``done`` or ``failed``.
+* Shutdown:    :meth:`WorkerPool.stop` drains up to a deadline, then
+               exits even if jobs remain queued.
+
+Job types (stubs for now — real handlers land in follow-up PRs):
+
+* ``SYNTHESIZE_META_RULES``  — LLM meta-rule synthesis from graduated rules.
+* ``APPLY_DECAY``            — Periodic confidence decay.
+* ``CONSOLIDATE_EVENTS``     — Event-log consolidation / compression.
+* ``DP_EXPORT``              — Differentially-private brain export.
+
+The handlers registered here are intentionally no-op-with-logging stubs.
+Implementation wiring happens in the PRs that own the touched files.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sqlite3
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from gradata._db import get_connection
+
+logger = logging.getLogger("gradata.workers")
+
+
+# ── Job types ───────────────────────────────────────────────────────────
+
+SYNTHESIZE_META_RULES = "SYNTHESIZE_META_RULES"
+APPLY_DECAY = "APPLY_DECAY"
+CONSOLIDATE_EVENTS = "CONSOLIDATE_EVENTS"
+DP_EXPORT = "DP_EXPORT"
+
+KNOWN_JOB_TYPES: frozenset[str] = frozenset({
+    SYNTHESIZE_META_RULES,
+    APPLY_DECAY,
+    CONSOLIDATE_EVENTS,
+    DP_EXPORT,
+})
+
+
+# ── Schema ──────────────────────────────────────────────────────────────
+
+_WORKER_JOBS_SQL = """
+CREATE TABLE IF NOT EXISTS worker_jobs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    type TEXT NOT NULL,
+    payload_json TEXT NOT NULL DEFAULT '{}',
+    payload_hash TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at REAL NOT NULL,
+    started_at REAL,
+    finished_at REAL,
+    error TEXT
+)
+"""
+
+_WORKER_JOBS_INDEXES: list[str] = [
+    "CREATE INDEX IF NOT EXISTS idx_worker_jobs_status ON worker_jobs(status)",
+    (
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_worker_jobs_dedup "
+        "ON worker_jobs(type, payload_hash) "
+        "WHERE status IN ('pending', 'running')"
+    ),
+]
+
+
+def ensure_schema(db_path: str | Path) -> None:
+    """Create ``worker_jobs`` table and indexes if missing.
+
+    Safe to call repeatedly; uses ``CREATE IF NOT EXISTS``. Callers should
+    invoke this once at daemon startup, before any enqueue.
+    """
+    conn = get_connection(db_path)
+    try:
+        conn.execute(_WORKER_JOBS_SQL)
+        for sql in _WORKER_JOBS_INDEXES:
+            conn.execute(sql)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ── Dataclass ───────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Job:
+    """A single row from ``worker_jobs`` delivered to a handler."""
+
+    id: int
+    type: str
+    payload: dict[str, Any]
+    created_at: float
+
+
+Handler = Callable[[Job], None]
+
+
+# ── Default handlers (no-op with logging) ───────────────────────────────
+
+
+def _handler_synthesize_meta_rules(job: Job) -> None:
+    logger.info("worker: would synthesize meta-rules (job=%d)", job.id)
+
+
+def _handler_apply_decay(job: Job) -> None:
+    logger.info("worker: would apply decay (job=%d)", job.id)
+
+
+def _handler_consolidate_events(job: Job) -> None:
+    logger.info("worker: would consolidate events (job=%d)", job.id)
+
+
+def _handler_dp_export(job: Job) -> None:
+    logger.info("worker: would run DP export (job=%d)", job.id)
+
+
+def default_handlers() -> dict[str, Handler]:
+    """Return the default handler map (stubs).
+
+    Follow-up PRs that own the synthesis / decay / export code will
+    replace these by calling :meth:`WorkerPool.register` with real
+    implementations.
+    """
+    return {
+        SYNTHESIZE_META_RULES: _handler_synthesize_meta_rules,
+        APPLY_DECAY: _handler_apply_decay,
+        CONSOLIDATE_EVENTS: _handler_consolidate_events,
+        DP_EXPORT: _handler_dp_export,
+    }
+
+
+# ── Utility ─────────────────────────────────────────────────────────────
+
+
+def _payload_hash(payload: dict[str, Any]) -> str:
+    """Stable hash of a payload for dedup. Sorted keys, JSON-serialised."""
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+
+# ── Clock abstraction (for tests) ───────────────────────────────────────
+
+
+class _Clock:
+    """Indirection over ``time.time`` / ``time.monotonic`` so tests can
+    inject a fake. The pool uses ``mono()`` for deadlines (shutdown) and
+    ``now()`` for timestamp columns.
+    """
+
+    def now(self) -> float:
+        return time.time()
+
+    def mono(self) -> float:
+        return time.monotonic()
+
+
+# ── The pool ────────────────────────────────────────────────────────────
+
+
+class WorkerPool:
+    """Thread pool that drains ``worker_jobs`` from SQLite.
+
+    The pool is designed to run embedded inside the daemon, but it is
+    self-contained and can also be driven from a standalone script (see
+    ``brain/scripts/daemon_runner.py``).
+
+    Parameters
+    ----------
+    db_path:
+        Path to the brain's ``system.db`` (same file the rest of the
+        SDK uses).
+    workers:
+        Number of worker threads. Default 1 — these jobs are rare and
+        heavyweight; we mostly want them off the hot path, not parallel.
+    poll_interval:
+        Seconds between polls when the queue is empty. Low enough to
+        feel responsive, high enough not to burn CPU.
+    handlers:
+        Optional handler map. Defaults to :func:`default_handlers`.
+    clock:
+        Optional :class:`_Clock` for tests. Defaults to the real clock.
+    """
+
+    def __init__(
+        self,
+        db_path: str | Path,
+        workers: int = 1,
+        poll_interval: float = 0.5,
+        handlers: dict[str, Handler] | None = None,
+        clock: _Clock | None = None,
+    ) -> None:
+        self._db_path = Path(db_path)
+        self._n_workers = max(1, workers)
+        self._poll_interval = poll_interval
+        self._handlers: dict[str, Handler] = dict(handlers or default_handlers())
+        self._clock = clock or _Clock()
+
+        self._stop_event = threading.Event()
+        self._drain_deadline: float | None = None
+        self._threads: list[threading.Thread] = []
+        self._lock = threading.Lock()
+        self._started = False
+
+    # ── Registration ────────────────────────────────────────────────────
+
+    def register(self, job_type: str, handler: Handler) -> None:
+        """Register (or override) a handler for ``job_type``.
+
+        Follow-up PRs call this to swap a stub for a real implementation.
+        """
+        with self._lock:
+            self._handlers[job_type] = handler
+
+    # ── Enqueue ─────────────────────────────────────────────────────────
+
+    def enqueue(self, job_type: str, payload: dict[str, Any] | None = None) -> int | None:
+        """Enqueue a job. Returns the new job id, or ``None`` if a job
+        with the same ``(type, payload_hash)`` is already pending/running
+        (dedup).
+
+        At-least-once semantics: handlers MUST be idempotent. The dedup
+        index guarantees that a burst of identical enqueues collapses to
+        a single handler invocation, but a job that failed mid-flight
+        may be retried by a future enqueue once the prior attempt is
+        marked ``failed``.
+        """
+        payload = payload or {}
+        phash = _payload_hash(payload)
+        created_at = self._clock.now()
+
+        conn = get_connection(self._db_path)
+        try:
+            try:
+                cur = conn.execute(
+                    "INSERT INTO worker_jobs "
+                    "(type, payload_json, payload_hash, status, created_at) "
+                    "VALUES (?, ?, ?, 'pending', ?)",
+                    (job_type, json.dumps(payload, sort_keys=True), phash, created_at),
+                )
+                conn.commit()
+                return int(cur.lastrowid) if cur.lastrowid is not None else None
+            except sqlite3.IntegrityError:
+                # Unique index collision => a duplicate is already live.
+                logger.debug(
+                    "enqueue dedup: type=%s hash=%s already pending/running",
+                    job_type, phash,
+                )
+                return None
+        finally:
+            conn.close()
+
+    # ── Static helper for callers that don't hold the pool ──────────────
+
+    @staticmethod
+    def enqueue_to(
+        db_path: str | Path,
+        job_type: str,
+        payload: dict[str, Any] | None = None,
+    ) -> int | None:
+        """Convenience: enqueue without instantiating a full pool.
+
+        Used by hot-path callers (e.g. ``brain.correct``) that only need
+        to drop a job; the daemon's pool picks it up.
+        """
+        ensure_schema(db_path)
+        pool = WorkerPool(db_path)
+        return pool.enqueue(job_type, payload)
+
+    # ── Claim + run a single job ────────────────────────────────────────
+
+    def _claim_one(self, conn: sqlite3.Connection) -> Job | None:
+        """Atomically claim one pending job. Returns None if the queue is empty."""
+        now = self._clock.now()
+        # BEGIN IMMEDIATE takes a write lock so two workers can't claim the same row.
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            row = conn.execute(
+                "SELECT id, type, payload_json, created_at "
+                "FROM worker_jobs WHERE status = 'pending' "
+                "ORDER BY id LIMIT 1"
+            ).fetchone()
+            if row is None:
+                conn.execute("COMMIT")
+                return None
+            conn.execute(
+                "UPDATE worker_jobs SET status='running', started_at=? WHERE id=?",
+                (now, row["id"]),
+            )
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+
+        try:
+            payload = json.loads(row["payload_json"]) if row["payload_json"] else {}
+        except json.JSONDecodeError:
+            payload = {}
+        return Job(
+            id=int(row["id"]),
+            type=str(row["type"]),
+            payload=payload,
+            created_at=float(row["created_at"]),
+        )
+
+    def _mark_done(self, conn: sqlite3.Connection, job_id: int) -> None:
+        conn.execute(
+            "UPDATE worker_jobs SET status='done', finished_at=? WHERE id=?",
+            (self._clock.now(), job_id),
+        )
+        conn.commit()
+
+    def _mark_failed(self, conn: sqlite3.Connection, job_id: int, err: str) -> None:
+        conn.execute(
+            "UPDATE worker_jobs SET status='failed', finished_at=?, error=? WHERE id=?",
+            (self._clock.now(), err[:500], job_id),
+        )
+        conn.commit()
+
+    def drain_once(self) -> bool:
+        """Claim and run a single pending job. Returns True if a job
+        was processed, False if the queue was empty.
+
+        Used both by the worker loop and by tests that want deterministic
+        single-step execution without spawning threads.
+        """
+        conn = get_connection(self._db_path)
+        try:
+            job = self._claim_one(conn)
+            if job is None:
+                return False
+            with self._lock:
+                handler = self._handlers.get(job.type)
+            if handler is None:
+                self._mark_failed(conn, job.id, f"no handler for type={job.type}")
+                logger.warning("worker: no handler for job type=%s id=%d", job.type, job.id)
+                return True
+            try:
+                handler(job)
+                self._mark_done(conn, job.id)
+            except Exception as exc:
+                logger.exception("worker: handler for %s raised", job.type)
+                self._mark_failed(conn, job.id, f"{type(exc).__name__}: {exc}")
+            return True
+        finally:
+            conn.close()
+
+    # ── Worker loop ─────────────────────────────────────────────────────
+
+    def _should_exit(self) -> bool:
+        """True if we've been asked to stop AND either the queue is drained
+        or the drain deadline has passed.
+        """
+        if not self._stop_event.is_set():
+            return False
+        if self._drain_deadline is not None and self._clock.mono() >= self._drain_deadline:
+            return True
+        # Stop set but deadline not hit: keep draining while there's work.
+        return not self._has_pending()
+
+    def _has_pending(self) -> bool:
+        conn = get_connection(self._db_path)
+        try:
+            row = conn.execute(
+                "SELECT 1 FROM worker_jobs WHERE status='pending' LIMIT 1"
+            ).fetchone()
+            return row is not None
+        finally:
+            conn.close()
+
+    def _worker_loop(self) -> None:
+        while not self._should_exit():
+            try:
+                processed = self.drain_once()
+            except Exception:
+                logger.exception("worker loop: drain_once failed")
+                processed = False
+            if not processed:
+                # Idle: short sleep, but wake early on stop so we notice
+                # the deadline.
+                self._stop_event.wait(self._poll_interval)
+
+    # ── Lifecycle ───────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        """Start worker threads. Idempotent."""
+        if self._started:
+            return
+        ensure_schema(self._db_path)
+        self._stop_event.clear()
+        self._drain_deadline = None
+        for i in range(self._n_workers):
+            t = threading.Thread(
+                target=self._worker_loop,
+                name=f"gradata-worker-{i}",
+                daemon=True,
+            )
+            t.start()
+            self._threads.append(t)
+        self._started = True
+        logger.info("WorkerPool started with %d worker(s)", self._n_workers)
+
+    def stop(self, drain_timeout: float = 5.0) -> None:
+        """Signal workers to exit. Blocks up to ``drain_timeout`` seconds
+        while the queue drains, then returns even if jobs remain.
+        """
+        if not self._started:
+            return
+        self._drain_deadline = self._clock.mono() + max(0.0, drain_timeout)
+        self._stop_event.set()
+        for t in self._threads:
+            t.join(timeout=drain_timeout + 1.0)
+        self._threads.clear()
+        self._started = False
+        logger.info("WorkerPool stopped")
+
+
+# ── Module-level convenience ────────────────────────────────────────────
+
+
+def enqueue_job(
+    db_path: str | Path,
+    job_type: str,
+    payload: dict[str, Any] | None = None,
+) -> int | None:
+    """Top-level helper mirroring :meth:`WorkerPool.enqueue_to`.
+
+    Call from anywhere in the SDK::
+
+        from gradata._workers import enqueue_job, APPLY_DECAY
+        enqueue_job(brain.db_path, APPLY_DECAY, {"reason": "nightly"})
+
+    Returns the new job id, or ``None`` on dedup.
+    """
+    return WorkerPool.enqueue_to(db_path, job_type, payload)
+
+
+# ── Standalone runner ───────────────────────────────────────────────────
+
+
+def run_standalone(
+    brain_dir: str | Path,
+    workers: int = 1,
+    drain_timeout: float = 5.0,
+) -> None:
+    """Run a worker pool without the HTTP daemon.
+
+    Useful for cron jobs, CI, or a dedicated systemd unit that only
+    drains the queue. Blocks until SIGTERM / SIGINT, then drains up
+    to ``drain_timeout`` seconds before exiting.
+    """
+    import contextlib
+    import signal
+
+    brain_dir = Path(brain_dir).resolve()
+    db_path = brain_dir / "system.db"
+    ensure_schema(db_path)
+
+    pool = WorkerPool(db_path, workers=workers)
+    pool.start()
+    logger.info("workers: standalone pool started (workers=%d, db=%s)", workers, db_path)
+
+    stop_event = threading.Event()
+
+    def _handle_signal(signum: int, _frame: object) -> None:
+        logger.info("workers: signal %d received, shutting down", signum)
+        stop_event.set()
+
+    if hasattr(signal, "SIGTERM"):
+        with contextlib.suppress(ValueError):
+            signal.signal(signal.SIGTERM, _handle_signal)
+    with contextlib.suppress(ValueError):
+        signal.signal(signal.SIGINT, _handle_signal)
+
+    try:
+        stop_event.wait()
+    finally:
+        pool.stop(drain_timeout=drain_timeout)
+        logger.info("workers: standalone pool exited")
+
+
+def _main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Gradata standalone worker-pool runner (no HTTP server).",
+    )
+    parser.add_argument("--brain-dir", required=True, help="Path to the brain directory")
+    parser.add_argument("--workers", type=int, default=1, help="Worker threads (default 1)")
+    parser.add_argument(
+        "--drain-timeout", type=float, default=5.0,
+        help="Seconds to let the queue drain on shutdown (default 5)",
+    )
+    parser.add_argument("--log-level", default="INFO")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=args.log_level.upper(),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    run_standalone(args.brain_dir, args.workers, args.drain_timeout)
+
+
+if __name__ == "__main__":
+    _main()

--- a/src/gradata/_workers.py
+++ b/src/gradata/_workers.py
@@ -1,33 +1,20 @@
 """
 Background Worker Queue — off-the-hot-path job runner.
-======================================================
 
-Provides a minimal, durable (SQLite-backed) job queue plus a worker
-thread pool that drains it. Heavy operations (meta-rule synthesis,
-decay application, event consolidation, DP export) enqueue jobs here
-instead of running inline during ``brain.correct()`` or session-end.
+SQLite-backed job queue + worker-thread pool that drains it. Heavy ops
+(meta-rule synthesis, decay, consolidation, DP export) enqueue here
+instead of running inline in ``brain.correct()`` or session-end.
 
-Design
-------
-* Storage:     ``worker_jobs`` table in the brain's ``system.db``.
-* Dedup:       ``(type, payload_hash)`` — same job enqueued twice while
-               the first is still pending runs only once.
-* Semantics:   at-least-once. Handlers should be idempotent.
-* Dispatch:    one or more worker threads poll for ``pending`` rows,
-               claim with an ``UPDATE ... status='running'``, run the
-               handler, then mark ``done`` or ``failed``.
-* Shutdown:    :meth:`WorkerPool.stop` drains up to a deadline, then
-               exits even if jobs remain queued.
+* Storage:   ``worker_jobs`` table in the brain's ``system.db``.
+* Dedup:     unique partial index on ``(type, payload_hash)`` for rows
+             with ``status IN ('pending','running')``. Bursts of
+             identical enqueues collapse to one handler call.
+* Semantics: at-least-once. Handlers MUST be idempotent.
+* Shutdown:  :meth:`WorkerPool.stop` drains up to a deadline then exits.
 
-Job types (stubs for now — real handlers land in follow-up PRs):
-
-* ``SYNTHESIZE_META_RULES``  — LLM meta-rule synthesis from graduated rules.
-* ``APPLY_DECAY``            — Periodic confidence decay.
-* ``CONSOLIDATE_EVENTS``     — Event-log consolidation / compression.
-* ``DP_EXPORT``              — Differentially-private brain export.
-
-The handlers registered here are intentionally no-op-with-logging stubs.
-Implementation wiring happens in the PRs that own the touched files.
+Four job-type constants (SYNTHESIZE_META_RULES, APPLY_DECAY,
+CONSOLIDATE_EVENTS, DP_EXPORT) come pre-registered as log-only stubs.
+Follow-up PRs swap real implementations via :meth:`WorkerPool.register`.
 """
 
 from __future__ import annotations
@@ -47,65 +34,45 @@ from gradata._db import get_connection
 
 logger = logging.getLogger("gradata.workers")
 
-
-# ── Job types ───────────────────────────────────────────────────────────
-
 SYNTHESIZE_META_RULES = "SYNTHESIZE_META_RULES"
 APPLY_DECAY = "APPLY_DECAY"
 CONSOLIDATE_EVENTS = "CONSOLIDATE_EVENTS"
 DP_EXPORT = "DP_EXPORT"
 
 KNOWN_JOB_TYPES: frozenset[str] = frozenset({
-    SYNTHESIZE_META_RULES,
-    APPLY_DECAY,
-    CONSOLIDATE_EVENTS,
-    DP_EXPORT,
+    SYNTHESIZE_META_RULES, APPLY_DECAY, CONSOLIDATE_EVENTS, DP_EXPORT,
 })
 
-
-# ── Schema ──────────────────────────────────────────────────────────────
-
-_WORKER_JOBS_SQL = """
-CREATE TABLE IF NOT EXISTS worker_jobs (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    type TEXT NOT NULL,
-    payload_json TEXT NOT NULL DEFAULT '{}',
-    payload_hash TEXT NOT NULL,
-    status TEXT NOT NULL DEFAULT 'pending',
-    created_at REAL NOT NULL,
-    started_at REAL,
-    finished_at REAL,
-    error TEXT
-)
-"""
-
-_WORKER_JOBS_INDEXES: list[str] = [
+_SCHEMA_SQL: tuple[str, ...] = (
+    """
+    CREATE TABLE IF NOT EXISTS worker_jobs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        type TEXT NOT NULL,
+        payload_json TEXT NOT NULL DEFAULT '{}',
+        payload_hash TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending',
+        created_at REAL NOT NULL,
+        started_at REAL,
+        finished_at REAL,
+        error TEXT
+    )
+    """,
     "CREATE INDEX IF NOT EXISTS idx_worker_jobs_status ON worker_jobs(status)",
-    (
-        "CREATE UNIQUE INDEX IF NOT EXISTS idx_worker_jobs_dedup "
-        "ON worker_jobs(type, payload_hash) "
-        "WHERE status IN ('pending', 'running')"
-    ),
-]
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_worker_jobs_dedup "
+    "ON worker_jobs(type, payload_hash) "
+    "WHERE status IN ('pending', 'running')",
+)
 
 
 def ensure_schema(db_path: str | Path) -> None:
-    """Create ``worker_jobs`` table and indexes if missing.
-
-    Safe to call repeatedly; uses ``CREATE IF NOT EXISTS``. Callers should
-    invoke this once at daemon startup, before any enqueue.
-    """
+    """Create ``worker_jobs`` table + indexes if missing. Idempotent."""
     conn = get_connection(db_path)
     try:
-        conn.execute(_WORKER_JOBS_SQL)
-        for sql in _WORKER_JOBS_INDEXES:
+        for sql in _SCHEMA_SQL:
             conn.execute(sql)
         conn.commit()
     finally:
         conn.close()
-
-
-# ── Dataclass ───────────────────────────────────────────────────────────
 
 
 @dataclass(frozen=True)
@@ -121,57 +88,33 @@ class Job:
 Handler = Callable[[Job], None]
 
 
-# ── Default handlers (no-op with logging) ───────────────────────────────
-
-
-def _handler_synthesize_meta_rules(job: Job) -> None:
-    logger.info("worker: would synthesize meta-rules (job=%d)", job.id)
-
-
-def _handler_apply_decay(job: Job) -> None:
-    logger.info("worker: would apply decay (job=%d)", job.id)
-
-
-def _handler_consolidate_events(job: Job) -> None:
-    logger.info("worker: would consolidate events (job=%d)", job.id)
-
-
-def _handler_dp_export(job: Job) -> None:
-    logger.info("worker: would run DP export (job=%d)", job.id)
+def _stub_handler(label: str) -> Handler:
+    """Log-and-succeed stub. Follow-up PRs swap via ``WorkerPool.register``."""
+    def _run(job: Job) -> None:
+        logger.info("worker: would %s (job=%d)", label, job.id)
+    return _run
 
 
 def default_handlers() -> dict[str, Handler]:
-    """Return the default handler map (stubs).
-
-    Follow-up PRs that own the synthesis / decay / export code will
-    replace these by calling :meth:`WorkerPool.register` with real
-    implementations.
-    """
     return {
-        SYNTHESIZE_META_RULES: _handler_synthesize_meta_rules,
-        APPLY_DECAY: _handler_apply_decay,
-        CONSOLIDATE_EVENTS: _handler_consolidate_events,
-        DP_EXPORT: _handler_dp_export,
+        SYNTHESIZE_META_RULES: _stub_handler("synthesize meta-rules"),
+        APPLY_DECAY:           _stub_handler("apply decay"),
+        CONSOLIDATE_EVENTS:    _stub_handler("consolidate events"),
+        DP_EXPORT:             _stub_handler("run DP export"),
     }
 
 
-# ── Utility ─────────────────────────────────────────────────────────────
+def _canonical_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
 
 
 def _payload_hash(payload: dict[str, Any]) -> str:
-    """Stable hash of a payload for dedup. Sorted keys, JSON-serialised."""
-    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
-    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
-
-
-# ── Clock abstraction (for tests) ───────────────────────────────────────
+    """Stable short hash of a payload for dedup."""
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()[:16]
 
 
 class _Clock:
-    """Indirection over ``time.time`` / ``time.monotonic`` so tests can
-    inject a fake. The pool uses ``mono()`` for deadlines (shutdown) and
-    ``now()`` for timestamp columns.
-    """
+    """Clock indirection so tests can inject a fake (see ``FakeClock``)."""
 
     def now(self) -> float:
         return time.time()
@@ -180,31 +123,11 @@ class _Clock:
         return time.monotonic()
 
 
-# ── The pool ────────────────────────────────────────────────────────────
-
-
 class WorkerPool:
     """Thread pool that drains ``worker_jobs`` from SQLite.
 
-    The pool is designed to run embedded inside the daemon, but it is
-    self-contained and can also be driven from a standalone script (see
-    ``brain/scripts/daemon_runner.py``).
-
-    Parameters
-    ----------
-    db_path:
-        Path to the brain's ``system.db`` (same file the rest of the
-        SDK uses).
-    workers:
-        Number of worker threads. Default 1 — these jobs are rare and
-        heavyweight; we mostly want them off the hot path, not parallel.
-    poll_interval:
-        Seconds between polls when the queue is empty. Low enough to
-        feel responsive, high enough not to burn CPU.
-    handlers:
-        Optional handler map. Defaults to :func:`default_handlers`.
-    clock:
-        Optional :class:`_Clock` for tests. Defaults to the real clock.
+    Runs embedded inside the daemon but is self-contained enough to drive
+    from a standalone script (see :func:`run_standalone`).
     """
 
     def __init__(
@@ -220,39 +143,25 @@ class WorkerPool:
         self._poll_interval = poll_interval
         self._handlers: dict[str, Handler] = dict(handlers or default_handlers())
         self._clock = clock or _Clock()
-
         self._stop_event = threading.Event()
         self._drain_deadline: float | None = None
         self._threads: list[threading.Thread] = []
         self._lock = threading.Lock()
         self._started = False
 
-    # ── Registration ────────────────────────────────────────────────────
-
     def register(self, job_type: str, handler: Handler) -> None:
-        """Register (or override) a handler for ``job_type``.
-
-        Follow-up PRs call this to swap a stub for a real implementation.
-        """
+        """Register (or override) a handler for ``job_type``."""
         with self._lock:
             self._handlers[job_type] = handler
 
-    # ── Enqueue ─────────────────────────────────────────────────────────
-
     def enqueue(self, job_type: str, payload: dict[str, Any] | None = None) -> int | None:
-        """Enqueue a job. Returns the new job id, or ``None`` if a job
-        with the same ``(type, payload_hash)`` is already pending/running
-        (dedup).
+        """Insert a pending job. Returns new id, or ``None`` if deduped.
 
-        At-least-once semantics: handlers MUST be idempotent. The dedup
-        index guarantees that a burst of identical enqueues collapses to
-        a single handler invocation, but a job that failed mid-flight
-        may be retried by a future enqueue once the prior attempt is
-        marked ``failed``.
+        At-least-once: handlers MUST be idempotent. A failed job's dedup
+        slot is released, so a later enqueue can retry it.
         """
-        payload = payload or {}
-        phash = _payload_hash(payload)
-        created_at = self._clock.now()
+        payload_json = _canonical_json(payload or {})
+        phash = hashlib.sha256(payload_json.encode("utf-8")).hexdigest()[:16]
 
         conn = get_connection(self._db_path)
         try:
@@ -261,43 +170,19 @@ class WorkerPool:
                     "INSERT INTO worker_jobs "
                     "(type, payload_json, payload_hash, status, created_at) "
                     "VALUES (?, ?, ?, 'pending', ?)",
-                    (job_type, json.dumps(payload, sort_keys=True), phash, created_at),
+                    (job_type, payload_json, phash, self._clock.now()),
                 )
                 conn.commit()
                 return int(cur.lastrowid) if cur.lastrowid is not None else None
             except sqlite3.IntegrityError:
-                # Unique index collision => a duplicate is already live.
-                logger.debug(
-                    "enqueue dedup: type=%s hash=%s already pending/running",
-                    job_type, phash,
-                )
+                logger.debug("enqueue dedup: type=%s hash=%s live", job_type, phash)
                 return None
         finally:
             conn.close()
 
-    # ── Static helper for callers that don't hold the pool ──────────────
-
-    @staticmethod
-    def enqueue_to(
-        db_path: str | Path,
-        job_type: str,
-        payload: dict[str, Any] | None = None,
-    ) -> int | None:
-        """Convenience: enqueue without instantiating a full pool.
-
-        Used by hot-path callers (e.g. ``brain.correct``) that only need
-        to drop a job; the daemon's pool picks it up.
-        """
-        ensure_schema(db_path)
-        pool = WorkerPool(db_path)
-        return pool.enqueue(job_type, payload)
-
-    # ── Claim + run a single job ────────────────────────────────────────
-
     def _claim_one(self, conn: sqlite3.Connection) -> Job | None:
-        """Atomically claim one pending job. Returns None if the queue is empty."""
+        """Atomically claim one pending job. BEGIN IMMEDIATE prevents races."""
         now = self._clock.now()
-        # BEGIN IMMEDIATE takes a write lock so two workers can't claim the same row.
         conn.execute("BEGIN IMMEDIATE")
         try:
             row = conn.execute(
@@ -322,33 +207,26 @@ class WorkerPool:
         except json.JSONDecodeError:
             payload = {}
         return Job(
-            id=int(row["id"]),
-            type=str(row["type"]),
-            payload=payload,
-            created_at=float(row["created_at"]),
+            id=int(row["id"]), type=str(row["type"]),
+            payload=payload, created_at=float(row["created_at"]),
         )
 
-    def _mark_done(self, conn: sqlite3.Connection, job_id: int) -> None:
+    def _finalize(
+        self, conn: sqlite3.Connection, job_id: int, *, error: str | None = None,
+    ) -> None:
         conn.execute(
-            "UPDATE worker_jobs SET status='done', finished_at=? WHERE id=?",
-            (self._clock.now(), job_id),
-        )
-        conn.commit()
-
-    def _mark_failed(self, conn: sqlite3.Connection, job_id: int, err: str) -> None:
-        conn.execute(
-            "UPDATE worker_jobs SET status='failed', finished_at=?, error=? WHERE id=?",
-            (self._clock.now(), err[:500], job_id),
+            "UPDATE worker_jobs SET status=?, finished_at=?, error=? WHERE id=?",
+            (
+                "failed" if error else "done",
+                self._clock.now(),
+                (error[:500] if error else None),
+                job_id,
+            ),
         )
         conn.commit()
 
     def drain_once(self) -> bool:
-        """Claim and run a single pending job. Returns True if a job
-        was processed, False if the queue was empty.
-
-        Used both by the worker loop and by tests that want deterministic
-        single-step execution without spawning threads.
-        """
+        """Claim + run one pending job. Returns True if one was processed."""
         conn = get_connection(self._db_path)
         try:
             job = self._claim_one(conn)
@@ -357,41 +235,35 @@ class WorkerPool:
             with self._lock:
                 handler = self._handlers.get(job.type)
             if handler is None:
-                self._mark_failed(conn, job.id, f"no handler for type={job.type}")
+                self._finalize(conn, job.id, error=f"no handler for type={job.type}")
                 logger.warning("worker: no handler for job type=%s id=%d", job.type, job.id)
                 return True
             try:
                 handler(job)
-                self._mark_done(conn, job.id)
+                self._finalize(conn, job.id)
             except Exception as exc:
                 logger.exception("worker: handler for %s raised", job.type)
-                self._mark_failed(conn, job.id, f"{type(exc).__name__}: {exc}")
+                self._finalize(conn, job.id, error=f"{type(exc).__name__}: {exc}")
             return True
         finally:
             conn.close()
-
-    # ── Worker loop ─────────────────────────────────────────────────────
-
-    def _should_exit(self) -> bool:
-        """True if we've been asked to stop AND either the queue is drained
-        or the drain deadline has passed.
-        """
-        if not self._stop_event.is_set():
-            return False
-        if self._drain_deadline is not None and self._clock.mono() >= self._drain_deadline:
-            return True
-        # Stop set but deadline not hit: keep draining while there's work.
-        return not self._has_pending()
 
     def _has_pending(self) -> bool:
         conn = get_connection(self._db_path)
         try:
-            row = conn.execute(
+            return conn.execute(
                 "SELECT 1 FROM worker_jobs WHERE status='pending' LIMIT 1"
-            ).fetchone()
-            return row is not None
+            ).fetchone() is not None
         finally:
             conn.close()
+
+    def _should_exit(self) -> bool:
+        """Stop requested AND (deadline passed OR queue empty)."""
+        if not self._stop_event.is_set():
+            return False
+        if self._drain_deadline is not None and self._clock.mono() >= self._drain_deadline:
+            return True
+        return not self._has_pending()
 
     def _worker_loop(self) -> None:
         while not self._should_exit():
@@ -401,11 +273,7 @@ class WorkerPool:
                 logger.exception("worker loop: drain_once failed")
                 processed = False
             if not processed:
-                # Idle: short sleep, but wake early on stop so we notice
-                # the deadline.
                 self._stop_event.wait(self._poll_interval)
-
-    # ── Lifecycle ───────────────────────────────────────────────────────
 
     def start(self) -> None:
         """Start worker threads. Idempotent."""
@@ -416,9 +284,7 @@ class WorkerPool:
         self._drain_deadline = None
         for i in range(self._n_workers):
             t = threading.Thread(
-                target=self._worker_loop,
-                name=f"gradata-worker-{i}",
-                daemon=True,
+                target=self._worker_loop, name=f"gradata-worker-{i}", daemon=True,
             )
             t.start()
             self._threads.append(t)
@@ -426,9 +292,7 @@ class WorkerPool:
         logger.info("WorkerPool started with %d worker(s)", self._n_workers)
 
     def stop(self, drain_timeout: float = 5.0) -> None:
-        """Signal workers to exit. Blocks up to ``drain_timeout`` seconds
-        while the queue drains, then returns even if jobs remain.
-        """
+        """Signal exit; block up to ``drain_timeout`` s while queue drains."""
         if not self._started:
             return
         self._drain_deadline = self._clock.mono() + max(0.0, drain_timeout)
@@ -440,27 +304,18 @@ class WorkerPool:
         logger.info("WorkerPool stopped")
 
 
-# ── Module-level convenience ────────────────────────────────────────────
-
-
 def enqueue_job(
     db_path: str | Path,
     job_type: str,
     payload: dict[str, Any] | None = None,
 ) -> int | None:
-    """Top-level helper mirroring :meth:`WorkerPool.enqueue_to`.
+    """Enqueue without instantiating a long-lived pool.
 
-    Call from anywhere in the SDK::
-
-        from gradata._workers import enqueue_job, APPLY_DECAY
-        enqueue_job(brain.db_path, APPLY_DECAY, {"reason": "nightly"})
-
-    Returns the new job id, or ``None`` on dedup.
+    For hot-path callers (e.g. ``brain.correct``) that drop a job and let
+    the daemon's pool pick it up. Returns id or ``None`` on dedup.
     """
-    return WorkerPool.enqueue_to(db_path, job_type, payload)
-
-
-# ── Standalone runner ───────────────────────────────────────────────────
+    ensure_schema(db_path)
+    return WorkerPool(db_path).enqueue(job_type, payload)
 
 
 def run_standalone(
@@ -468,19 +323,12 @@ def run_standalone(
     workers: int = 1,
     drain_timeout: float = 5.0,
 ) -> None:
-    """Run a worker pool without the HTTP daemon.
-
-    Useful for cron jobs, CI, or a dedicated systemd unit that only
-    drains the queue. Blocks until SIGTERM / SIGINT, then drains up
-    to ``drain_timeout`` seconds before exiting.
-    """
+    """Run a worker pool without the HTTP daemon. Blocks until SIGTERM/SIGINT."""
     import contextlib
     import signal
 
-    brain_dir = Path(brain_dir).resolve()
-    db_path = brain_dir / "system.db"
+    db_path = Path(brain_dir).resolve() / "system.db"
     ensure_schema(db_path)
-
     pool = WorkerPool(db_path, workers=workers)
     pool.start()
     logger.info("workers: standalone pool started (workers=%d, db=%s)", workers, db_path)
@@ -491,11 +339,11 @@ def run_standalone(
         logger.info("workers: signal %d received, shutting down", signum)
         stop_event.set()
 
-    if hasattr(signal, "SIGTERM"):
-        with contextlib.suppress(ValueError):
-            signal.signal(signal.SIGTERM, _handle_signal)
-    with contextlib.suppress(ValueError):
-        signal.signal(signal.SIGINT, _handle_signal)
+    for sig_name in ("SIGTERM", "SIGINT"):
+        sig = getattr(signal, sig_name, None)
+        if sig is not None:
+            with contextlib.suppress(ValueError):
+                signal.signal(sig, _handle_signal)
 
     try:
         stop_event.wait()
@@ -504,7 +352,7 @@ def run_standalone(
         logger.info("workers: standalone pool exited")
 
 
-def _main() -> None:
+if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(
@@ -524,7 +372,3 @@ def _main() -> None:
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
     run_standalone(args.brain_dir, args.workers, args.drain_timeout)
-
-
-if __name__ == "__main__":
-    _main()

--- a/src/gradata/daemon.py
+++ b/src/gradata/daemon.py
@@ -43,6 +43,7 @@ from socketserver import ThreadingMixIn
 import gradata
 from gradata._scope import RuleScope
 from gradata._types import LessonState
+from gradata._workers import WorkerPool
 from gradata.detection.addition_pattern import AdditionTracker, classify_addition, is_addition
 from gradata.detection.correction_conflict import (
     ConflictTracker,
@@ -621,6 +622,11 @@ class GradataDaemon:
         # Idle auto-shutdown
         self._idle_timer: threading.Timer | None = None
 
+        # Background worker pool (heavy jobs: meta-rule synthesis, decay,
+        # consolidation, DP export). Stays None until start(); tests can
+        # construct a daemon without a live pool.
+        self._worker_pool: WorkerPool | None = None
+
     # ── Session ID → number mapping ────────────────────────────────────
 
     def _get_session_num(self, session_id: str) -> int:
@@ -691,6 +697,10 @@ class GradataDaemon:
         # Start idle timer
         self._reset_idle_timer()
 
+        # Spin up the background worker pool alongside the HTTP server.
+        self._worker_pool = WorkerPool(self._brain.db_path)
+        self._worker_pool.start()
+
         # Opt-in anonymous telemetry
         self._maybe_send_telemetry()
 
@@ -723,6 +733,10 @@ class GradataDaemon:
     def _cleanup(self) -> None:
         if self._idle_timer:
             self._idle_timer.cancel()
+        if self._worker_pool is not None:
+            with contextlib.suppress(Exception):
+                self._worker_pool.stop(drain_timeout=5.0)
+            self._worker_pool = None
         if self._pid_file and self._pid_file.exists():
             with contextlib.suppress(OSError):
                 self._pid_file.unlink()

--- a/tests/test_workers.py
+++ b/tests/test_workers.py
@@ -1,0 +1,253 @@
+"""Tests for the background worker queue (src/gradata/_workers.py).
+
+All time-dependent logic uses a fake clock; nothing sleeps for real
+seconds. Thread-based tests use :meth:`WorkerPool.drain_once` so runs
+are deterministic and fast.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from gradata._workers import (
+    APPLY_DECAY,
+    CONSOLIDATE_EVENTS,
+    DP_EXPORT,
+    SYNTHESIZE_META_RULES,
+    Job,
+    WorkerPool,
+    _Clock,
+    _payload_hash,
+    enqueue_job,
+    ensure_schema,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ── Fakes ───────────────────────────────────────────────────────────────
+
+
+class FakeClock(_Clock):
+    """Deterministic clock for tests."""
+
+    def __init__(self, start_now: float = 1_000_000.0, start_mono: float = 0.0) -> None:
+        self._now = start_now
+        self._mono = start_mono
+
+    def now(self) -> float:
+        return self._now
+
+    def mono(self) -> float:
+        return self._mono
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
+        self._mono += seconds
+
+
+def _db(tmp_path: Path) -> Path:
+    """Create a fresh brain-like directory with an empty system.db."""
+    brain_dir = tmp_path / "brain"
+    brain_dir.mkdir()
+    db = brain_dir / "system.db"
+    db.touch()
+    ensure_schema(db)
+    return db
+
+
+# ── Schema & enqueue basics ─────────────────────────────────────────────
+
+
+def test_ensure_schema_idempotent(tmp_path: Path) -> None:
+    db = _db(tmp_path)
+    # Calling twice must not raise.
+    ensure_schema(db)
+    ensure_schema(db)
+
+
+def test_payload_hash_is_stable() -> None:
+    a = _payload_hash({"x": 1, "y": 2})
+    b = _payload_hash({"y": 2, "x": 1})  # key order differs
+    c = _payload_hash({"x": 1, "y": 3})
+    assert a == b
+    assert a != c
+
+
+def test_known_job_types_are_registered_by_default(tmp_path: Path) -> None:
+    db = _db(tmp_path)
+    pool = WorkerPool(db)
+    # All four stubs come pre-registered.
+    assert SYNTHESIZE_META_RULES in pool._handlers
+    assert APPLY_DECAY in pool._handlers
+    assert CONSOLIDATE_EVENTS in pool._handlers
+    assert DP_EXPORT in pool._handlers
+
+
+# ── Enqueue + drain ─────────────────────────────────────────────────────
+
+
+def test_enqueue_and_drain_runs_handler(tmp_path: Path) -> None:
+    db = _db(tmp_path)
+    clock = FakeClock()
+    seen: list[Job] = []
+
+    def handler(job: Job) -> None:
+        seen.append(job)
+
+    pool = WorkerPool(db, clock=clock, handlers={APPLY_DECAY: handler})
+    job_id = pool.enqueue(APPLY_DECAY, {"reason": "nightly"})
+    assert job_id is not None and job_id > 0
+
+    assert pool.drain_once() is True
+    assert pool.drain_once() is False  # queue now empty
+
+    assert len(seen) == 1
+    assert seen[0].type == APPLY_DECAY
+    assert seen[0].payload == {"reason": "nightly"}
+
+
+def test_module_level_enqueue_job_helper(tmp_path: Path) -> None:
+    db = _db(tmp_path)
+    job_id = enqueue_job(db, CONSOLIDATE_EVENTS, {"window": "24h"})
+    assert job_id is not None
+
+    calls: list[Job] = []
+    pool = WorkerPool(db, handlers={CONSOLIDATE_EVENTS: lambda j: calls.append(j)})
+    assert pool.drain_once() is True
+    assert len(calls) == 1
+    assert calls[0].payload == {"window": "24h"}
+
+
+# ── Dedup ───────────────────────────────────────────────────────────────
+
+
+def test_dedup_same_type_and_payload_collapses_to_one_handler_call(tmp_path: Path) -> None:
+    db = _db(tmp_path)
+    calls: list[Job] = []
+
+    def handler(job: Job) -> None:
+        calls.append(job)
+
+    pool = WorkerPool(db, handlers={SYNTHESIZE_META_RULES: handler})
+
+    first = pool.enqueue(SYNTHESIZE_META_RULES, {"window": "session_end"})
+    second = pool.enqueue(SYNTHESIZE_META_RULES, {"window": "session_end"})
+    third = pool.enqueue(SYNTHESIZE_META_RULES, {"window": "session_end"})
+
+    assert first is not None
+    # Duplicates while the first is still pending return None (deduped).
+    assert second is None
+    assert third is None
+
+    # Drain everything. Should run exactly once.
+    assert pool.drain_once() is True
+    assert pool.drain_once() is False
+    assert len(calls) == 1
+
+
+def test_dedup_distinct_payloads_both_run(tmp_path: Path) -> None:
+    db = _db(tmp_path)
+    calls: list[Job] = []
+    pool = WorkerPool(db, handlers={APPLY_DECAY: lambda j: calls.append(j)})
+
+    a = pool.enqueue(APPLY_DECAY, {"half_life_days": 7})
+    b = pool.enqueue(APPLY_DECAY, {"half_life_days": 30})
+    assert a is not None and b is not None and a != b
+
+    assert pool.drain_once() is True
+    assert pool.drain_once() is True
+    assert pool.drain_once() is False
+    assert len(calls) == 2
+
+
+def test_dedup_releases_after_completion(tmp_path: Path) -> None:
+    """Once a job is done, an identical payload can be enqueued again."""
+    db = _db(tmp_path)
+    calls: list[Job] = []
+    pool = WorkerPool(db, handlers={DP_EXPORT: lambda j: calls.append(j)})
+
+    first = pool.enqueue(DP_EXPORT, {"epsilon": 1.0})
+    assert first is not None
+    assert pool.drain_once() is True  # marks done, frees the dedup slot
+
+    second = pool.enqueue(DP_EXPORT, {"epsilon": 1.0})
+    assert second is not None and second != first
+    assert pool.drain_once() is True
+
+    assert len(calls) == 2
+
+
+# ── Unknown type + handler error ────────────────────────────────────────
+
+
+def test_unknown_job_type_marked_failed(tmp_path: Path) -> None:
+    db = _db(tmp_path)
+    pool = WorkerPool(db, handlers={})  # explicitly empty
+    pool.enqueue("MYSTERY_JOB", {})
+    assert pool.drain_once() is True  # it processed (and failed) the row
+    assert pool.drain_once() is False
+
+
+def test_handler_exception_marks_failed_but_does_not_crash_pool(tmp_path: Path) -> None:
+    db = _db(tmp_path)
+
+    def bad(_job: Job) -> None:
+        raise RuntimeError("boom")
+
+    def good(job: Job) -> None:
+        calls.append(job)
+
+    calls: list[Job] = []
+    pool = WorkerPool(db, handlers={APPLY_DECAY: bad, DP_EXPORT: good})
+    pool.enqueue(APPLY_DECAY, {})
+    pool.enqueue(DP_EXPORT, {})
+
+    assert pool.drain_once() is True  # bad one fails silently
+    assert pool.drain_once() is True  # good one still runs
+    assert len(calls) == 1
+
+
+# ── Shutdown / drain deadline ───────────────────────────────────────────
+
+
+def test_should_exit_respects_drain_deadline(tmp_path: Path) -> None:
+    """With stop requested and the deadline passed, the pool exits even if
+    the queue still has work. This is the graceful-shutdown contract.
+    """
+    db = _db(tmp_path)
+    clock = FakeClock()
+    pool = WorkerPool(db, clock=clock)
+
+    # Enqueue a job but don't drain it — queue has pending work.
+    pool.enqueue(APPLY_DECAY, {"still": "pending"})
+
+    # Not stopping yet: _should_exit is False regardless of work.
+    assert pool._should_exit() is False
+
+    # Stop requested, deadline in the future, work still pending -> keep going.
+    pool._stop_event.set()
+    pool._drain_deadline = clock.mono() + 10.0
+    assert pool._should_exit() is False
+
+    # Deadline reached -> exit even though a job is still pending.
+    clock.advance(11.0)
+    assert pool._should_exit() is True
+
+
+def test_should_exit_returns_true_when_queue_empty_and_stop_requested(tmp_path: Path) -> None:
+    db = _db(tmp_path)
+    clock = FakeClock()
+    pool = WorkerPool(db, clock=clock)
+
+    pool._stop_event.set()
+    pool._drain_deadline = clock.mono() + 10.0
+    # No work, stop set, deadline not hit -> still exit (nothing to drain).
+    assert pool._should_exit() is True
+
+
+def test_stop_without_start_is_noop(tmp_path: Path) -> None:
+    db = _db(tmp_path)
+    pool = WorkerPool(db)
+    pool.stop()  # must not raise


### PR DESCRIPTION
## Summary
Adds a background worker pool to the existing HTTP daemon. SQLite-backed `worker_jobs` queue, unique partial index for race-free dedup, 4 handler stubs ready for downstream PRs to implement.

## Files
- `src/gradata/_workers.py` (new) — `WorkerPool`, `Job`, `enqueue_job`, schema
- `src/gradata/daemon.py` — +14 lines, instantiates pool on `start()`, 5s drain on `_cleanup()`
- `tests/test_workers.py` — 13 tests (fake clock, no time.sleep)

## Handler stubs registered (no-op-with-logging)
- `SYNTHESIZE_META_RULES`, `APPLY_DECAY`, `CONSOLIDATE_EVENTS`, `DP_EXPORT`

Real implementations land in follow-up PRs from domain-owning worktrees via `pool.register(type, handler)`.

## Tests
2270 pass (+13), ruff clean.

## Commits
- `901e02d` feat(daemon): background worker queue
- `296662f` refactor(workers): collapse stub handlers into factory, merge finalize, unify schema (530→374 LOC, −29%)

Co-Authored-By: Gradata <noreply@gradata.ai>