### PR TITLE
feat(adapters): Mem0 memory adapter with push/pull/reconcile protocol (Phase 3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,13 @@ embeddings = ["sentence-transformers>=2.0.0"]  # Local embeddings
 gemini = ["google-genai>=1.0.0"]  # Gemini embeddings (free tier)
 encrypted = ["cryptography>=41.0"]  # Encryption at rest for system.db
 cloud = []  # Cloud client uses stdlib only (urllib). Enhancements included in base package.
-all = ["sentence-transformers>=2.0.0", "google-genai>=1.0.0", "cryptography>=41.0"]
+adapters-mem0 = ["mem0ai>=0.1.0"]  # Mem0 external memory adapter (opt-in)
+all = [
+    "sentence-transformers>=2.0.0",
+    "google-genai>=1.0.0",
+    "cryptography>=41.0",
+    "mem0ai>=0.1.0",
+]
 dev = [
     "pytest>=8.0",
     "hypothesis>=6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,12 +30,12 @@ embeddings = ["sentence-transformers>=2.0.0"]  # Local embeddings
 gemini = ["google-genai>=1.0.0"]  # Gemini embeddings (free tier)
 encrypted = ["cryptography>=41.0"]  # Encryption at rest for system.db
 cloud = []  # Cloud client uses stdlib only (urllib). Enhancements included in base package.
-adapters-mem0 = ["mem0ai>=0.1.0"]  # Mem0 external memory adapter (opt-in)
+adapters-mem0 = ["mem0ai>=1.0.11"]  # Mem0 external memory adapter (opt-in)
 all = [
     "sentence-transformers>=2.0.0",
     "google-genai>=1.0.0",
     "cryptography>=41.0",
-    "mem0ai>=0.1.0",
+    "mem0ai>=1.0.11",
 ]
 dev = [
     "pytest>=8.0",

--- a/src/gradata/adapters/__init__.py
+++ b/src/gradata/adapters/__init__.py
@@ -1,0 +1,22 @@
+"""
+External memory adapters for Gradata.
+======================================
+
+Opt-in integrations that let Gradata mirror corrections and pull relevant
+context from external memory backends (Mem0, Letta, EverMind, Hermes, ...).
+
+Adapters are **not** wired into Gradata's event pipeline automatically.
+Users call adapter methods themselves from their own `Brain.correct()`
+callsites. A future release may add a `Brain(...)` constructor option
+that auto-mirrors events to an adapter.
+
+All adapters implement the :class:`MemoryAdapter` protocol
+(:mod:`gradata.adapters.base`).
+"""
+
+from __future__ import annotations
+
+from gradata.adapters.base import MemoryAdapter
+from gradata.adapters.mem0 import Mem0Adapter
+
+__all__ = ["Mem0Adapter", "MemoryAdapter"]

--- a/src/gradata/adapters/base.py
+++ b/src/gradata/adapters/base.py
@@ -1,0 +1,93 @@
+"""
+MemoryAdapter protocol — backend-agnostic shape for external memory stores.
+===========================================================================
+
+Every external adapter (Mem0, Letta, EverMind, Hermes, ...) implements this
+same three-method protocol so callers can swap backends without touching
+their learning code.
+
+Design notes:
+- `typing.runtime_checkable` so callers can do `isinstance(x, MemoryAdapter)`
+- Sync-only for now; an async counterpart can ship later once a concrete
+  adapter needs it.
+- Adapters NEVER raise on backend failure. They log and return `None` or
+  `[]` so a misbehaving memory backend cannot take down the host brain.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class MemoryAdapter(Protocol):
+    """Backend-agnostic interface for mirroring corrections to / pulling
+    context from an external memory store.
+
+    Concrete implementations must be safe to call from any thread and must
+    never raise on transport failure. A failed call returns ``None`` (for
+    writes) or ``[]`` (for reads) and logs at ``WARNING``.
+    """
+
+    def push_correction(
+        self,
+        *,
+        draft: str,
+        final: str,
+        summary: str = "",
+        tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> str | None:
+        """Mirror a Gradata correction to the external store.
+
+        Args:
+            draft: What the AI originally produced.
+            final: What the user corrected it to.
+            summary: Short human-readable summary of the correction.
+            tags: Optional tags / categories for filtering on retrieval.
+            metadata: Optional extra metadata (session id, lesson id, etc).
+
+        Returns:
+            The external memory id (string) on success, or ``None`` on
+            failure. MUST NOT raise.
+        """
+        ...
+
+    def pull_memory_for_context(
+        self,
+        query: str,
+        *,
+        k: int = 5,
+        filters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Fetch up to ``k`` memories relevant to ``query``.
+
+        Args:
+            query: Free-text query (usually the current draft or task).
+            k: Max number of memories to return.
+            filters: Optional backend-specific filters (user_id, tags, ...).
+
+        Returns:
+            A list of dicts with keys ``text``, ``metadata``, ``score``.
+            Returns ``[]`` on failure. MUST NOT raise.
+        """
+        ...
+
+    def reconcile(
+        self,
+        *,
+        gradata_memory_ids: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Return a diff between Gradata's local memory and the external
+        backend.
+
+        Implementations may be best-effort. The return shape is
+        intentionally loose (a dict with keys like ``only_local``,
+        ``only_remote``, ``conflicts``) so different backends can report
+        whatever their API actually supports.
+
+        Returns:
+            A reconciliation report dict. Returns ``{}`` on failure.
+            MUST NOT raise.
+        """
+        ...

--- a/src/gradata/adapters/mem0.py
+++ b/src/gradata/adapters/mem0.py
@@ -115,16 +115,16 @@ class Mem0Adapter:
             {"role": "user", "content": final},
         ]
 
-        meta: dict[str, Any] = {
-            "source": "gradata",
-            "kind": "correction",
-        }
+        meta: dict[str, Any] = {}
+        if metadata:
+            meta.update(metadata)
+        # Internal keys set AFTER caller metadata so they cannot be overridden.
+        meta["source"] = "gradata"
+        meta["kind"] = "correction"
         if summary:
             meta["summary"] = summary
         if tags:
             meta["tags"] = list(tags)
-        if metadata:
-            meta.update(metadata)
 
         try:
             response = self._client.add(

--- a/src/gradata/adapters/mem0.py
+++ b/src/gradata/adapters/mem0.py
@@ -1,0 +1,297 @@
+"""
+Mem0 memory adapter.
+====================
+
+Opt-in mirror between Gradata corrections and a Mem0 workspace. Implements
+the :class:`~gradata.adapters.base.MemoryAdapter` protocol.
+
+Install the optional extra::
+
+    pip install "gradata[adapters-mem0]"
+
+Usage::
+
+    import os
+    from gradata.adapters.mem0 import Mem0Adapter
+
+    adapter = Mem0Adapter(
+        api_key=os.environ["MEM0_API_KEY"],
+        user_id="oliver",
+    )
+
+    memory_id = adapter.push_correction(
+        draft="hey there",
+        final="Hi Oliver,",
+        summary="greeting style: full name, no 'hey there'",
+        tags=["email", "greeting"],
+    )
+
+    hits = adapter.pull_memory_for_context("draft cold email", k=5)
+
+The adapter never raises on backend failure: writes return ``None`` and
+reads return ``[]``. A host brain must stay up even if Mem0 is down.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class Mem0Adapter:
+    """MemoryAdapter backed by the Mem0 managed service.
+
+    This class wraps the official `mem0ai` Python SDK's `MemoryClient`.
+    It is deliberately a thin shim: all Gradata-specific enrichment lives
+    in ``push_correction``; ``pull_memory_for_context`` and ``reconcile``
+    are mostly passthroughs.
+
+    Args:
+        api_key: Mem0 API key. Required unless ``client`` is supplied.
+        user_id: Default Mem0 user id to scope all operations to. Required.
+        client: Optional pre-constructed Mem0 client. Used for tests and
+            for callers who want custom Mem0 config. When supplied,
+            ``api_key`` is ignored.
+
+    Raises:
+        ValueError: If ``user_id`` is empty.
+        ImportError: If ``mem0ai`` is not installed AND no ``client`` is
+            supplied.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        user_id: str,
+        client: Any | None = None,
+    ) -> None:
+        if not user_id:
+            raise ValueError("Mem0Adapter requires a non-empty user_id")
+
+        self.user_id: str = user_id
+
+        if client is not None:
+            self._client = client
+            return
+
+        try:
+            from mem0 import MemoryClient  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise ImportError(
+                "Mem0Adapter requires the 'mem0ai' package. "
+                "Install with: pip install 'gradata[adapters-mem0]'"
+            ) from exc
+
+        if not api_key:
+            raise ValueError(
+                "Mem0Adapter requires an api_key when no client is supplied"
+            )
+        self._client = MemoryClient(api_key=api_key)
+
+    # ------------------------------------------------------------------
+    # MemoryAdapter protocol
+    # ------------------------------------------------------------------
+
+    def push_correction(
+        self,
+        *,
+        draft: str,
+        final: str,
+        summary: str = "",
+        tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> str | None:
+        """Mirror a Gradata correction to Mem0.
+
+        Builds a messages payload from the draft / final pair and calls
+        ``client.add()``. Returns the first memory id Mem0 reports, or
+        ``None`` on any failure.
+        """
+        messages = [
+            {"role": "assistant", "content": draft},
+            {"role": "user", "content": final},
+        ]
+
+        meta: dict[str, Any] = {
+            "source": "gradata",
+            "kind": "correction",
+        }
+        if summary:
+            meta["summary"] = summary
+        if tags:
+            meta["tags"] = list(tags)
+        if metadata:
+            meta.update(metadata)
+
+        try:
+            response = self._client.add(
+                messages,
+                user_id=self.user_id,
+                metadata=meta,
+            )
+        except Exception as exc:
+            logger.warning("Mem0Adapter.push_correction failed: %s", exc)
+            return None
+
+        return _extract_memory_id(response)
+
+    def pull_memory_for_context(
+        self,
+        query: str,
+        *,
+        k: int = 5,
+        filters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Search Mem0 for up to ``k`` memories relevant to ``query``.
+
+        Returns a normalised ``list[dict]`` with keys ``text``, ``metadata``,
+        ``score``. Returns ``[]`` on failure.
+        """
+        try:
+            raw = self._client.search(
+                query,
+                user_id=self.user_id,
+                limit=k,
+                filters=filters,
+            )
+        except TypeError:
+            # Older mem0ai versions don't accept `filters` kwarg.
+            try:
+                raw = self._client.search(
+                    query, user_id=self.user_id, limit=k
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Mem0Adapter.pull_memory_for_context failed: %s", exc
+                )
+                return []
+        except Exception as exc:
+            logger.warning(
+                "Mem0Adapter.pull_memory_for_context failed: %s", exc
+            )
+            return []
+
+        return _normalise_search_results(raw)
+
+    def reconcile(
+        self,
+        *,
+        gradata_memory_ids: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """List all Mem0 memories for this user and diff against the
+        caller-supplied Gradata memory ids.
+
+        Returns:
+            ``{"only_local": [...], "only_remote": [...], "remote_count": N}``
+            or ``{}`` on failure.
+        """
+        try:
+            raw = self._client.get_all(user_id=self.user_id)
+        except Exception as exc:
+            logger.warning("Mem0Adapter.reconcile failed: %s", exc)
+            return {}
+
+        remote_ids = _extract_all_ids(raw)
+        local_ids = set(gradata_memory_ids or [])
+        remote_set = set(remote_ids)
+
+        return {
+            "only_local": sorted(local_ids - remote_set),
+            "only_remote": sorted(remote_set - local_ids),
+            "remote_count": len(remote_set),
+        }
+
+
+# ----------------------------------------------------------------------
+# Response-shape helpers (Mem0 SDK returns slightly different shapes
+# across versions; isolate the parsing in one place)
+# ----------------------------------------------------------------------
+
+
+def _extract_memory_id(response: Any) -> str | None:
+    """Best-effort: pluck a memory id out of whatever ``client.add()``
+    returned.
+
+    Handles all observed Mem0 shapes:
+      - ``{"id": "..."}``
+      - ``{"results": [{"id": "..."}, ...]}``
+      - ``[{"id": "..."}, ...]``
+      - ``"..."`` (plain id)
+    """
+    if response is None:
+        return None
+    if isinstance(response, str):
+        return response
+    if isinstance(response, dict):
+        if "id" in response and isinstance(response["id"], str):
+            return response["id"]
+        results = response.get("results")
+        if isinstance(results, list) and results:
+            first = results[0]
+            if isinstance(first, dict) and isinstance(first.get("id"), str):
+                return first["id"]
+    if isinstance(response, list) and response:
+        first = response[0]
+        if isinstance(first, dict) and isinstance(first.get("id"), str):
+            return first["id"]
+    return None
+
+
+def _normalise_search_results(raw: Any) -> list[dict[str, Any]]:
+    """Coerce Mem0 search output into ``list[{text, metadata, score}]``."""
+    if raw is None:
+        return []
+
+    # mem0ai >=0.1 wraps results in {"results": [...]}
+    if isinstance(raw, dict):
+        items = raw.get("results")
+        if not isinstance(items, list):
+            return []
+    elif isinstance(raw, list):
+        items = raw
+    else:
+        return []
+
+    out: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        # Mem0 uses "memory" for the text in most versions; fall back to
+        # "text" and "content" for older / alternative shapes.
+        text = (
+            item.get("memory")
+            or item.get("text")
+            or item.get("content")
+            or ""
+        )
+        metadata = item.get("metadata") or {}
+        score = item.get("score")
+        out.append({
+            "text": text,
+            "metadata": metadata if isinstance(metadata, dict) else {},
+            "score": score,
+        })
+    return out
+
+
+def _extract_all_ids(raw: Any) -> list[str]:
+    """Pull every ``id`` out of a ``client.get_all()`` response."""
+    if raw is None:
+        return []
+    if isinstance(raw, dict):
+        items = raw.get("results")
+        if not isinstance(items, list):
+            return []
+    elif isinstance(raw, list):
+        items = raw
+    else:
+        return []
+
+    ids: list[str] = []
+    for item in items:
+        if isinstance(item, dict) and isinstance(item.get("id"), str):
+            ids.append(item["id"])
+    return ids

--- a/tests/test_mem0_adapter.py
+++ b/tests/test_mem0_adapter.py
@@ -1,0 +1,328 @@
+"""Tests for :mod:`gradata.adapters.mem0`.
+
+All tests use an injected fake client so the suite runs offline. A single
+``@pytest.mark.integration`` smoke test hits the real Mem0 API when
+``MEM0_API_KEY`` is set in the environment.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+from gradata.adapters import Mem0Adapter, MemoryAdapter
+
+# ---------------------------------------------------------------------------
+# Fake Mem0 client
+# ---------------------------------------------------------------------------
+
+
+class _FakeMem0Client:
+    """Minimal stand-in for ``mem0.MemoryClient``.
+
+    Records every call so tests can assert on payload shape. Returns
+    canned responses that mirror the real SDK's dict envelopes.
+    """
+
+    def __init__(
+        self,
+        *,
+        add_response: Any = None,
+        search_response: Any = None,
+        get_all_response: Any = None,
+        raise_on: set[str] | None = None,
+        accepts_filters: bool = True,
+    ) -> None:
+        self.add_response = add_response
+        self.search_response = search_response
+        self.get_all_response = get_all_response
+        self._raise_on = raise_on or set()
+        self._accepts_filters = accepts_filters
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def add(self, messages: Any, **kwargs: Any) -> Any:
+        self.calls.append(("add", {"messages": messages, **kwargs}))
+        if "add" in self._raise_on:
+            raise RuntimeError("boom")
+        return self.add_response
+
+    def search(self, query: str, **kwargs: Any) -> Any:
+        if not self._accepts_filters and "filters" in kwargs:
+            raise TypeError("search() got unexpected keyword 'filters'")
+        self.calls.append(("search", {"query": query, **kwargs}))
+        if "search" in self._raise_on:
+            raise RuntimeError("boom")
+        return self.search_response
+
+    def get_all(self, **kwargs: Any) -> Any:
+        self.calls.append(("get_all", kwargs))
+        if "get_all" in self._raise_on:
+            raise RuntimeError("boom")
+        return self.get_all_response
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_requires_user_id() -> None:
+    with pytest.raises(ValueError, match="user_id"):
+        Mem0Adapter(api_key="k", user_id="", client=_FakeMem0Client())
+
+
+def test_accepts_injected_client_without_api_key() -> None:
+    adapter = Mem0Adapter(user_id="oliver", client=_FakeMem0Client())
+    assert adapter.user_id == "oliver"
+
+
+def test_runtime_checkable_protocol() -> None:
+    adapter = Mem0Adapter(user_id="oliver", client=_FakeMem0Client())
+    assert isinstance(adapter, MemoryAdapter)
+
+
+# ---------------------------------------------------------------------------
+# push_correction
+# ---------------------------------------------------------------------------
+
+
+def test_push_correction_returns_id_from_results_envelope() -> None:
+    fake = _FakeMem0Client(
+        add_response={"results": [{"id": "mem-123"}, {"id": "mem-124"}]}
+    )
+    adapter = Mem0Adapter(user_id="oliver", client=fake)
+
+    memory_id = adapter.push_correction(
+        draft="hey there",
+        final="Hi Oliver,",
+        summary="greeting style",
+        tags=["email", "greeting"],
+    )
+
+    assert memory_id == "mem-123"
+    assert len(fake.calls) == 1
+    name, payload = fake.calls[0]
+    assert name == "add"
+
+    messages = payload["messages"]
+    assert messages == [
+        {"role": "assistant", "content": "hey there"},
+        {"role": "user", "content": "Hi Oliver,"},
+    ]
+    assert payload["user_id"] == "oliver"
+
+    meta = payload["metadata"]
+    assert meta["source"] == "gradata"
+    assert meta["kind"] == "correction"
+    assert meta["summary"] == "greeting style"
+    assert meta["tags"] == ["email", "greeting"]
+
+
+def test_push_correction_handles_flat_id_response() -> None:
+    fake = _FakeMem0Client(add_response={"id": "mem-flat"})
+    adapter = Mem0Adapter(user_id="oliver", client=fake)
+    assert adapter.push_correction(draft="a", final="b") == "mem-flat"
+
+
+def test_push_correction_handles_list_response() -> None:
+    fake = _FakeMem0Client(add_response=[{"id": "mem-list"}])
+    adapter = Mem0Adapter(user_id="oliver", client=fake)
+    assert adapter.push_correction(draft="a", final="b") == "mem-list"
+
+
+def test_push_correction_handles_string_response() -> None:
+    fake = _FakeMem0Client(add_response="mem-str")
+    adapter = Mem0Adapter(user_id="oliver", client=fake)
+    assert adapter.push_correction(draft="a", final="b") == "mem-str"
+
+
+def test_push_correction_returns_none_on_unknown_shape() -> None:
+    fake = _FakeMem0Client(add_response={"no": "id"})
+    adapter = Mem0Adapter(user_id="oliver", client=fake)
+    assert adapter.push_correction(draft="a", final="b") is None
+
+
+def test_push_correction_returns_none_and_logs_on_exception(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    fake = _FakeMem0Client(raise_on={"add"})
+    adapter = Mem0Adapter(user_id="oliver", client=fake)
+
+    with caplog.at_level("WARNING", logger="gradata.adapters.mem0"):
+        result = adapter.push_correction(draft="a", final="b")
+
+    assert result is None
+    assert any("push_correction failed" in r.message for r in caplog.records)
+
+
+def test_push_correction_merges_extra_metadata() -> None:
+    fake = _FakeMem0Client(add_response={"id": "mem-1"})
+    adapter = Mem0Adapter(user_id="oliver", client=fake)
+    adapter.push_correction(
+        draft="a",
+        final="b",
+        metadata={"session_id": "s42", "lesson_id": "L1"},
+    )
+    _, payload = fake.calls[0]
+    meta = payload["metadata"]
+    assert meta["session_id"] == "s42"
+    assert meta["lesson_id"] == "L1"
+    assert meta["source"] == "gradata"  # base metadata still present
+
+
+# ---------------------------------------------------------------------------
+# pull_memory_for_context
+# ---------------------------------------------------------------------------
+
+
+def test_pull_memory_for_context_normalises_results() -> None:
+    fake = _FakeMem0Client(
+        search_response={
+            "results": [
+                {
+                    "memory": "user prefers full names",
+                    "metadata": {"tags": ["greeting"]},
+                    "score": 0.91,
+                },
+                {
+                    "memory": "no em dashes",
+                    "metadata": {"tags": ["style"]},
+                    "score": 0.77,
+                },
+            ]
+        }
+    )
+    adapter = Mem0Adapter(user_id="oliver", client=fake)
+
+    hits = adapter.pull_memory_for_context("draft cold email", k=5)
+
+    assert len(hits) == 2
+    assert hits[0] == {
+        "text": "user prefers full names",
+        "metadata": {"tags": ["greeting"]},
+        "score": 0.91,
+    }
+    _, payload = fake.calls[0]
+    assert payload["query"] == "draft cold email"
+    assert payload["user_id"] == "oliver"
+    assert payload["limit"] == 5
+
+
+def test_pull_memory_for_context_handles_bare_list() -> None:
+    fake = _FakeMem0Client(
+        search_response=[{"text": "plain text memory", "score": 0.5}]
+    )
+    adapter = Mem0Adapter(user_id="oliver", client=fake)
+    hits = adapter.pull_memory_for_context("q")
+    assert hits == [{"text": "plain text memory", "metadata": {}, "score": 0.5}]
+
+
+def test_pull_memory_for_context_retries_without_filters_for_old_sdks() -> None:
+    fake = _FakeMem0Client(
+        search_response={"results": [{"memory": "x"}]},
+        accepts_filters=False,
+    )
+    adapter = Mem0Adapter(user_id="oliver", client=fake)
+
+    hits = adapter.pull_memory_for_context(
+        "q", k=3, filters={"tag": "email"}
+    )
+
+    assert len(hits) == 1
+    # Exactly one successful call: the retry without the filters kwarg.
+    # (The TypeError path rejects before appending to calls.)
+    assert len(fake.calls) == 1
+    _, payload = fake.calls[0]
+    assert "filters" not in payload
+
+
+def test_pull_memory_for_context_returns_empty_on_exception(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    fake = _FakeMem0Client(raise_on={"search"})
+    adapter = Mem0Adapter(user_id="oliver", client=fake)
+
+    with caplog.at_level("WARNING", logger="gradata.adapters.mem0"):
+        hits = adapter.pull_memory_for_context("q")
+
+    assert hits == []
+    assert any(
+        "pull_memory_for_context failed" in r.message for r in caplog.records
+    )
+
+
+def test_pull_memory_for_context_handles_none() -> None:
+    fake = _FakeMem0Client(search_response=None)
+    adapter = Mem0Adapter(user_id="oliver", client=fake)
+    assert adapter.pull_memory_for_context("q") == []
+
+
+# ---------------------------------------------------------------------------
+# reconcile
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_produces_diff() -> None:
+    fake = _FakeMem0Client(
+        get_all_response={
+            "results": [
+                {"id": "mem-1"},
+                {"id": "mem-2"},
+                {"id": "mem-3"},
+            ]
+        }
+    )
+    adapter = Mem0Adapter(user_id="oliver", client=fake)
+
+    report = adapter.reconcile(gradata_memory_ids=["mem-2", "mem-local-only"])
+
+    assert report["remote_count"] == 3
+    assert report["only_local"] == ["mem-local-only"]
+    assert report["only_remote"] == ["mem-1", "mem-3"]
+
+
+def test_reconcile_handles_bare_list() -> None:
+    fake = _FakeMem0Client(get_all_response=[{"id": "a"}, {"id": "b"}])
+    adapter = Mem0Adapter(user_id="oliver", client=fake)
+    report = adapter.reconcile(gradata_memory_ids=[])
+    assert report["remote_count"] == 2
+    assert report["only_remote"] == ["a", "b"]
+
+
+def test_reconcile_returns_empty_on_exception(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    fake = _FakeMem0Client(raise_on={"get_all"})
+    adapter = Mem0Adapter(user_id="oliver", client=fake)
+    with caplog.at_level("WARNING", logger="gradata.adapters.mem0"):
+        assert adapter.reconcile() == {}
+    assert any("reconcile failed" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Real-client integration smoke test (skipped unless MEM0_API_KEY is set)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("MEM0_API_KEY"),
+    reason="MEM0_API_KEY not set; skipping real Mem0 smoke test",
+)
+def test_real_mem0_roundtrip() -> None:
+    adapter = Mem0Adapter(
+        api_key=os.environ["MEM0_API_KEY"],
+        user_id="gradata-ci-smoke",
+    )
+    memory_id = adapter.push_correction(
+        draft="hey there",
+        final="Hi Oliver,",
+        summary="greeting style smoke test",
+        tags=["gradata-ci"],
+    )
+    assert memory_id is not None
+
+    hits = adapter.pull_memory_for_context("greeting style", k=3)
+    assert isinstance(hits, list)

--- a/tests/test_mem0_adapter.py
+++ b/tests/test_mem0_adapter.py
@@ -172,6 +172,39 @@ def test_push_correction_merges_extra_metadata() -> None:
     assert meta["source"] == "gradata"  # base metadata still present
 
 
+def test_push_correction_caller_metadata_cannot_override_internal_keys() -> None:
+    """Reserved internal keys (source, kind) must win over caller metadata.
+
+    Regression guard for CodeRabbit review on PR #79: if caller metadata were
+    merged AFTER the internal keys, a malicious or careless caller could
+    impersonate gradata-origin records or hide the correction kind.
+    """
+    fake = _FakeMem0Client(add_response={"id": "mem-1"})
+    adapter = Mem0Adapter(user_id="oliver", client=fake)
+    adapter.push_correction(
+        draft="a",
+        final="b",
+        summary="legit summary",
+        tags=["legit"],
+        metadata={
+            "source": "evil",
+            "kind": "evil",
+            "summary": "evil summary",
+            "tags": ["evil"],
+            "session_id": "s42",  # non-reserved keys should still pass through
+        },
+    )
+    _, payload = fake.calls[0]
+    meta = payload["metadata"]
+    # Reserved internal keys must be preserved.
+    assert meta["source"] == "gradata"
+    assert meta["kind"] == "correction"
+    assert meta["summary"] == "legit summary"
+    assert meta["tags"] == ["legit"]
+    # Non-reserved caller keys still flow through.
+    assert meta["session_id"] == "s42"
+
+
 # ---------------------------------------------------------------------------
 # pull_memory_for_context
 # ---------------------------------------------------------------------------

--- a/tests/test_mem0_adapter.py
+++ b/tests/test_mem0_adapter.py
@@ -120,28 +120,22 @@ def test_push_correction_returns_id_from_results_envelope() -> None:
     assert meta["tags"] == ["email", "greeting"]
 
 
-def test_push_correction_handles_flat_id_response() -> None:
-    fake = _FakeMem0Client(add_response={"id": "mem-flat"})
+@pytest.mark.parametrize(
+    "add_response, expected_id",
+    [
+        ({"id": "mem-flat"}, "mem-flat"),
+        ([{"id": "mem-list"}], "mem-list"),
+        ("mem-str", "mem-str"),
+        ({"no": "id"}, None),
+    ],
+    ids=["flat_id", "list_response", "string_response", "unknown_shape"],
+)
+def test_push_correction_handles_response_shapes(
+    add_response: Any, expected_id: str | None
+) -> None:
+    fake = _FakeMem0Client(add_response=add_response)
     adapter = Mem0Adapter(user_id="oliver", client=fake)
-    assert adapter.push_correction(draft="a", final="b") == "mem-flat"
-
-
-def test_push_correction_handles_list_response() -> None:
-    fake = _FakeMem0Client(add_response=[{"id": "mem-list"}])
-    adapter = Mem0Adapter(user_id="oliver", client=fake)
-    assert adapter.push_correction(draft="a", final="b") == "mem-list"
-
-
-def test_push_correction_handles_string_response() -> None:
-    fake = _FakeMem0Client(add_response="mem-str")
-    adapter = Mem0Adapter(user_id="oliver", client=fake)
-    assert adapter.push_correction(draft="a", final="b") == "mem-str"
-
-
-def test_push_correction_returns_none_on_unknown_shape() -> None:
-    fake = _FakeMem0Client(add_response={"no": "id"})
-    adapter = Mem0Adapter(user_id="oliver", client=fake)
-    assert adapter.push_correction(draft="a", final="b") is None
+    assert adapter.push_correction(draft="a", final="b") == expected_id
 
 
 def test_push_correction_returns_none_and_logs_on_exception(


### PR DESCRIPTION
## Summary
First external-memory adapter. Greenfield `src/gradata/adapters/` module with `MemoryAdapter` Protocol + concrete `Mem0Adapter`. Lays the pattern for Letta/EverMind/Hermes follow-ups.

## API
```python
from gradata.adapters import Mem0Adapter
adapter = Mem0Adapter(api_key=..., user_id=..., client=None)  # client= for DI/tests
adapter.push_correction(*, draft, final, summary="", tags=None, metadata=None) -> str | None
adapter.pull_memory_for_context(query, *, k=5, filters=None) -> list[dict]
adapter.reconcile(*, gradata_memory_ids=None) -> dict
```

All three methods swallow backend exceptions, log at WARNING, return sentinel (`None` / `[]` / `{}`).

## Optional dep
Added `adapters-mem0 = ["mem0ai>=0.1.0"]` extra in `pyproject.toml` and folded into `all`. Lazy-imported inside `__init__`, so `from gradata.adapters import Mem0Adapter` works without the extra installed.

## Wiring
NOT wired into the event pipeline. Users call `adapter.push_correction()` themselves. Auto-mirror via `Brain(...)` constructor option is a follow-up.

## Divergences from plan (intentional)
1. Added `client=` DI kwarg — only clean way to hit "fake-client tests pass without network" without monkeypatching.
2. Added response-shape tolerance (`_extract_memory_id`, `_normalise_search_results`, `_extract_all_ids`) — `mem0ai` shipped 3 different envelope shapes across versions.
3. Added SDK-version fallback test.

## Tests
2419 pass (+18 fake-client + 1 gated integration test on `MEM0_API_KEY`). Ruff clean.

## Commits
- `0ede7e7` feat(adapters): Mem0 memory adapter with push/pull/reconcile protocol

Co-Authored-By: Gradata <noreply@gradata.ai>