### PR TITLE
feat(meta_rules): DP-noise scaffold (off-by-default) for marketplace export path

### DIFF
--- a/cloud/app/routes/meta_rules.py
+++ b/cloud/app/routes/meta_rules.py
@@ -1,17 +1,65 @@
-"""GET /brains/{brain_id}/meta-rules — universal principles from 3+ lessons."""
+"""GET /brains/{brain_id}/meta-rules — universal principles from 3+ lessons.
+
+When the marketplace cross-brain sharing path is enabled (Phase 4), meta-rule
+rows are compressed behavioral fingerprints and vulnerable to Carlini-style
+membership-inference extraction.  The optional differential-privacy scaffold
+below (``_load_dp_config`` + :func:`apply_dp_to_export_row`) perturbs numerical
+fields and suppresses raw text fields before release.  It is OFF BY DEFAULT;
+marketplace ops must explicitly set ``GRADATA_DP_ENABLED=true`` to turn it on.
+
+References:
+    - Dwork & Roth 2014: https://www.cis.upenn.edu/~aaroth/Papers/privacybook.pdf
+    - Abadi et al. 2016: https://arxiv.org/abs/1607.00133
+"""
 
 from __future__ import annotations
 
+import copy
 import logging
+import os
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, Query
 
 from app.auth import get_brain_for_request
 from app.db import get_db
 
+# SDK-side scaffold: DPConfig + Laplace-mechanism row transformer.
+from gradata.enhancements.meta_rules_storage import (
+    DPConfig,
+    apply_dp_to_export_row,
+)
+
 _log = logging.getLogger(__name__)
+_audit_log = logging.getLogger("gradata.audit.dp_export")
 
 router = APIRouter()
+
+
+def _load_dp_config() -> DPConfig:
+    """Read DP settings from env.  All vars prefixed ``GRADATA_DP_``.
+
+    Off by default — only flipping ``GRADATA_DP_ENABLED=true`` turns on
+    noise injection.  Epsilon/clip defaults match the DPConfig dataclass
+    (ε=1.0, clip_norm=1.0).  Note: a per-brain ε-budget tracker is NOT
+    yet implemented; see the COMPOSITION WARNING in meta_rules_storage.py.
+    """
+    enabled = os.environ.get("GRADATA_DP_ENABLED", "").lower() in {"1", "true", "yes"}
+    try:
+        epsilon = float(os.environ.get("GRADATA_DP_EPSILON", "1.0"))
+    except ValueError:
+        epsilon = 1.0
+    try:
+        clip_norm = float(os.environ.get("GRADATA_DP_CLIP_NORM", "1.0"))
+    except ValueError:
+        clip_norm = 1.0
+    mechanism = os.environ.get("GRADATA_DP_MECHANISM", "laplace")
+    return DPConfig(
+        enabled=enabled,
+        epsilon=epsilon,
+        mechanism=mechanism,
+        clip_norm=clip_norm,
+    )
 
 
 @router.get("/brains/{brain_id}/meta-rules")
