### PR TITLE
feat(scoped-brains): Brain.scope(domain) + sub-agent inheritance (Phase 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,8 +156,9 @@ templates/
 # examples/ — included for open source hygiene
 research/
 !docs/research/
-scripts/
+scripts/*
 !cloud/scripts/
+!scripts/migrate_legacy_scopes.py
 docs/cloud/
 docs/study-protocol.md
 

--- a/scripts/migrate_legacy_scopes.py
+++ b/scripts/migrate_legacy_scopes.py
@@ -1,0 +1,288 @@
+"""Migrate legacy lessons that lack ``scope_json.domain``.
+
+Council verdict 4/4 STRICT (Phase 2 scoped brains): the category-as-domain
+fallback has been removed from ``gradata._scoped_brain`` and
+``gradata.rules.rule_context``. Legacy lessons that relied on the fallback
+will no longer surface under ``brain.scope(<domain>)`` until their
+``scope_json.domain`` is populated.
+
+This script inspects a brain's ``lessons.md`` and, for each lesson whose
+``scope_json`` is empty OR missing a ``domain`` key:
+
+- if the lesson's ``category`` matches exactly one configured domain from
+  ``domains.yaml`` (or the inferred set of distinct categories in the file),
+  it rewrites ``scope_json`` to set ``domain = category.lower()``;
+- if the category is ambiguous (``MIXED``, ``OTHER``, ``GENERAL``, or
+  matches more than one configured domain), the lesson is flagged for
+  manual review and left untouched;
+- lessons whose ``scope_json.domain`` is already set are skipped.
+
+Usage::
+
+    # dry run (default)
+    python scripts/migrate_legacy_scopes.py --brain ./brain
+
+    # write changes
+    python scripts/migrate_legacy_scopes.py --brain ./brain --apply
+
+    # explicit domains list
+    python scripts/migrate_legacy_scopes.py --brain ./brain \\
+        --domains-file domains.yaml --apply
+
+No external deps beyond the SDK. ``domains.yaml`` support is optional; if
+PyYAML is not available the script falls back to inferring the domain set
+from the distinct ``category`` values present in the file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+# Make the SDK importable when the script is run from a checkout without
+# the package installed in editable mode.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SRC = _REPO_ROOT / "src"
+if _SRC.is_dir() and str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from gradata.enhancements.self_improvement import (
+    format_lessons,
+    parse_lessons,
+)
+
+if TYPE_CHECKING:
+    from gradata._types import Lesson
+
+logger = logging.getLogger("migrate_legacy_scopes")
+
+AMBIGUOUS_CATEGORIES: frozenset[str] = frozenset(
+    {"mixed", "other", "general", "misc", "unknown", ""}
+)
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MigrationResult:
+    migrated: int = 0
+    flagged: int = 0
+    skipped: int = 0
+    flagged_entries: list[tuple[str, str]] = None  # (category, description_snippet)
+
+    def __post_init__(self) -> None:
+        if self.flagged_entries is None:
+            self.flagged_entries = []
+
+    def as_dict(self) -> dict:
+        return {
+            "migrated": self.migrated,
+            "flagged": self.flagged,
+            "skipped": self.skipped,
+            "flagged_entries": list(self.flagged_entries),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Core planning logic (pure function, unit-tested)
+# ---------------------------------------------------------------------------
+
+
+def load_domain_set(
+    lessons: Iterable[Lesson],
+    domains_file: Path | None = None,
+) -> set[str]:
+    """Return the set of lower-cased valid domains.
+
+    If ``domains_file`` exists and PyYAML is available, the file is parsed
+    (expected to be a YAML list under key ``domains`` or a top-level list).
+    Otherwise the domain set is inferred from distinct, unambiguous
+    ``category`` values observed across ``lessons``.
+    """
+    if domains_file and domains_file.is_file():
+        try:
+            import yaml  # type: ignore[import-untyped]
+
+            data = yaml.safe_load(domains_file.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and "domains" in data:
+                data = data["domains"]
+            if isinstance(data, list):
+                return {str(d).strip().lower() for d in data if str(d).strip()}
+        except ImportError:
+            logger.warning(
+                "PyYAML not installed; falling back to inferred domain set."
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Could not parse %s: %s", domains_file, exc)
+
+    inferred: set[str] = set()
+    for l in lessons:
+        cat = (l.category or "").strip().lower()
+        if cat and cat not in AMBIGUOUS_CATEGORIES:
+            inferred.add(cat)
+    return inferred
+
+
+def _has_domain(lesson: Lesson) -> bool:
+    """True if the lesson already has scope_json.domain set."""
+    if not lesson.scope_json:
+        return False
+    try:
+        data = json.loads(lesson.scope_json)
+    except (json.JSONDecodeError, TypeError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    return bool(str(data.get("domain", "")).strip())
+
+
+def plan_migration(
+    lessons: list[Lesson],
+    domains: set[str],
+) -> tuple[list[Lesson], MigrationResult]:
+    """Return (new_lessons, result). Pure — does not touch disk.
+
+    New lessons list preserves order. Each lesson is either unchanged or
+    has a new ``scope_json`` with ``domain`` populated.
+    """
+    result = MigrationResult()
+    out: list[Lesson] = []
+
+    for l in lessons:
+        if _has_domain(l):
+            result.skipped += 1
+            out.append(l)
+            continue
+
+        cat = (l.category or "").strip().lower()
+        if cat in AMBIGUOUS_CATEGORIES or cat not in domains:
+            result.flagged += 1
+            result.flagged_entries.append((l.category or "", (l.description or "")[:80]))
+            out.append(l)
+            continue
+
+        # Unambiguous match: merge existing scope_json if any, add domain
+        merged: dict = {}
+        if l.scope_json:
+            try:
+                parsed = json.loads(l.scope_json)
+                if isinstance(parsed, dict):
+                    merged.update(parsed)
+            except (json.JSONDecodeError, TypeError):
+                pass
+        merged["domain"] = cat
+
+        # dataclasses are mutable by default; update in place via replacement
+        from dataclasses import replace
+
+        out.append(replace(l, scope_json=json.dumps(merged, sort_keys=True)))
+        result.migrated += 1
+
+    return out, result
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def _find_lessons_path(brain_dir: Path) -> Path:
+    """Locate lessons.md inside a brain directory."""
+    candidates = [brain_dir / "lessons.md", brain_dir / "brain" / "lessons.md"]
+    for c in candidates:
+        if c.is_file():
+            return c
+    raise FileNotFoundError(
+        f"No lessons.md found in {brain_dir} (tried: {[str(c) for c in candidates]})"
+    )
+
+
+def run_cli(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Migrate legacy lessons that lack scope_json.domain."
+    )
+    parser.add_argument(
+        "--brain",
+        type=Path,
+        default=Path("./brain"),
+        help="Path to the brain directory (contains lessons.md). Default: ./brain",
+    )
+    parser.add_argument(
+        "--domains-file",
+        type=Path,
+        default=None,
+        help="Optional YAML file listing valid domains. Falls back to inference.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write changes to lessons.md. Without this flag the script is a dry run.",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Verbose logging.",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(message)s",
+    )
+
+    try:
+        lessons_path = _find_lessons_path(args.brain)
+    except FileNotFoundError as exc:
+        logger.error("%s", exc)
+        return 2
+
+    raw = lessons_path.read_text(encoding="utf-8")
+    lessons = parse_lessons(raw)
+    domains = load_domain_set(lessons, args.domains_file)
+
+    if not domains:
+        logger.warning(
+            "No domains resolved (empty domains.yaml and no unambiguous categories). "
+            "All legacy lessons will be flagged."
+        )
+
+    new_lessons, result = plan_migration(lessons, domains)
+
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    logger.info("=== migrate_legacy_scopes [%s] ===", mode)
+    logger.info("brain: %s", args.brain)
+    logger.info("lessons.md: %s", lessons_path)
+    logger.info("domains: %s", sorted(domains) or "<empty>")
+    logger.info("total lessons: %d", len(lessons))
+    logger.info("  migrated: %d", result.migrated)
+    logger.info("  flagged for manual review: %d", result.flagged)
+    logger.info("  skipped (already had domain): %d", result.skipped)
+
+    if result.flagged_entries and args.verbose:
+        logger.debug("flagged entries:")
+        for cat, snippet in result.flagged_entries[:20]:
+            logger.debug("  [%s] %s", cat, snippet)
+
+    if args.apply and result.migrated > 0:
+        from gradata._db import write_lessons_safe
+
+        write_lessons_safe(lessons_path, format_lessons(new_lessons))
+        logger.info("wrote %d migrated lessons to %s", result.migrated, lessons_path)
+    elif not args.apply:
+        logger.info("(dry-run) re-run with --apply to write changes")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(run_cli())

--- a/src/gradata/__init__.py
+++ b/src/gradata/__init__.py
@@ -33,6 +33,7 @@ if _log_level in ("DEBUG", "INFO", "WARNING", "ERROR"):
     _logging.getLogger("gradata").setLevel(getattr(_logging, _log_level))
 
 from gradata._paths import BrainContext
+from gradata._scoped_brain import ScopedBrain
 from gradata._types import Lesson, LessonState, RuleTransferScope
 from gradata.brain import Brain
 from gradata.context_wrapper import brain_context
@@ -68,6 +69,7 @@ __all__ = [
     "LessonState",
     "Notification",
     "RuleTransferScope",
+    "ScopedBrain",
     "TaxonomyError",
     "ValidationError",
     "__version__",

--- a/src/gradata/_scoped_brain.py
+++ b/src/gradata/_scoped_brain.py
@@ -1,0 +1,283 @@
+"""
+ScopedBrain — A domain-scoped view over a parent Brain.
+========================================================
+SDK LAYER: Layer 0 (no enhancement deps). Filters the parent brain's
+graduated rules to those matching a domain, then delegates the rest of
+the API (correct, emit, search, memory, etc.) straight to the parent.
+
+Usage::
+
+    brain = Brain("./my-brain")
+    code_brain = brain.scope("code")
+    rules = code_brain.rules()          # only code-domain rules
+    prompt = code_brain.inject("fix bug")  # only code rules injected
+
+Domain match semantics (see ``lesson_matches_domain``):
+    A lesson belongs to domain ``D`` if ANY of the following holds:
+
+    1. ``scope_json.domain == D`` (exact match on the stored RuleScope).
+    2. ``scope_json.applies_to`` starts with ``f"{D}:"`` (e.g. ``"code:refactor"``
+       matches domain ``"code"``). Bare ``applies_to == D`` also matches.
+    3. ``lesson.category.lower() == D.lower()`` (category-as-domain fallback).
+
+    Matching is case-insensitive. This is a deliberately permissive OR so
+    legacy lessons (category-tagged only) still surface under a scoped view.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from gradata._types import Lesson
+    from gradata.brain import Brain
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Domain matching
+# ---------------------------------------------------------------------------
+
+
+def lesson_matches_domain(lesson: Lesson, domain: str) -> bool:
+    """Return True if ``lesson`` is in-scope for ``domain``.
+
+    See :mod:`gradata._scoped_brain` module docstring for the three-way
+    match rules. Empty ``domain`` matches everything (wildcard).
+    """
+    if not domain:
+        return True
+    d_norm = domain.strip().lower()
+    if not d_norm:
+        return True
+
+    # Rule 3: category fallback (cheapest check first)
+    if (lesson.category or "").strip().lower() == d_norm:
+        return True
+
+    # Rules 1 and 2: dig into scope_json
+    if lesson.scope_json:
+        try:
+            scope_data = json.loads(lesson.scope_json)
+        except (json.JSONDecodeError, TypeError):
+            scope_data = {}
+        if isinstance(scope_data, dict):
+            scope_domain = str(scope_data.get("domain", "") or "").strip().lower()
+            if scope_domain == d_norm:
+                return True
+            applies_to = str(scope_data.get("applies_to", "") or "").strip().lower()
+            if applies_to == d_norm or applies_to.startswith(f"{d_norm}:"):
+                return True
+
+    return False
+
+
+def filter_lessons_by_domain(lessons: list[Lesson], domain: str) -> list[Lesson]:
+    """Return the subset of ``lessons`` that match ``domain``."""
+    if not domain:
+        return list(lessons)
+    return [l for l in lessons if lesson_matches_domain(l, domain)]
+
+
+# ---------------------------------------------------------------------------
+# ScopedBrain proxy
+# ---------------------------------------------------------------------------
+
+
+class ScopedBrain:
+    """A domain-scoped view over a :class:`Brain`.
+
+    Attribute access is delegated to the parent brain for everything except
+    the rule-reading APIs, which are filtered by domain. The parent brain's
+    storage, event bus, and cloud connection are shared.
+    """
+
+    # Shared sentinel so sub-agents can detect they received a scoped brain
+    _gradata_scoped: bool = True
+
+    def __init__(self, parent: Brain, domain: str) -> None:
+        if not domain or not str(domain).strip():
+            raise ValueError("ScopedBrain requires a non-empty domain")
+        self._parent = parent
+        self._domain = str(domain).strip()
+
+    # ── Identity helpers ───────────────────────────────────────────────
+
+    @property
+    def domain(self) -> str:
+        return self._domain
+
+    @property
+    def parent(self) -> Brain:
+        return self._parent
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return f"ScopedBrain(domain='{self._domain}', parent={self._parent!r})"
+
+    # ── Filtered reads ─────────────────────────────────────────────────
+
+    def rules(self, *, include_all: bool = False, category: str | None = None) -> list[dict]:
+        """List graduated rules filtered to this scope's domain."""
+        all_rules = self._parent.rules(include_all=include_all, category=category)
+        return [r for r in all_rules if self._rule_dict_matches(r)]
+
+    def _rule_dict_matches(self, rule: dict) -> bool:
+        """Domain-match a dict as returned by ``list_rules``.
+
+        The inspection layer already serialises lessons to dicts; we re-derive
+        the match by loading the underlying Lesson via its rule_id. To keep
+        this cheap and dependency-free, we inspect dict fields directly.
+        """
+        d_norm = self._domain.lower()
+
+        # Category fallback
+        cat = str(rule.get("category", "")).lower()
+        if cat == d_norm:
+            return True
+
+        # Scope data lives under metadata.where_scope or a top-level scope key
+        # depending on the exporter. Probe both conservatively.
+        meta = rule.get("metadata") or {}
+        where = str(meta.get("where_scope", "")).lower() if isinstance(meta, dict) else ""
+        if where == d_norm:
+            return True
+
+        # Walk raw scope dict if present
+        for key in ("scope", "scope_json"):
+            raw = rule.get(key)
+            if not raw:
+                continue
+            if isinstance(raw, str):
+                try:
+                    raw = json.loads(raw)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+            if isinstance(raw, dict):
+                if str(raw.get("domain", "")).lower() == d_norm:
+                    return True
+                applies = str(raw.get("applies_to", "")).lower()
+                if applies == d_norm or applies.startswith(f"{d_norm}:"):
+                    return True
+
+        return False
+
+    def lessons(self) -> list[Lesson]:
+        """Return parsed :class:`Lesson` objects filtered to this domain.
+
+        Unlike :meth:`rules` (which returns dicts from the inspection layer),
+        this returns the raw Lesson dataclasses — useful for tests and
+        advanced filtering.
+        """
+        all_lessons = self._parent._load_lessons()
+        return filter_lessons_by_domain(all_lessons, self._domain)
+
+    def inject(self, task: str = "", *, max_rules: int = 10) -> str:
+        """Return scoped rules formatted for prompt injection.
+
+        Equivalent to :meth:`Brain.apply_brain_rules` but only rules whose
+        stored scope matches this ScopedBrain's domain are included. The
+        underlying relevance ranking is still applied on top of the filter.
+        """
+        context: dict[str, Any] = {"domain": self._domain}
+        if task:
+            context["task"] = task
+
+        # Pull the full injection string then rebuild from filtered lessons.
+        # We re-run the same ranking logic scoped to the filtered lesson set.
+        from gradata._scope import build_scope
+        from gradata.rules.rule_engine import (
+            apply_rules,
+            format_rules_for_prompt,
+        )
+
+        scoped_lessons = self.lessons()
+        if not scoped_lessons:
+            return ""
+
+        query_scope = build_scope({"domain": self._domain, "task": task or self._domain})
+        try:
+            from gradata.rules.rule_engine import apply_rules_with_tree
+
+            applied = apply_rules_with_tree(scoped_lessons, query_scope, max_rules=max_rules)
+        except Exception:
+            applied = apply_rules(scoped_lessons, query_scope, max_rules=max_rules)
+
+        return format_rules_for_prompt(applied)
+
+    def apply_brain_rules(
+        self,
+        task: str,
+        context: dict | None = None,
+        agent_type: str | None = None,
+        max_rules: int = 10,
+    ) -> str:
+        """Scoped equivalent of :meth:`Brain.apply_brain_rules`."""
+        ctx = dict(context or {})
+        ctx["domain"] = self._domain  # force domain filter
+        # Reuse inject() which already filters to the scoped lesson set
+        return self.inject(task=task, max_rules=max_rules)
+
+    def stats(self) -> dict:
+        """Counts of rules in this scope."""
+        scoped = self.lessons()
+        return {
+            "domain": self._domain,
+            "total": len(scoped),
+            "by_state": {
+                state: sum(1 for l in scoped if l.state.value == state)
+                for state in ("RULE", "PATTERN", "INSTINCT")
+            },
+        }
+
+    # ── Scope composition ──────────────────────────────────────────────
+
+    def scope(self, domain: str) -> ScopedBrain:
+        """Nested scoping: returns a ScopedBrain for ``domain`` against the
+        original parent brain. Nested scopes do not intersect (a scoped brain
+        is always a view over its top-level parent)."""
+        return ScopedBrain(self._parent, domain)
+
+    # ── Write-through delegation ──────────────────────────────────────
+    #
+    # Corrections, events, memory, and other write operations delegate to
+    # the parent brain. We annotate the correction with the scope's domain
+    # so that rules graduating from scoped sessions inherit the binding.
+
+    def correct(
+        self,
+        draft: str,
+        final: str,
+        category: str | None = None,
+        context: dict | None = None,
+        **kwargs: Any,
+    ) -> dict:
+        """Record a correction. The scope's domain is injected into
+        ``context`` and (by default) ``applies_to`` so graduating rules
+        carry the scope binding."""
+        merged_context = dict(context or {})
+        merged_context.setdefault("domain", self._domain)
+
+        # Default applies_to to the domain if the caller didn't specify.
+        kwargs.setdefault("applies_to", self._domain)
+        kwargs.setdefault("scope", "domain")
+
+        return self._parent.correct(
+            draft=draft,
+            final=final,
+            category=category,
+            context=merged_context,
+            **kwargs,
+        )
+
+    # ── Transparent attribute delegation ──────────────────────────────
+
+    def __getattr__(self, name: str) -> Any:
+        """Forward anything we don't explicitly override to the parent.
+
+        Python only calls __getattr__ for missing attributes, so the
+        overridden methods above win automatically.
+        """
+        return getattr(self._parent, name)

--- a/src/gradata/_scoped_brain.py
+++ b/src/gradata/_scoped_brain.py
@@ -16,12 +16,14 @@ Domain match semantics (see ``lesson_matches_domain``):
     A lesson belongs to domain ``D`` if ANY of the following holds:
 
     1. ``scope_json.domain == D`` (exact match on the stored RuleScope).
-    2. ``scope_json.applies_to`` starts with ``f"{D}:"`` (e.g. ``"code:refactor"``
-       matches domain ``"code"``). Bare ``applies_to == D`` also matches.
-    3. ``lesson.category.lower() == D.lower()`` (category-as-domain fallback).
+    2. ``scope_json.applies_to == D`` or starts with ``f"{D}:"``
+       (e.g. ``"code:refactor"`` matches domain ``"code"``).
 
-    Matching is case-insensitive. This is a deliberately permissive OR so
-    legacy lessons (category-tagged only) still surface under a scoped view.
+    Matching is case-insensitive. The category-as-domain fallback was
+    removed per the 4/4 STRICT council verdict: ``category`` is a
+    taxonomy label (STYLE, TONE, SECURITY), not a domain. Legacy
+    lessons without a ``scope_json.domain`` must be migrated using
+    ``scripts/migrate_legacy_scopes.py``.
 """
 
 from __future__ import annotations
@@ -45,8 +47,9 @@ logger = logging.getLogger(__name__)
 def lesson_matches_domain(lesson: Lesson, domain: str) -> bool:
     """Return True if ``lesson`` is in-scope for ``domain``.
 
-    See :mod:`gradata._scoped_brain` module docstring for the three-way
-    match rules. Empty ``domain`` matches everything (wildcard).
+    Matching is STRICT (council verdict 4/4): only the stored
+    ``scope_json`` is consulted. ``lesson.category`` is deliberately
+    ignored. Empty ``domain`` matches everything (wildcard).
     """
     if not domain:
         return True
@@ -54,25 +57,20 @@ def lesson_matches_domain(lesson: Lesson, domain: str) -> bool:
     if not d_norm:
         return True
 
-    # Rule 3: category fallback (cheapest check first)
-    if (lesson.category or "").strip().lower() == d_norm:
+    if not lesson.scope_json:
+        return False
+    try:
+        scope_data = json.loads(lesson.scope_json)
+    except (json.JSONDecodeError, TypeError):
+        return False
+    if not isinstance(scope_data, dict):
+        return False
+
+    scope_domain = str(scope_data.get("domain", "") or "").strip().lower()
+    if scope_domain == d_norm:
         return True
-
-    # Rules 1 and 2: dig into scope_json
-    if lesson.scope_json:
-        try:
-            scope_data = json.loads(lesson.scope_json)
-        except (json.JSONDecodeError, TypeError):
-            scope_data = {}
-        if isinstance(scope_data, dict):
-            scope_domain = str(scope_data.get("domain", "") or "").strip().lower()
-            if scope_domain == d_norm:
-                return True
-            applies_to = str(scope_data.get("applies_to", "") or "").strip().lower()
-            if applies_to == d_norm or applies_to.startswith(f"{d_norm}:"):
-                return True
-
-    return False
+    applies_to = str(scope_data.get("applies_to", "") or "").strip().lower()
+    return applies_to == d_norm or applies_to.startswith(f"{d_norm}:")
 
 
 def filter_lessons_by_domain(lessons: list[Lesson], domain: str) -> list[Lesson]:
@@ -127,19 +125,15 @@ class ScopedBrain:
     def _rule_dict_matches(self, rule: dict) -> bool:
         """Domain-match a dict as returned by ``list_rules``.
 
-        The inspection layer already serialises lessons to dicts; we re-derive
-        the match by loading the underlying Lesson via its rule_id. To keep
-        this cheap and dependency-free, we inspect dict fields directly.
+        STRICT matching (council verdict 4/4): only ``scope_json.domain``
+        or ``scope_json.applies_to`` are consulted. ``category`` is
+        ignored. ``metadata.where_scope`` is preserved as a legitimate
+        alternate serialization of the stored scope domain.
         """
         d_norm = self._domain.lower()
 
-        # Category fallback
-        cat = str(rule.get("category", "")).lower()
-        if cat == d_norm:
-            return True
-
-        # Scope data lives under metadata.where_scope or a top-level scope key
-        # depending on the exporter. Probe both conservatively.
+        # metadata.where_scope is how the inspection layer serialises
+        # the stored scope_json.domain, so it counts as a domain match.
         meta = rule.get("metadata") or {}
         where = str(meta.get("where_scope", "")).lower() if isinstance(meta, dict) else ""
         if where == d_norm:

--- a/src/gradata/brain.py
+++ b/src/gradata/brain.py
@@ -842,14 +842,15 @@ class Brain(BrainInspectionMixin):
         self._rule_cache.put(cache_key, result)
         return result
 
-    def scope(
+    def scoped_rules(
         self, domain: str = "", task_type: str = "", agent_type: str = "", max_rules: int = 10
     ) -> str:
-        """Get brain rules scoped to a specific domain and task type.
+        """Get brain rules scoped to a specific domain and task type, as a string.
 
-        A convenience wrapper around :meth:`apply_brain_rules` that builds the
-        context dict from named domain/task_type parameters instead of a raw
-        task string.
+        Convenience wrapper around :meth:`apply_brain_rules` that builds the
+        context dict from named parameters. For an object-oriented view that
+        exposes ``rules()``, ``inject()``, and scoped ``correct()``, see
+        :meth:`scope`.
 
         Args:
             domain: Operational domain, e.g. ``"sales"``, ``"engineering"``.
@@ -872,6 +873,30 @@ class Brain(BrainInspectionMixin):
             agent_type=agent_type or None,
             max_rules=max_rules,
         )
+
+    def scope(self, domain: str):
+        """Return a :class:`ScopedBrain` view over this brain.
+
+        A ScopedBrain filters graduated rules to those tagged with ``domain``
+        (via ``scope_json.domain``, ``scope_json.applies_to`` starting with
+        ``"{domain}:"``, or a matching category) and proxies writes (correct,
+        emit) through to this brain so learning still accrues to one store.
+
+        Args:
+            domain: Non-empty domain string, e.g. ``"code"``, ``"sales"``.
+
+        Returns:
+            A :class:`gradata._scoped_brain.ScopedBrain` bound to this brain.
+
+        Example::
+
+            code_brain = brain.scope("code")
+            prompt = code_brain.inject("refactor the parser")
+            code_brain.correct("old draft", "new draft")  # tagged applies_to="code"
+        """
+        from gradata._scoped_brain import ScopedBrain
+
+        return ScopedBrain(self, domain)
 
     def plan(self, task: str, context: dict | None = None) -> dict:
         """Generate a structured plan using graduated rules."""

--- a/src/gradata/hooks/agent_precontext.py
+++ b/src/gradata/hooks/agent_precontext.py
@@ -1,6 +1,17 @@
-"""PreToolUse hook: inject relevant brain rules into Agent subagent context."""
+"""PreToolUse hook: inject relevant brain rules into Agent subagent context.
+
+Sub-agents inherit scope from the parent brain through two channels:
+
+1. ``tool_input.scope_domain`` — explicit domain the parent passed to the
+   subagent (highest priority).
+2. ``os.environ["GRADATA_SCOPE_DOMAIN"]`` — propagated when the parent is
+   running under a scoped brain view.
+
+Falls back to keyword inference when no explicit scope is set.
+"""
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from gradata.hooks._base import resolve_brain_dir, run_hook
@@ -28,6 +39,20 @@ SCOPE_KEYWORDS = {
     "research": ["research", "analyze", "investigate", "compare", "study"],
     "writing": ["write", "draft", "document", "blog", "article", "copy"],
 }
+
+
+def _resolve_scope_domain(data: dict) -> str:
+    """Resolve the scope domain for this sub-agent invocation.
+
+    Priority: explicit ``tool_input.scope_domain`` > env var > "".
+    Empty string means "no scope filter" (caller falls back to keyword match).
+    """
+    tool_input = data.get("tool_input", {}) or {}
+    explicit = str(tool_input.get("scope_domain", "") or "").strip()
+    if explicit:
+        return explicit
+    env = os.environ.get("GRADATA_SCOPE_DOMAIN", "").strip()
+    return env
 
 
 def _infer_agent_type(data: dict) -> str:
@@ -76,6 +101,18 @@ def main(data: dict) -> dict | None:
         filtered = [lesson for lesson in all_lessons if lesson.state.name in ("RULE", "PATTERN") and lesson.confidence >= MIN_CONFIDENCE]
         if not filtered:
             return None
+
+        # Sub-agent scope inheritance: filter by parent-declared domain first
+        scope_domain = _resolve_scope_domain(data)
+        if scope_domain:
+            try:
+                from gradata._scoped_brain import filter_lessons_by_domain
+
+                scoped = filter_lessons_by_domain(filtered, scope_domain)
+                if scoped:
+                    filtered = scoped
+            except Exception:
+                pass  # Fall back to unfiltered on any import/runtime error
 
         agent_type = _infer_agent_type(data)
         scored = sorted(filtered, key=lambda r: _relevance_score(r, agent_type), reverse=True)

--- a/src/gradata/rules/rule_context.py
+++ b/src/gradata/rules/rule_context.py
@@ -48,11 +48,15 @@ class GraduatedRule:
 def _rule_matches_domain(rule: GraduatedRule, domain_norm: str) -> bool:
     """Return True if ``rule`` is in-scope for ``domain_norm`` (already lowercased).
 
-    Match rules (OR):
+    STRICT matching (council verdict 4/4). Match rules (OR):
       1. ``rule.scope["domain"]`` equals ``domain_norm`` (case-insensitive).
       2. ``rule.scope["applies_to"]`` equals ``domain_norm`` or starts with
          ``f"{domain_norm}:"``.
-      3. ``rule.category`` equals ``domain_norm`` (case-insensitive fallback).
+
+    ``rule.category`` is deliberately ignored. Categories are taxonomy
+    labels (STYLE, TONE, SECURITY), not domains. Legacy rules with no
+    ``scope.domain`` set must be migrated via
+    ``scripts/migrate_legacy_scopes.py``.
     """
     if not domain_norm:
         return True
@@ -60,9 +64,7 @@ def _rule_matches_domain(rule: GraduatedRule, domain_norm: str) -> bool:
     if str(scope.get("domain", "")).strip().lower() == domain_norm:
         return True
     applies = str(scope.get("applies_to", "")).strip().lower()
-    if applies == domain_norm or (applies and applies.startswith(f"{domain_norm}:")):
-        return True
-    return (rule.category or "").strip().lower() == domain_norm
+    return applies == domain_norm or (applies and applies.startswith(f"{domain_norm}:"))
 
 
 class RuleContext:
@@ -114,10 +116,10 @@ class RuleContext:
 
         Args:
             domain: Optional domain filter. When set, only rules whose
-                ``scope["domain"]`` matches (case-insensitive), whose
+                ``scope["domain"]`` matches (case-insensitive) or whose
                 ``scope["applies_to"]`` equals ``domain`` or starts with
-                ``f"{domain}:"``, or whose ``category`` matches ``domain``
-                are returned.
+                ``f"{domain}:"`` are returned. Category is NOT used as a
+                fallback (council verdict 4/4 STRICT).
         """
         candidates = list(self._rules.values())
 

--- a/src/gradata/rules/rule_context.py
+++ b/src/gradata/rules/rule_context.py
@@ -45,6 +45,26 @@ class GraduatedRule:
         return 0.60 <= self.confidence < 0.90
 
 
+def _rule_matches_domain(rule: GraduatedRule, domain_norm: str) -> bool:
+    """Return True if ``rule`` is in-scope for ``domain_norm`` (already lowercased).
+
+    Match rules (OR):
+      1. ``rule.scope["domain"]`` equals ``domain_norm`` (case-insensitive).
+      2. ``rule.scope["applies_to"]`` equals ``domain_norm`` or starts with
+         ``f"{domain_norm}:"``.
+      3. ``rule.category`` equals ``domain_norm`` (case-insensitive fallback).
+    """
+    if not domain_norm:
+        return True
+    scope = rule.scope or {}
+    if str(scope.get("domain", "")).strip().lower() == domain_norm:
+        return True
+    applies = str(scope.get("applies_to", "")).strip().lower()
+    if applies == domain_norm or (applies and applies.startswith(f"{domain_norm}:")):
+        return True
+    return (rule.category or "").strip().lower() == domain_norm
+
+
 class RuleContext:
     """Singleton registry of graduated rules that all patterns query.
 
@@ -88,8 +108,17 @@ class RuleContext:
         agent_type: str = "",
         min_confidence: float = 0.0,
         limit: int = 10,
+        domain: str | None = None,
     ) -> list[GraduatedRule]:
-        """Query graduated rules. Any pattern can call this."""
+        """Query graduated rules. Any pattern can call this.
+
+        Args:
+            domain: Optional domain filter. When set, only rules whose
+                ``scope["domain"]`` matches (case-insensitive), whose
+                ``scope["applies_to"]`` equals ``domain`` or starts with
+                ``f"{domain}:"``, or whose ``category`` matches ``domain``
+                are returned.
+        """
         candidates = list(self._rules.values())
 
         if category:
@@ -106,6 +135,10 @@ class RuleContext:
             for tag in tags:
                 tag_ids.update(self._by_tag.get(tag, []))
             candidates = [r for r in candidates if r.rule_id in tag_ids]
+
+        if domain:
+            d_norm = domain.strip().lower()
+            candidates = [r for r in candidates if _rule_matches_domain(r, d_norm)]
 
         if min_confidence > 0:
             candidates = [r for r in candidates if r.confidence >= min_confidence]

--- a/tests/test_migrate_legacy_scopes.py
+++ b/tests/test_migrate_legacy_scopes.py
@@ -1,0 +1,180 @@
+"""Tests for scripts/migrate_legacy_scopes.py.
+
+Covers the council-mandated migration path for legacy lessons that relied
+on the removed category-as-domain fallback.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_SCRIPT = _REPO / "scripts" / "migrate_legacy_scopes.py"
+
+
+def _load_migrate_module():
+    """Dynamically load the script as a module (scripts/ isn't a package)."""
+    spec = importlib.util.spec_from_file_location(
+        "_migrate_legacy_scopes_under_test", _SCRIPT
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def migrate_mod():
+    return _load_migrate_module()
+
+
+@pytest.fixture()
+def brain_with_mixed_lessons(tmp_path):
+    """Create a brain dir with 5 lessons: 2 migratable, 1 ambiguous,
+    1 already-scoped, 1 with unknown category."""
+    from gradata._types import Lesson, LessonState
+    from gradata.enhancements.self_improvement import format_lessons
+
+    brain_dir = tmp_path / "brain"
+    brain_dir.mkdir()
+    lessons = [
+        Lesson(
+            date="2026-04-14",
+            state=LessonState.RULE,
+            confidence=0.95,
+            category="CODE",
+            description="Run tests first",
+            scope_json="",
+        ),
+        Lesson(
+            date="2026-04-14",
+            state=LessonState.RULE,
+            confidence=0.95,
+            category="EMAIL",
+            description="Hyperlink the Calendly",
+            scope_json="",
+        ),
+        Lesson(
+            date="2026-04-14",
+            state=LessonState.RULE,
+            confidence=0.92,
+            category="GENERAL",
+            description="Verify before shipping",
+            scope_json="",
+        ),
+        Lesson(
+            date="2026-04-14",
+            state=LessonState.RULE,
+            confidence=0.93,
+            category="CODE",
+            description="Already explicitly scoped",
+            scope_json=json.dumps({"domain": "code"}),
+        ),
+        Lesson(
+            date="2026-04-14",
+            state=LessonState.RULE,
+            confidence=0.91,
+            category="RANDOM",  # not present in the domains list below
+            description="Weird legacy lesson",
+            scope_json="",
+        ),
+    ]
+
+    (brain_dir / "lessons.md").write_text(format_lessons(lessons), encoding="utf-8")
+    return brain_dir
+
+
+def test_plan_migration_counts(migrate_mod, brain_with_mixed_lessons):
+    from gradata.enhancements.self_improvement import parse_lessons
+
+    lessons_path = brain_with_mixed_lessons / "lessons.md"
+    lessons = parse_lessons(lessons_path.read_text(encoding="utf-8"))
+
+    # Explicit domain set (simulating a future domains.yaml)
+    domains = {"code", "email"}
+    _new_lessons, result = migrate_mod.plan_migration(lessons, domains)
+
+    assert result.migrated == 2  # CODE + EMAIL -> scope_json.domain set
+    assert result.skipped == 1  # the already-scoped CODE lesson
+    assert result.flagged == 2  # GENERAL + RANDOM
+
+
+def test_plan_migration_sets_scope_json(migrate_mod, brain_with_mixed_lessons):
+    from gradata.enhancements.self_improvement import parse_lessons
+
+    lessons_path = brain_with_mixed_lessons / "lessons.md"
+    lessons = parse_lessons(lessons_path.read_text(encoding="utf-8"))
+    new_lessons, _ = migrate_mod.plan_migration(lessons, {"code", "email"})
+
+    # The first two (CODE, EMAIL) should now carry domain
+    first = json.loads(new_lessons[0].scope_json)
+    second = json.loads(new_lessons[1].scope_json)
+    assert first["domain"] == "code"
+    assert second["domain"] == "email"
+
+    # The already-scoped one is unchanged
+    fourth = json.loads(new_lessons[3].scope_json)
+    assert fourth["domain"] == "code"
+
+    # The flagged ones keep empty scope_json
+    assert new_lessons[2].scope_json in ("", None)
+    assert new_lessons[4].scope_json in ("", None)
+
+
+def test_cli_dry_run_does_not_write(
+    migrate_mod, brain_with_mixed_lessons, caplog, monkeypatch
+):
+    lessons_path = brain_with_mixed_lessons / "lessons.md"
+    before = lessons_path.read_text(encoding="utf-8")
+
+    rc = migrate_mod.run_cli(["--brain", str(brain_with_mixed_lessons)])
+    assert rc == 0
+
+    after = lessons_path.read_text(encoding="utf-8")
+    assert after == before, "dry-run must not modify lessons.md"
+
+
+def test_cli_apply_writes_scope_json(migrate_mod, brain_with_mixed_lessons):
+    from gradata.enhancements.self_improvement import parse_lessons
+
+    lessons_path = brain_with_mixed_lessons / "lessons.md"
+    rc = migrate_mod.run_cli(
+        ["--brain", str(brain_with_mixed_lessons), "--apply"]
+    )
+    assert rc == 0
+
+    lessons = parse_lessons(lessons_path.read_text(encoding="utf-8"))
+    scoped_domains = {
+        json.loads(l.scope_json).get("domain")
+        for l in lessons
+        if l.scope_json
+    }
+    assert "code" in scoped_domains
+    assert "email" in scoped_domains
+
+
+def test_ambiguous_category_is_flagged_not_migrated(migrate_mod):
+    from dataclasses import replace
+
+    from gradata._types import Lesson, LessonState
+
+    lesson = Lesson(
+        date="2026-04-14",
+        state=LessonState.RULE,
+        confidence=0.9,
+        category="GENERAL",
+        description="vague",
+        scope_json="",
+    )
+    new, result = migrate_mod.plan_migration([lesson], {"code", "email", "general"})
+    # "general" is an ambiguous sentinel even if present in domains list
+    assert result.flagged == 1
+    assert result.migrated == 0
+    # unchanged
+    assert new[0] == replace(lesson)

--- a/tests/test_scoped_brain.py
+++ b/tests/test_scoped_brain.py
@@ -1,36 +1,41 @@
-"""Tests for brain.scope(), detect_cross_domain_candidates(), and suggest_scope_narrowing."""
+"""Tests for brain.scoped_rules(), detect_cross_domain_candidates(), and suggest_scope_narrowing.
+
+The legacy string-returning scope API moved to :meth:`Brain.scoped_rules`; the
+name ``scope`` now returns a :class:`ScopedBrain` object (see
+``tests/test_scoped_brains.py``).
+"""
 from __future__ import annotations
 import json
 import pytest
 
 
-# Feature 1: brain.scope()
+# Feature 1: brain.scoped_rules()
 
-def test_brain_scope_returns_str(tmp_path):
+def test_brain_scoped_rules_returns_str(tmp_path):
     from gradata.brain import Brain
     brain = Brain.init(str(tmp_path))
-    result = brain.scope(domain="sales")
+    result = brain.scoped_rules(domain="sales")
     assert isinstance(result, str)
 
 
-def test_brain_scope_no_args_returns_str(tmp_path):
+def test_brain_scoped_rules_no_args_returns_str(tmp_path):
     from gradata.brain import Brain
     brain = Brain.init(str(tmp_path))
-    result = brain.scope()
+    result = brain.scoped_rules()
     assert isinstance(result, str)
 
 
-def test_brain_scope_with_task_type(tmp_path):
+def test_brain_scoped_rules_with_task_type(tmp_path):
     from gradata.brain import Brain
     brain = Brain.init(str(tmp_path))
-    result = brain.scope(domain="sales", task_type="email_draft")
+    result = brain.scoped_rules(domain="sales", task_type="email_draft")
     assert isinstance(result, str)
 
 
-def test_brain_scope_with_agent_type(tmp_path):
+def test_brain_scoped_rules_with_agent_type(tmp_path):
     from gradata.brain import Brain
     brain = Brain.init(str(tmp_path))
-    result = brain.scope(domain="engineering", agent_type="reviewer")
+    result = brain.scoped_rules(domain="engineering", agent_type="reviewer")
     assert isinstance(result, str)
 
 

--- a/tests/test_scoped_brains.py
+++ b/tests/test_scoped_brains.py
@@ -1,0 +1,427 @@
+"""Tests for Phase 2 — Scoped Brains.
+
+Covers:
+    - brain.scope(domain) returns a ScopedBrain
+    - ScopedBrain.rules() filters parent rules by domain
+    - ScopedBrain.lessons() filters parsed Lessons by domain
+    - ScopedBrain.inject() emits only scoped rule text
+    - Round-trip: correct(scope="domain", applies_to="code:X") then scope("code") surfaces the rule
+    - Sub-agent scope inheritance via the agent_precontext hook
+    - RuleContext.query(domain=...) filter
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_lessons(lessons_path: Path, entries: list[dict]) -> None:
+    """Write a simple lessons.md with the given entries.
+
+    Each entry: {category, description, state, confidence, scope_json?}
+    """
+    from gradata._types import Lesson, LessonState
+    from gradata.enhancements.self_improvement import format_lessons
+
+    lessons = []
+    for e in entries:
+        lessons.append(
+            Lesson(
+                date="2026-04-14",
+                state=LessonState[e.get("state", "RULE")],
+                confidence=float(e.get("confidence", 0.95)),
+                category=e["category"],
+                description=e["description"],
+                scope_json=e.get("scope_json", ""),
+            )
+        )
+    lessons_path.write_text(format_lessons(lessons), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Core API
+# ---------------------------------------------------------------------------
+
+
+def test_scope_returns_scoped_brain(tmp_path):
+    from gradata._scoped_brain import ScopedBrain
+    from gradata.brain import Brain
+
+    brain = Brain.init(str(tmp_path))
+    scoped = brain.scope("code")
+    assert isinstance(scoped, ScopedBrain)
+    assert scoped.domain == "code"
+    assert scoped.parent is brain
+
+
+def test_scope_empty_domain_rejected(tmp_path):
+    from gradata.brain import Brain
+
+    brain = Brain.init(str(tmp_path))
+    with pytest.raises(ValueError):
+        brain.scope("")
+    with pytest.raises(ValueError):
+        brain.scope("   ")
+
+
+def test_scope_is_public_export():
+    import gradata
+
+    assert hasattr(gradata, "ScopedBrain")
+
+
+# ---------------------------------------------------------------------------
+# Lesson / rule filtering
+# ---------------------------------------------------------------------------
+
+
+def test_lessons_filtered_by_scope_domain(tmp_path):
+    from gradata.brain import Brain
+
+    brain = Brain.init(str(tmp_path))
+    lessons_path = brain.dir / "lessons.md"
+    _write_lessons(
+        lessons_path,
+        [
+            {
+                "category": "STYLE",
+                "description": "Use four-space indents",
+                "scope_json": json.dumps({"domain": "code"}),
+            },
+            {
+                "category": "TONE",
+                "description": "Stay casual with prospects",
+                "scope_json": json.dumps({"domain": "sales"}),
+            },
+            {
+                "category": "GENERAL",
+                "description": "Verify before shipping",
+                "scope_json": "",
+            },
+        ],
+    )
+
+    code_brain = brain.scope("code")
+    scoped = code_brain.lessons()
+    descs = [l.description for l in scoped]
+    assert "Use four-space indents" in descs
+    assert "Stay casual with prospects" not in descs
+    assert "Verify before shipping" not in descs
+
+
+def test_lessons_filtered_by_applies_to_prefix(tmp_path):
+    from gradata.brain import Brain
+
+    brain = Brain.init(str(tmp_path))
+    lessons_path = brain.dir / "lessons.md"
+    _write_lessons(
+        lessons_path,
+        [
+            {
+                "category": "STYLE",
+                "description": "Refactor into pure functions",
+                "scope_json": json.dumps({"applies_to": "code:refactor"}),
+            },
+            {
+                "category": "STYLE",
+                "description": "Tighten the subject line",
+                "scope_json": json.dumps({"applies_to": "email:cold"}),
+            },
+        ],
+    )
+
+    code_scoped = brain.scope("code").lessons()
+    assert len(code_scoped) == 1
+    assert "Refactor" in code_scoped[0].description
+
+
+def test_lessons_filtered_by_category_fallback(tmp_path):
+    """Legacy lessons with no scope_json still surface via category match."""
+    from gradata.brain import Brain
+
+    brain = Brain.init(str(tmp_path))
+    lessons_path = brain.dir / "lessons.md"
+    _write_lessons(
+        lessons_path,
+        [
+            {"category": "CODE", "description": "Run tests first", "scope_json": ""},
+            {"category": "EMAIL", "description": "Hyperlink Calendly", "scope_json": ""},
+        ],
+    )
+
+    code_scoped = brain.scope("code").lessons()
+    assert len(code_scoped) == 1
+    assert code_scoped[0].description == "Run tests first"
+
+
+def test_inject_returns_only_scoped_rules(tmp_path):
+    from gradata.brain import Brain
+
+    brain = Brain.init(str(tmp_path))
+    lessons_path = brain.dir / "lessons.md"
+    _write_lessons(
+        lessons_path,
+        [
+            {
+                "category": "STYLE",
+                "description": "Use type hints",
+                "scope_json": json.dumps({"domain": "code"}),
+            },
+            {
+                "category": "TONE",
+                "description": "Warm opening",
+                "scope_json": json.dumps({"domain": "sales"}),
+            },
+        ],
+    )
+
+    text = brain.scope("code").inject("refactor parser")
+    assert "Use type hints" in text
+    assert "Warm opening" not in text
+
+
+def test_inject_empty_when_no_matching_rules(tmp_path):
+    from gradata.brain import Brain
+
+    brain = Brain.init(str(tmp_path))
+    lessons_path = brain.dir / "lessons.md"
+    _write_lessons(
+        lessons_path,
+        [
+            {
+                "category": "TONE",
+                "description": "Warm opening",
+                "scope_json": json.dumps({"domain": "sales"}),
+            },
+        ],
+    )
+
+    text = brain.scope("code").inject("refactor parser")
+    assert text == ""
+
+
+# ---------------------------------------------------------------------------
+# Round-trip with correct()
+# ---------------------------------------------------------------------------
+
+
+def test_correct_then_scope_round_trip(tmp_path):
+    """Correcting through a ScopedBrain stamps applies_to=domain so subsequent
+    scope() calls surface the lesson."""
+    from gradata.brain import Brain
+
+    brain = Brain.init(str(tmp_path))
+    code_brain = brain.scope("code")
+
+    result = code_brain.correct(
+        draft="def foo(x): return x+1",
+        final="def foo(x: int) -> int:\n    return x + 1",
+        category="STYLE",
+    )
+
+    # The parent brain records the event with applies_to="code" and scope="domain"
+    assert isinstance(result, dict)
+
+    # Pull CORRECTION events from the parent and verify applies_to propagated
+    events = brain.query_events(event_type="CORRECTION") if hasattr(brain, "query_events") else []
+    tagged = [e for e in events if (e.get("data") or {}).get("applies_to") == "code"]
+    assert tagged, "expected at least one CORRECTION event tagged applies_to=code"
+
+
+def test_scoped_correct_preserves_explicit_applies_to(tmp_path):
+    from gradata.brain import Brain
+
+    brain = Brain.init(str(tmp_path))
+    code_brain = brain.scope("code")
+
+    code_brain.correct(
+        draft="x=1",
+        final="x = 1",
+        category="STYLE",
+        applies_to="code:formatting",
+    )
+
+    events = brain.query_events(event_type="CORRECTION") if hasattr(brain, "query_events") else []
+    targeted = [
+        e for e in events
+        if (e.get("data") or {}).get("applies_to") == "code:formatting"
+    ]
+    assert targeted, "explicit applies_to must not be overwritten"
+
+
+# ---------------------------------------------------------------------------
+# Nested scoping and delegation
+# ---------------------------------------------------------------------------
+
+
+def test_nested_scope_is_flat_not_intersected(tmp_path):
+    """Nested scoping rebinds to the top-level parent rather than intersecting."""
+    from gradata.brain import Brain
+
+    brain = Brain.init(str(tmp_path))
+    first = brain.scope("code")
+    second = first.scope("sales")
+    assert second.domain == "sales"
+    assert second.parent is brain  # not first
+
+
+def test_scoped_brain_delegates_attrs(tmp_path):
+    from gradata.brain import Brain
+
+    brain = Brain.init(str(tmp_path))
+    scoped = brain.scope("code")
+    # Arbitrary parent attribute should be reachable
+    assert scoped.dir == brain.dir
+    assert scoped.db_path == brain.db_path
+
+
+# ---------------------------------------------------------------------------
+# RuleContext domain filter
+# ---------------------------------------------------------------------------
+
+
+def test_rule_context_domain_filter():
+    from gradata.rules.rule_context import GraduatedRule, RuleContext
+
+    ctx = RuleContext()
+    ctx.publish(
+        GraduatedRule(
+            rule_id="r1",
+            category="STYLE",
+            principle="type hints",
+            confidence=0.95,
+            scope={"domain": "code"},
+        )
+    )
+    ctx.publish(
+        GraduatedRule(
+            rule_id="r2",
+            category="TONE",
+            principle="warm opener",
+            confidence=0.95,
+            scope={"domain": "sales"},
+        )
+    )
+    ctx.publish(
+        GraduatedRule(
+            rule_id="r3",
+            category="STYLE",
+            principle="refactor pattern",
+            confidence=0.92,
+            scope={"applies_to": "code:refactor"},
+        )
+    )
+
+    code_rules = ctx.query(domain="code", limit=10)
+    ids = {r.rule_id for r in code_rules}
+    assert ids == {"r1", "r3"}
+
+    sales_rules = ctx.query(domain="sales", limit=10)
+    assert {r.rule_id for r in sales_rules} == {"r2"}
+
+
+def test_rule_context_domain_category_fallback():
+    from gradata.rules.rule_context import GraduatedRule, RuleContext
+
+    ctx = RuleContext()
+    ctx.publish(
+        GraduatedRule(
+            rule_id="r1",
+            category="CODE",  # no scope but category matches
+            principle="unit-test coverage",
+            confidence=0.9,
+        )
+    )
+    result = ctx.query(domain="code", limit=10)
+    assert [r.rule_id for r in result] == ["r1"]
+
+
+# ---------------------------------------------------------------------------
+# Sub-agent inheritance (agent_precontext hook)
+# ---------------------------------------------------------------------------
+
+
+def test_agent_precontext_respects_scope_domain(tmp_path, monkeypatch):
+    """The sub-agent precontext hook should filter to the scoped domain when
+    ``tool_input.scope_domain`` is set."""
+    from gradata.brain import Brain
+    from gradata.hooks import agent_precontext
+
+    brain = Brain.init(str(tmp_path))
+    lessons_path = brain.dir / "lessons.md"
+    _write_lessons(
+        lessons_path,
+        [
+            {
+                "category": "STYLE",
+                "description": "CODE-RULE: type hints",
+                "scope_json": json.dumps({"domain": "code"}),
+                "confidence": 0.95,
+            },
+            {
+                "category": "TONE",
+                "description": "SALES-RULE: warm opener",
+                "scope_json": json.dumps({"domain": "sales"}),
+                "confidence": 0.95,
+            },
+        ],
+    )
+
+    # Point the hook at our brain dir
+    monkeypatch.setenv("BRAIN_DIR", str(brain.dir))
+
+    data = {
+        "tool_input": {
+            "subagent_type": "general",
+            "description": "help with a task",
+            "scope_domain": "code",
+        }
+    }
+
+    result = agent_precontext.main(data)
+    assert result is not None
+    block = result.get("result", "")
+    assert "CODE-RULE" in block
+    assert "SALES-RULE" not in block
+
+
+def test_agent_precontext_respects_env_domain(tmp_path, monkeypatch):
+    from gradata.brain import Brain
+    from gradata.hooks import agent_precontext
+
+    brain = Brain.init(str(tmp_path))
+    lessons_path = brain.dir / "lessons.md"
+    _write_lessons(
+        lessons_path,
+        [
+            {
+                "category": "STYLE",
+                "description": "CODE-RULE: type hints",
+                "scope_json": json.dumps({"domain": "code"}),
+                "confidence": 0.95,
+            },
+            {
+                "category": "TONE",
+                "description": "SALES-RULE: warm opener",
+                "scope_json": json.dumps({"domain": "sales"}),
+                "confidence": 0.95,
+            },
+        ],
+    )
+
+    monkeypatch.setenv("BRAIN_DIR", str(brain.dir))
+    monkeypatch.setenv("GRADATA_SCOPE_DOMAIN", "sales")
+
+    data = {"tool_input": {"subagent_type": "general", "description": "help with a task"}}
+    result = agent_precontext.main(data)
+    assert result is not None
+    block = result.get("result", "")
+    assert "SALES-RULE" in block
+    assert "CODE-RULE" not in block

--- a/tests/test_scoped_brains.py
+++ b/tests/test_scoped_brains.py
@@ -142,8 +142,13 @@ def test_lessons_filtered_by_applies_to_prefix(tmp_path):
     assert "Refactor" in code_scoped[0].description
 
 
-def test_lessons_filtered_by_category_fallback(tmp_path):
-    """Legacy lessons with no scope_json still surface via category match."""
+def test_legacy_category_only_lessons_excluded(tmp_path):
+    """Council verdict 4/4 STRICT: category-as-domain fallback removed.
+
+    Legacy lessons with no scope_json (category-only) MUST NOT surface
+    under a scoped view. Users migrate them via
+    ``scripts/migrate_legacy_scopes.py``.
+    """
     from gradata.brain import Brain
 
     brain = Brain.init(str(tmp_path))
@@ -152,6 +157,29 @@ def test_lessons_filtered_by_category_fallback(tmp_path):
         lessons_path,
         [
             {"category": "CODE", "description": "Run tests first", "scope_json": ""},
+            {"category": "EMAIL", "description": "Hyperlink Calendly", "scope_json": ""},
+        ],
+    )
+
+    code_scoped = brain.scope("code").lessons()
+    assert code_scoped == []
+
+
+def test_migrated_lesson_surfaces_after_scope_json_set(tmp_path):
+    """Once scope_json.domain is populated (e.g. by migrate_legacy_scopes),
+    the lesson surfaces under the scoped view."""
+    from gradata.brain import Brain
+
+    brain = Brain.init(str(tmp_path))
+    lessons_path = brain.dir / "lessons.md"
+    _write_lessons(
+        lessons_path,
+        [
+            {
+                "category": "CODE",
+                "description": "Run tests first",
+                "scope_json": json.dumps({"domain": "code"}),
+            },
             {"category": "EMAIL", "description": "Hyperlink Calendly", "scope_json": ""},
         ],
     )
@@ -327,16 +355,35 @@ def test_rule_context_domain_filter():
     assert {r.rule_id for r in sales_rules} == {"r2"}
 
 
-def test_rule_context_domain_category_fallback():
+def test_rule_context_category_only_excluded():
+    """STRICT: category-only rules (no scope.domain) do NOT match a domain query."""
     from gradata.rules.rule_context import GraduatedRule, RuleContext
 
     ctx = RuleContext()
     ctx.publish(
         GraduatedRule(
             rule_id="r1",
-            category="CODE",  # no scope but category matches
+            category="CODE",  # category matches but scope.domain is unset
             principle="unit-test coverage",
             confidence=0.9,
+        )
+    )
+    result = ctx.query(domain="code", limit=10)
+    assert result == []
+
+
+def test_rule_context_domain_explicit_scope_required():
+    """After migration, scope.domain='code' on the same rule makes it match."""
+    from gradata.rules.rule_context import GraduatedRule, RuleContext
+
+    ctx = RuleContext()
+    ctx.publish(
+        GraduatedRule(
+            rule_id="r1",
+            category="CODE",
+            principle="unit-test coverage",
+            confidence=0.9,
+            scope={"domain": "code"},
         )
     )
     result = ctx.query(domain="code", limit=10)


### PR DESCRIPTION
## Summary
Ships `brain.scope(domain) -> ScopedBrain` API: a filtered view where only rules tagged with the domain inject. Sub-agents inherit the scope automatically.

## API
```python
brain.scope("code")
  .rules(include_all=False, category=None) -> list[dict]
  .lessons() -> list[Lesson]
  .inject(task="", max_rules=10) -> str
  .apply_brain_rules(task, context, agent_type, max_rules)
  .correct(draft, final, ...)  # auto-tags applies_to=domain, scope="domain"
  .scope(D2)  # rebind
  .stats()
  .domain, .parent
```

Sub-agent inheritance: parent passes `tool_input.scope_domain="code"` or exports `GRADATA_SCOPE_DOMAIN=code`; `agent_precontext.main()` filters before keyword scoring.

`RuleContext.query(..., domain="code")` filters the singleton rule registry identically.

## Naming change
Old `Brain.scope()` (4-value enum getter) renamed to `Brain.scoped_rules()` to free the name. 4 legacy tests updated.

## Council verdict 4/4 STRICT (applied)
Domain match logic is now STRICT. A lesson belongs to domain `D` iff:
1. `scope_json.domain == D`, or
2. `scope_json.applies_to == D` or `applies_to.startswith(f"{D}:")`

The category-as-domain fallback was dropped: `category` is a taxonomy label (STYLE, TONE, SECURITY), not a domain, and the implicit coupling created non-deterministic scope membership for any lesson whose category label happened to look like a domain.

Legacy lessons that previously relied on the fallback are handled by `scripts/migrate_legacy_scopes.py` (dry-run by default, `--apply` to persist). Ambiguous categories (`MIXED`, `OTHER`, `GENERAL`, unknown) are flagged for manual review rather than silently migrated.

## Files
- `src/gradata/_scoped_brain.py` (new) — strict match logic
- `src/gradata/rules/rule_context.py` — strict `_rule_matches_domain`
- `src/gradata/brain.py`, `hooks/agent_precontext.py`, `__init__.py`
- `scripts/migrate_legacy_scopes.py` (new) + `.gitignore` negation rule
- `tests/test_scoped_brains.py` (18 tests) + `test_migrate_legacy_scopes.py` (5 tests) + `test_scoped_brain.py` (4 legacy updated)

## Tests
2424 pass, 23 skipped. Ruff clean on all touched files.

## Commits
- `0e69b06` feat(scoped-brains): add `Brain.scope(domain) -> ScopedBrain` view
- `c4d131b` feat(rule-context): add `domain=` filter to `RuleContext.query()`
- `79dedc6` feat(hooks): propagate scope domain into sub-agent precontext
- `67a1907` test(scoped-brains): cover ScopedBrain + domain filter + hook
- `09a523e` fix(scoped-brains): drop category-as-domain fallback per council verdict
- `5d1790f` feat(scripts): add `migrate_legacy_scopes` for category-only lessons

Co-Authored-By: Gradata <noreply@gradata.ai>