### PR TITLE
chore: align gradata-install to v0.5.0 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,54 @@
 # Changelog
 
-## [0.5.0] - 2026-04-10
+## [0.5.0] - 2026-04-15
+
+First public release. Aligns `gradata-install` npm wrapper to 0.5.0.
 
 ### Added
 
 - Self-healing engine: rule failure detection + auto-patching (PR #21)
-- Cloud backend: Supabase schema, FastAPI sync endpoint, Railway deploy config (PR #22)
-- Wiki-aware rule injection: semantic boost from qmd wiki pages
-- Notification system: `brain.on_notification()` API with 5 event formatters
-- Supabase wiki store: pgvector semantic search for cloud rule injection
+- Cloud backend: Supabase schema, FastAPI sync endpoint, Railway deploy (PR #22)
+- Wiki-aware rule injection with qmd semantic boost, Supabase wiki store (pgvector)
+- `brain.on_notification()` API with 5 event formatters
 - 19 Python hooks + installer + profile system (PR #20)
-
-### Fixed
-
-- 210 ruff errors across 106 files
-- Bandit false positives suppressed with explanations
-- Flaky graduation test stabilized for Python 3.12
-- CodeRabbit review findings across PRs #20, #21, #22
+- Team, operator, seed, and health endpoints ([#28](https://github.com/Gradata/gradata/pull/28))
+- Emails, legal pages, and auto-deploy CI ([#27](https://github.com/Gradata/gradata/pull/27))
+- Rule-to-hook UX: list, remove, events, stale detection ([#30](https://github.com/Gradata/gradata/pull/30))
+- `Brain.add_rule` API, runner profile gating, codex/cline/continue exports ([#31](https://github.com/Gradata/gradata/pull/31))
+- Middleware adapters for OpenAI, Anthropic, LangChain, CrewAI ([#32](https://github.com/Gradata/gradata/pull/32))
+- Rate limiting, Sentry wiring, and Stripe webhook hardening ([#33](https://github.com/Gradata/gradata/pull/33))
+- Dashboard wired to real backend for team, operator, and clear-demo flows ([#34](https://github.com/Gradata/gradata/pull/34))
+- GDPR data endpoints, DPA/SLA, security.txt, incident runbook ([#36](https://github.com/Gradata/gradata/pull/36))
+- Plausible analytics on marketing site plus opt-in SDK telemetry ([#37](https://github.com/Gradata/gradata/pull/37))
+- Full mkdocs Material docs site for gradata.ai/docs ([#38](https://github.com/Gradata/gradata/pull/38))
+- Session-start hook injects meta-rules into LLM context ([#45](https://github.com/Gradata/gradata/pull/45))
+- Honest A/B proof: `/public/proof` endpoint and ablation export ([#44](https://github.com/Gradata/gradata/pull/44))
+- Outcome-first dashboard pivot driven by sim data ([#46](https://github.com/Gradata/gradata/pull/46))
+- Visual graduation markers on the decay curve ([#47](https://github.com/Gradata/gradata/pull/47))
+- `gradata-install` npm wrapper for one-command install ([#52](https://github.com/Gradata/gradata/pull/52))
+- Claude Code plugin for `/plugin install gradata` ([#53](https://github.com/Gradata/gradata/pull/53))
 
 ### Changed
 
-- CI: added ruff>=0.4 to dev dependencies
-- CI: fixed sdk-ci.yml paths (removed stale working-directory)
+- Simplify pass across core SDK, enhancements layer, and cloud infra ([#40](https://github.com/Gradata/gradata/pull/40), [#41](https://github.com/Gradata/gradata/pull/41), [#42](https://github.com/Gradata/gradata/pull/42))
+- Simplify pass on tracked-ops brain scripts ([#39](https://github.com/Gradata/gradata/pull/39))
+- Rule-to-hook dispatcher: bundle N generated hooks into one for ~6x latency win ([#35](https://github.com/Gradata/gradata/pull/35))
+- Pre-public repo cleanup and launch narrative docs ([#49](https://github.com/Gradata/gradata/pull/49), [#50](https://github.com/Gradata/gradata/pull/50))
+- Populate `rule_patches` from `RULE_PATCHED` events in `/sync` ([#43](https://github.com/Gradata/gradata/pull/43))
+- Remove orphaned `gradata-plugin/` subdir ([#54](https://github.com/Gradata/gradata/pull/54))
+
+### Fixed
+
+- Resolve 10 pyright type errors blocking CI ([#29](https://github.com/Gradata/gradata/pull/29))
+- Add missing `export_ab_proof.py` script for proof pipeline ([#48](https://github.com/Gradata/gradata/pull/48))
+- GitHub now recognizes AGPL-3.0 license ([#58](https://github.com/Gradata/gradata/pull/58))
+- Move `LICENSE-NOTICE.md` to `docs/LICENSING.md` ([#59](https://github.com/Gradata/gradata/pull/59))
+- 210 ruff errors across 106 files; bandit false-positive suppression; flaky graduation test on 3.12
+
+### Infrastructure
+
+- Ship full AGPL-3.0 license text ([#51](https://github.com/Gradata/gradata/pull/51))
+- Add `ruff>=0.4` to dev dependencies; clean up stale `working-directory` in sdk-ci.yml
 
 ## [0.4.0] - 2026-04-06
 

--- a/docs/RELEASE-v0.5.0-DRAFT.md
+++ b/docs/RELEASE-v0.5.0-DRAFT.md
@@ -1,0 +1,93 @@
+# Release v0.5.0 Draft
+
+This doc holds the notes to paste into the GitHub Release form when cutting
+`v0.5.0`, plus the commands Oliver should run **after this PR and PR #60
+(publish workflows) are merged**.
+
+Do not tag before merge — the tag must point at the merge commit on `main`,
+not at this branch's HEAD.
+
+---
+
+## Prerequisites
+
+1. This PR (`chore/align-versions-v0.5.0`) merged to `main`.
+2. PR #60 (PyPI + npm publish workflows) merged to `main`.
+   - Heads-up: PR #60's body flags a conflict with the existing `sdk-release.yml`.
+     Resolve that before tagging, or the release job will double-publish /
+     fight itself. Either delete `sdk-release.yml` or make it a no-op on tags
+     that the new workflow already handles.
+3. `main` is green in CI.
+
+## Cut the release
+
+```bash
+git checkout main
+git pull origin main
+git tag -s v0.5.0 -m "gradata v0.5.0"
+git push origin v0.5.0
+```
+
+If you don't sign tags, drop `-s`:
+
+```bash
+git tag v0.5.0 && git push --tags
+```
+
+Pushing the tag triggers the publish workflows introduced in PR #60:
+
+- **PyPI**: builds `gradata==0.5.0` and publishes via OIDC / trusted publisher.
+- **npm**: publishes `gradata-install@0.5.0` (now aligned to the Python SDK).
+
+Watch the Actions tab — if either job fails, the tag is still valid; re-run
+the failed job after fixing.
+
+## GitHub Release notes (paste this into the form)
+
+Title: `v0.5.0 — First public release`
+
+Tag: `v0.5.0`
+
+Body:
+
+```markdown
+First public release of Gradata — the learning layer for AI agents.
+
+## What's in 0.5.0
+
+- **Graduation pipeline**: corrections → instincts → patterns → rules, with
+  meta-rule synthesis on top.
+- **Self-healing**: rule failure detection + auto-patching.
+- **Cloud backend**: Supabase schema, FastAPI `/sync`, Railway-ready deploy,
+  Stripe webhooks, rate limiting, Sentry.
+- **Middleware adapters**: OpenAI, Anthropic, LangChain, CrewAI — drop-in.
+- **Claude Code plugin**: `/plugin install gradata`.
+- **npm wrapper**: `npx gradata-install` for one-command setup.
+- **Docs site**: full mkdocs Material at gradata.ai/docs.
+- **A/B proof**: `/public/proof` endpoint with ablation export showing
+  +13.2% quality lift over baseline.
+- **GDPR + security**: data endpoints, DPA/SLA, security.txt, incident runbook.
+
+See [CHANGELOG.md](https://github.com/Gradata/gradata/blob/main/CHANGELOG.md#050---2026-04-15)
+for the full list.
+
+## Install
+
+```bash
+pipx install gradata
+# or
+npx gradata-install
+```
+
+## License
+
+AGPL-3.0-or-later. Full text in `LICENSE`. See `docs/LICENSING.md` for the
+dual-license story (AGPL for community, commercial for closed-source use).
+```
+
+## After the release
+
+- [ ] Verify `pip install gradata==0.5.0` works from a clean env.
+- [ ] Verify `npx gradata-install@0.5.0` prints the expected banner.
+- [ ] Announce in Discord + on the marketing site changelog page.
+- [ ] Update `docs/changelog.md` if it drifted from `CHANGELOG.md`.

--- a/gradata-install/package.json
+++ b/gradata-install/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gradata-install",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "description": "One-command installer for Gradata. Wraps pip/pipx + IDE hook setup.",
   "bin": {
     "gradata-install": "./bin/gradata-install.js"
@@ -9,6 +9,10 @@
     "type": "git",
     "url": "git+https://github.com/Gradata/gradata.git",
     "directory": "gradata-install"
+  },
+  "homepage": "https://github.com/Gradata/gradata#readme",
+  "bugs": {
+    "url": "https://github.com/Gradata/gradata/issues"
   },
   "license": "AGPL-3.0-or-later",
   "engines": { "node": ">=18" },


### PR DESCRIPTION
Aligns `gradata-install` npm wrapper version with the Python SDK (both at 0.5.0). Adds a 0.5.0 CHANGELOG entry summarizing ~30 PRs merged since going public.

## Changes

- `gradata-install/package.json`: version `0.1.0` to `0.5.0`, adds `homepage` and `bugs` fields pointing at `Gradata/gradata`.
- `CHANGELOG.md`: replaces placeholder `[0.5.0] - 2026-04-10` block with consolidated `[0.5.0] - 2026-04-15` entry covering PRs #27 through #59 (Added / Changed / Fixed / Infrastructure sections, Keep-a-Changelog format).
- `docs/RELEASE-v0.5.0-DRAFT.md`: release notes + tagging commands for Oliver to use after this PR and PR #60 (publish workflows) merge.

## Why

No GitHub Releases exist yet. pyproject.toml was already at 0.5.0 but the npm wrapper was still at 0.1.0. Aligning before the first tag so PyPI and npm ship matching versions.

## Not in this PR

- **No tag is pushed**. Tagging happens after merge, by Oliver, once PR #60 (PyPI + npm publish workflows) also lands. See `docs/RELEASE-v0.5.0-DRAFT.md` for the exact commands.
- `pyproject.toml` is untouched — already 0.5.0.
- No `src/` or `cloud/` code changed.

## Verification

- `pytest tests/ -x -q` locally: 2257 passed, 23 skipped. Docs + version bump is behavior-neutral.