@@ -25,6 +73,11 @@ async def list_meta_rules(
     Returns the meta_rules table joined with source lesson counts. Does NOT
     return raw correction text — only synthesized principles (per privacy
     posture: raw corrections never leave the device).
+
+    When ``GRADATA_DP_ENABLED=true``, each row is passed through
+    :func:`apply_dp_to_export_row` before return: numerical fields get
+    Laplace noise, raw text fields are suppressed, and an audit-log entry
+    records the brain_id, epsilon, timestamp, and exported-row count.
     """
     db = get_db()
     rows = await db.select(
@@ -33,4 +86,25 @@ async def list_meta_rules(
         filters={"brain_id": brain["id"]},
     )
     rows.sort(key=lambda r: r.get("created_at") or "", reverse=True)
-    return rows[offset : offset + limit]
+    page = rows[offset : offset + limit]
+
+    dp_config = _load_dp_config()
+    if dp_config.enabled:
+        # Deep-copy so we never mutate the DB-layer cache / upstream objects.
+        page = [apply_dp_to_export_row(copy.deepcopy(r), dp_config) for r in page]
+        # Audit: record every DP-perturbed export so marketplace ops can
+        # later reconstruct a per-brain ε-budget ledger (Dwork & Roth §3.5
+        # basic composition).  Today we log; Phase 4 will persist + enforce.
+        _audit_log.info(
+            "dp_export",
+            extra={
+                "brain_id": brain["id"],
+                "epsilon": dp_config.epsilon,
+                "mechanism": dp_config.mechanism,
+                "clip_norm": dp_config.clip_norm,
+                "rows_exported": len(page),
+                "timestamp": datetime.now(UTC).isoformat(),
+            },
+        )
+
+    return page

--- a/cloud/tests/test_new_routes.py
+++ b/cloud/tests/test_new_routes.py
@@ -54,6 +54,56 @@ class TestMetaRulesEndpoint:
         assert resp.status_code == 200
         assert len(resp.json()) == 3
 
+    def test_dp_off_by_default_passes_text_through(
+        self, client, mock_supabase, auth_headers, valid_bearer_patches, monkeypatch,
+    ):
+        """When GRADATA_DP_ENABLED is unset, raw description + lesson IDs pass through.
+
+        This is the current (pre-marketplace) behavior.  Confirms the DP
+        scaffold is truly off-by-default.
+        """
+        monkeypatch.delenv("GRADATA_DP_ENABLED", raising=False)
+        mock_supabase.add_response("meta_rules", "select", [
+            {"id": "m1", "brain_id": "brain-1", "title": "plain",
+             "description": "raw principle text",
+             "source_lesson_ids": ["l1", "l2", "l3"],
+             "created_at": "2026-04-10T00:00:00Z"},
+        ])
+        resp = client.get("/api/v1/brains/brain-1/meta-rules", headers=auth_headers)
+        assert resp.status_code == 200
+        row = resp.json()[0]
+        assert row["description"] == "raw principle text"
+        assert row["source_lesson_ids"] == ["l1", "l2", "l3"]
+
+    def test_dp_on_suppresses_text_and_noises_counts(
+        self, client, mock_supabase, auth_headers, valid_bearer_patches, monkeypatch,
+    ):
+        """Flipping GRADATA_DP_ENABLED=true must suppress text and noise counts.
+
+        Covers the adversary-relevant export path: with DP on, raw
+        principle text must NOT leak and the source-lesson cardinality
+        must be replaced by a noised integer (not the raw count).
+        """
+        monkeypatch.setenv("GRADATA_DP_ENABLED", "true")
+        monkeypatch.setenv("GRADATA_DP_EPSILON", "1.0")
+        monkeypatch.setenv("GRADATA_DP_CLIP_NORM", "1.0")
+        mock_supabase.add_response("meta_rules", "select", [
+            {"id": "m1", "brain_id": "brain-1", "title": "t",
+             "description": "SENSITIVE OPERATOR FINGERPRINT",
+             "source_lesson_ids": ["l1", "l2", "l3", "l4", "l5"],
+             "created_at": "2026-04-10T00:00:00Z"},
+        ])
+        resp = client.get("/api/v1/brains/brain-1/meta-rules", headers=auth_headers)
+        assert resp.status_code == 200
+        row = resp.json()[0]
+        # Text field MUST be suppressed under DP — Laplace doesn't cover NL.
+        assert row["description"] == "[DP-SUPPRESSED]"
+        # Raw IDs MUST be dropped; a noised cardinality is exposed instead.
+        assert row["source_lesson_ids"] == []
+        assert "source_lesson_count" in row
+        assert isinstance(row["source_lesson_count"], int)
+        assert row["source_lesson_count"] >= 0
+
 
 class TestActivityEndpoint:
     def test_filters_to_visible_types_only(self, client, mock_supabase, auth_headers, valid_bearer_patches):

--- a/src/gradata/enhancements/meta_rules_storage.py
+++ b/src/gradata/enhancements/meta_rules_storage.py
@@ -3,14 +3,28 @@ Meta-Rule SQLite Persistence — load/save for meta_rules and super_meta_rules t
 =====================================================================================
 All database I/O for meta-rules lives here.  Core logic and discovery live in
 ``meta_rules.py``; tier-2/3 super-meta-rule logic lives in ``super_meta_rules.py``.
+
+Also exposes a *differential-privacy scaffold* (:class:`DPConfig`,
+:func:`apply_dp_to_export_row`) used by the cloud export path when meta-rules
+are shared across brains.  The scaffold is OFF by default.  See
+``cloud/app/routes/meta_rules.py`` for the integration point and
+:func:`apply_dp_to_export_row` for the security model + composition caveats.
+
+References:
+  - Dwork & Roth 2014, "Algorithmic Foundations of Differential Privacy"
+    https://www.cis.upenn.edu/~aaroth/Papers/privacybook.pdf
+  - Abadi et al. 2016, "Deep Learning with Differential Privacy"
+    https://arxiv.org/abs/1607.00133
 """
 
 from __future__ import annotations
 
 import contextlib
 import json
+import random
 import sqlite3
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 
 from gradata._types import RuleTransferScope
 from gradata.enhancements.meta_rules import TIER_SUPER_META, MetaRule, SuperMetaRule
@@ -451,6 +465,193 @@ def upsert_correction_patterns_batch(
         return len(rows)
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Differential-Privacy Export Scaffold (off by default)
+# ---------------------------------------------------------------------------
+#
+# Meta-rules are compressed behavioral fingerprints by construction: they
+# encode *what a specific operator consistently corrects*.  If marketplace
+# consumers can query meta-rules across brains without perturbation, a
+# Carlini-style membership-inference attack (Carlini et al. 2021; see also
+# Dwork & Roth 2014 §1.1 "reconstruction attacks") becomes trivial — a
+# sufficiently motivated consumer learns, at minimum, which correction
+# categories a brain's operator cares about, and at worst, recovers
+# verbatim principle text that may contain private context.
+#
+# Today ε = ∞ (no noise, no DP, raw aggregation).  This scaffold lets
+# marketplace (Phase 4) flip on Laplace-mechanism perturbation via a
+# single config toggle.  It is deliberately *off-by-default* — no current
+# API path is affected unless DPConfig.enabled is explicitly True.
+#
+# COMPOSITION WARNING (adversary check):
+#   Basic sequential composition (Dwork & Roth 2014 Theorem 3.16): K
+#   ε-DP queries compose to Kε.  With ε=1.0 and a marketplace consumer
+#   querying 100 meta-rules from the same brain, the effective ε is
+#   **100.0** — i.e. essentially no privacy.  Defenses require one of:
+#     (a) a per-brain ε-budget tracker that blocks queries once spent,
+#     (b) approximate (ε, δ)-DP with advanced composition
+#         (Theorem 3.20: ε' ≈ √(2K·ln(1/δ'))·ε),
+#     (c) RDP / moments-accountant per Abadi et al. 2016 §3, suitable for
+#         Gaussian mechanism and much tighter for repeated queries.
+#   This scaffold implements (a)'s audit-log hook but does NOT yet
+#   enforce budgets — that's Phase 4 marketplace work.  Consumers that
+#   flip DP on in production MUST add budget enforcement before
+#   exposing the endpoint to untrusted clients.
+
+
+@dataclass
+class DPConfig:
+    """Configuration for differential-privacy noise on meta-rule exports.
+
+    Off by default.  Flip ``enabled=True`` to apply the Laplace mechanism
+    (Dwork et al. 2006) to numerical fields and suppress raw text fields
+    on the cloud export path.
+
+    Attributes:
+        enabled: Master switch.  When False, :func:`apply_dp_to_export_row`
+            is a no-op — rows pass through unchanged.  Default: ``False``.
+        epsilon: Privacy budget *per query*.  Smaller = more noise = more
+            privacy.  Default ``1.0``.  Note that composition across K
+            queries yields Kε under basic composition — see module-level
+            COMPOSITION WARNING above.
+        mechanism: Noise mechanism identifier.  Currently only
+            ``"laplace"`` is implemented; ``"gaussian"`` is reserved for
+            RDP accounting (Abadi et al. 2016) when marketplace ships.
+        clip_norm: Per-field L1 clipping bound applied *before* noise.
+            Bounds the sensitivity of numerical fields (confidence,
+            fire_count, source counts) to ``clip_norm`` so the Laplace
+            scale ``sensitivity/epsilon`` is well-defined.  Default
+            ``1.0`` — matches the natural [0, 1] range of ``confidence``.
+    """
+
+    enabled: bool = False
+    epsilon: float = 1.0
+    mechanism: str = "laplace"
+    clip_norm: float = 1.0
+
+
+def _laplace_noise(scale: float, rng: random.Random) -> float:
+    """Draw a sample from Laplace(0, scale).
+
+    Inverse-CDF method: if U ~ Uniform(-0.5, 0.5), then
+    ``-scale * sign(U) * log(1 - 2|U|)`` is Laplace(0, scale).  Using a
+    ``random.Random`` instance lets callers pass ``random.SystemRandom``
+    in production; tests use a seeded PRNG for reproducibility.
+    """
+    import math
+    u = rng.random() - 0.5
+    if u == 0:
+        return 0.0
+    return -scale * math.copysign(1.0, u) * math.log(1.0 - 2.0 * abs(u))
+
+
+def _clip(value: float, bound: float) -> float:
+    """Clip a value to [-bound, bound].  Required before Laplace noise
+    so the per-field sensitivity ≤ ``bound``."""
+    return max(-bound, min(bound, value))
+
+
+def apply_dp_to_export_row(
+    row: dict[str, Any],
+    config: DPConfig,
+    *,
+    rng: random.Random | None = None,
+) -> dict[str, Any]:
+    """Transform a meta-rule export row in-place for DP-safe release.
+
+    When ``config.enabled`` is False (the default), returns ``row``
+    unchanged — this function is a scaffold, not an enforcement layer.
+
+    When enabled, applies the Laplace mechanism (Dwork et al. 2006) to
+    numerical fields and strips raw text fields:
+
+    **Numerical fields** (``confidence``, ``fire_count``, any integer
+    source-count derived from ``source_lesson_ids``):
+        1. Clip to ``[-clip_norm, clip_norm]`` to bound sensitivity.
+        2. Add Laplace noise with scale ``clip_norm / epsilon``.
+        3. ``round``/``max(0, …)`` to preserve type sanity.  This is
+           post-processing (Dwork & Roth 2014 Proposition 2.1) and does
+           not weaken the DP guarantee.
+
+    **Text fields** (``principle``, ``description``, ``examples``,
+    ``representative_text``): raw text is **replaced with a placeholder
+    under DP**.  The Laplace mechanism is defined for numerical queries;
+    releasing raw natural-language text from a behavioral fingerprint
+    would leak high-entropy operator-identifying content that no
+    per-query noise can meaningfully mask.  Only *structural features*
+    (category, source count, tier, confidence bucket) are shared.  This
+    is a deliberate scoping choice, not DP itself — marketplace clients
+    should consume structural features only; text remains on-device.
+
+    Args:
+        row: A mutable dict representing one meta-rule as returned from
+            the cloud DB layer.  Must be safe to modify (copy upstream
+            if the caller reuses it).
+        config: DP configuration.  ``config.enabled=False`` -> no-op.
+        rng: Optional ``random.Random`` instance for noise draws.
+            Defaults to ``random.SystemRandom()`` for non-deterministic
+            draws in production.  Tests pass a seeded PRNG.
+
+    Returns:
+        The same ``row`` dict, mutated.  Returned for call-chaining.
+
+    Raises:
+        ValueError: If ``config.mechanism`` is not ``"laplace"`` (other
+            mechanisms reserved for future RDP accounting).
+    """
+    if not config.enabled:
+        return row
+
+    if config.mechanism != "laplace":
+        raise ValueError(
+            f"DPConfig.mechanism={config.mechanism!r} not implemented; "
+            "only 'laplace' is currently supported"
+        )
+    if config.epsilon <= 0:
+        raise ValueError(f"DPConfig.epsilon must be > 0, got {config.epsilon}")
+    if config.clip_norm <= 0:
+        raise ValueError(f"DPConfig.clip_norm must be > 0, got {config.clip_norm}")
+
+    if rng is None:
+        rng = random.SystemRandom()
+
+    scale = config.clip_norm / config.epsilon
+
+    # --- Numerical perturbation -------------------------------------------
+    if "confidence" in row and row["confidence"] is not None:
+        clipped = _clip(float(row["confidence"]), config.clip_norm)
+        noised = clipped + _laplace_noise(scale, rng)
+        # confidence is naturally in [0, 1]; clamp post-noise for display sanity
+        row["confidence"] = max(0.0, min(1.0, noised))
+
+    if "fire_count" in row and row["fire_count"] is not None:
+        clipped = _clip(float(row["fire_count"]), config.clip_norm)
+        noised = clipped + _laplace_noise(scale, rng)
+        # fire_count is a non-negative integer count
+        row["fire_count"] = max(0, round(noised))
+
+    # Source-count: replace list of IDs with a noised cardinality so we
+    # neither leak lesson IDs nor publish an un-noised count.
+    if "source_lesson_ids" in row:
+        ids = row.get("source_lesson_ids") or []
+        raw_count = len(ids) if isinstance(ids, list) else 0
+        clipped = _clip(float(raw_count), config.clip_norm)
+        noised = clipped + _laplace_noise(scale, rng)
+        row["source_lesson_count"] = max(0, round(noised))
+        row["source_lesson_ids"] = []  # never export raw IDs under DP
+
+    # --- Text suppression --------------------------------------------------
+    # Replace raw principle/description/examples with a structural token.
+    # See docstring for rationale — Laplace doesn't cover natural language.
+    for text_field in ("principle", "description", "representative_text"):
+        if row.get(text_field):
+            row[text_field] = "[DP-SUPPRESSED]"
+    if "examples" in row:
+        row["examples"] = []  # examples are verbatim correction text
+
+    return row
 
 
 def query_graduation_candidates(

--- a/tests/test_meta_rules.py
+++ b/tests/test_meta_rules.py
@@ -280,6 +280,110 @@ def test_with_real_data():
         print(f"Verified: loaded {len(loaded)} meta-rules back from DB")
 
 
+# ---------------------------------------------------------------------------
+# Differential-privacy export scaffold tests
+# ---------------------------------------------------------------------------
+
+import random as _random
+
+from gradata.enhancements.meta_rules_storage import (
+    DPConfig,
+    apply_dp_to_export_row,
+)
+
+
+def test_dp_config_defaults_are_off():
+    """DP must ship off-by-default; the dataclass is the source of truth."""
+    cfg = DPConfig()
+    assert cfg.enabled is False
+    assert cfg.epsilon == 1.0
+    assert cfg.mechanism == "laplace"
+    assert cfg.clip_norm == 1.0
+    print("[PASS] DPConfig defaults")
+
+
+def test_apply_dp_noop_when_disabled():
+    """With enabled=False the row must pass through untouched."""
+    row = {
+        "id": "m1",
+        "confidence": 0.87,
+        "fire_count": 12,
+        "principle": "raw operator fingerprint",
+        "source_lesson_ids": ["l1", "l2", "l3"],
+    }
+    original = dict(row)
+    result = apply_dp_to_export_row(row, DPConfig(enabled=False))
+    assert result == original
+    print("[PASS] DP off = identity")
+
+
+def test_apply_dp_enabled_suppresses_text_and_perturbs_numbers():
+    """With enabled=True text must be suppressed and numbers noised/clipped."""
+    rng = _random.Random(42)  # seeded for reproducibility
+    row = {
+        "id": "m1",
+        "confidence": 0.87,
+        "fire_count": 12,
+        "principle": "raw operator fingerprint",
+        "description": "also sensitive",
+        "representative_text": "verbatim correction",
+        "examples": ["ex1", "ex2"],
+        "source_lesson_ids": ["l1", "l2", "l3", "l4", "l5"],
+    }
+    cfg = DPConfig(enabled=True, epsilon=1.0, clip_norm=1.0)
+    result = apply_dp_to_export_row(row, cfg, rng=rng)
+
+    # Text fields: suppressed.
+    assert result["principle"] == "[DP-SUPPRESSED]"
+    assert result["description"] == "[DP-SUPPRESSED]"
+    assert result["representative_text"] == "[DP-SUPPRESSED]"
+    assert result["examples"] == []
+
+    # Source IDs: dropped; cardinality exposed as noised integer.
+    assert result["source_lesson_ids"] == []
+    assert isinstance(result["source_lesson_count"], int)
+    assert result["source_lesson_count"] >= 0
+
+    # Confidence: clamped to [0, 1] after noise.
+    assert 0.0 <= result["confidence"] <= 1.0
+
+    # fire_count: non-negative integer.
+    assert isinstance(result["fire_count"], int)
+    assert result["fire_count"] >= 0
+    print("[PASS] DP on = suppressed + noised")
+
+
+def test_apply_dp_noise_actually_perturbs_confidence():
+    """Flipping the flag must produce *different* outputs across draws.
+
+    Guards against a regression where someone stubs out the Laplace draw
+    but leaves the plumbing intact.
+    """
+    cfg = DPConfig(enabled=True, epsilon=0.5, clip_norm=1.0)
+    outputs = set()
+    for seed in range(20):
+        rng = _random.Random(seed)
+        row = {"id": "m", "confidence": 0.5, "fire_count": 10,
+               "principle": "x", "source_lesson_ids": ["a", "b"]}
+        out = apply_dp_to_export_row(row, cfg, rng=rng)
+        outputs.add(round(out["confidence"], 6))
+    # With ε=0.5 and 20 independent seeds, we expect many distinct values.
+    assert len(outputs) > 5, f"Expected noise variation, got {len(outputs)} distinct outputs"
+    print(f"[PASS] DP noise variation: {len(outputs)} distinct outputs across 20 seeds")
+
+
+def test_apply_dp_rejects_bad_config():
+    """ε must be > 0 and mechanism must be supported."""
+    row = {"id": "m", "confidence": 0.5}
+    with pytest.raises(ValueError):
+        apply_dp_to_export_row(row, DPConfig(enabled=True, epsilon=0.0))
+    with pytest.raises(ValueError):
+        apply_dp_to_export_row(row, DPConfig(enabled=True, mechanism="gaussian"))
+    with pytest.raises(ValueError):
+        apply_dp_to_export_row(row, DPConfig(enabled=True, clip_norm=-1.0))
+    print("[PASS] DP rejects bad config")
+
+
 if __name__ == "__main__":
     print("Running meta_rules unit tests...\n")
     test_parse_lessons()
@@ -289,6 +393,11 @@ if __name__ == "__main__":
     test_format_meta_rules()
     test_sqlite_roundtrip()
     test_refresh_meta_rules()
+    test_dp_config_defaults_are_off()
+    test_apply_dp_noop_when_disabled()
+    test_apply_dp_enabled_suppresses_text_and_perturbs_numbers()
+    test_apply_dp_noise_actually_perturbs_confidence()
+    test_apply_dp_rejects_bad_config()
 
     print("\n" + "="*60)
     print("Running against REAL lesson data...\n")


### PR DESCRIPTION
## Summary
Differential-privacy scaffold on the meta-rule export path. Flips on via `GRADATA_DP_ENABLED=true`. Today ε=∞, no noise, raw aggregation.

## What ships
- `DPConfig` dataclass + `apply_dp_to_export_row` in `meta_rules_storage.py` (Laplace mechanism, text-field suppression, clip-norm bounded sensitivity)
- `cloud/app/routes/meta_rules.py` `list_meta_rules` endpoint wired with flag + audit log
- SDK unit tests + cloud route test proving flag behavior

## Security context
Meta-rules are compressed behavioral fingerprints. Carlini-style membership-inference extraction risk (A8) becomes trivial on cross-brain marketplace consumers without noise. This PR ships the gate; Phase 4 ships the enforcement.

## Composition warning (in code)
Basic sequential composition (Dwork & Roth 2014 Theorem 3.16): 100 queries at ε=1.0 = effective ε=100. Production requires per-brain ε-budget tracker OR RDP accounting (Abadi et al. 2016). Scaffold only — marketplace deploy MUST add budget enforcement before exposing endpoint to untrusted clients.

## Tests
2262 pass. Ruff clean on new code (pre-existing errors in repo inherited verbatim).

## Refs
- Dwork & Roth 2014: https://www.cis.upenn.edu/~aaroth/Papers/privacybook.pdf
- Abadi et al. 2016: https://arxiv.org/abs/1607.00133

Co-Authored-By: Gradata <noreply@gradata.ai>