### PR TITLE
feat(rule-to-hook): close auto-promotion loop in injection paths (Phase 5)

### DIFF
--- a/src/gradata/_types.py
+++ b/src/gradata/_types.py
@@ -178,6 +178,10 @@ class Lesson:
     # / rule_evolution decay confidence once this crosses a threshold.
     _contradiction_streak: int = 0  # Consecutive contradictions; triggers self-correction / penalty acceleration
     stale: bool = False  # True = demoted via TTL (sessions_since_fire >= ttl); flagged for review
+    # Phase 5 council hook: optional registry slot for AST-class promotion routing.
+    # Unset today (rule_to_hook uses the regex-matched DETERMINISTIC_PATTERNS table).
+    # Reserved for a future AST-transform registry (shell substitution, path enforcement, etc.).
+    determinism_class: str | None = None
 
     def __post_init__(self) -> None:
         self.confidence = round(max(0.0, min(1.0, self.confidence)), 2)

--- a/src/gradata/cli.py
+++ b/src/gradata/cli.py
@@ -760,6 +760,36 @@ def cmd_rule_remove(args):
         if touched_lesson:
             lessons_file.write_text("\n".join(out_lines) + "\n", encoding="utf-8")
 
+    # Emit a RULE_PATCH_REVERTED event when a human explicitly demotes a
+    # hook-enforced rule back to text injection (or purges it). The
+    # empirical promotion gate consumes this signal so a recently-reverted
+    # rule cannot immediately re-promote.
+    if removed_file or touched_lesson:
+        try:
+            from gradata import _events
+            from gradata.enhancements.rule_to_hook import (
+                HOOK_DEMOTED,
+                RULE_PATCH_REVERTED,
+            )
+            _events.emit(
+                RULE_PATCH_REVERTED,
+                "cli:rule-remove",
+                {
+                    "slug": slug,
+                    "purge": bool(getattr(args, "purge", False)),
+                    "hook_removed": bool(removed_file),
+                    "lesson_touched": bool(touched_lesson),
+                },
+            )
+            if removed_file:
+                _events.emit(
+                    HOOK_DEMOTED,
+                    "cli:rule-remove",
+                    {"slug": slug, "hook_path": str(removed_file)},
+                )
+        except Exception:
+            pass  # Event emission is best-effort; CLI output still succeeds.
+
     if removed_file:
         print(f"Removed hook: {removed_file}")
     if touched_lesson and args.purge:

--- a/src/gradata/cli.py
+++ b/src/gradata/cli.py
@@ -682,21 +682,32 @@ def cmd_rule_remove(args):
             break
 
     # 2. Find matching lesson by slug → description
+    # Also clear `metadata.how_enforced = "hooked"` from any structured
+    # Metadata JSON line attached to this lesson, so the next graduation
+    # pass treats the rule as ordinary prompt injection again.
     touched_lesson = False
     if lessons_file.exists():
+        import json as _json_meta
+
         lines = lessons_file.read_text(encoding="utf-8").splitlines()
-        out_lines = []
+        out_lines: list[str] = []
         # Accept optional legacy "[hooked]" token between the state bracket
         # and the category (normalised out of the prefix so reformatted lines
         # carry the marker only in the description).
         lesson_re = _re.compile(
             r"^(\[[\d-]+\]\s+\[RULE:[\d.]+\])\s+(?:\[hooked\]\s+)?(\w+):\s+(.+)$"
         )
-        for line in lines:
+        # When purging, skip the lesson's trailing metadata block (indented
+        # lines) so we don't leave orphans. When unmarking, we process each
+        # indented line normally but rewrite the Metadata JSON.
+        i = 0
+        while i < len(lines):
+            line = lines[i]
             stripped = line.strip()
             m = lesson_re.match(stripped)
             if not m:
                 out_lines.append(line)
+                i += 1
                 continue
             state_prefix = m.group(1)
             category = m.group(2)
@@ -706,18 +717,46 @@ def cmd_rule_remove(args):
             modern_marker = desc.startswith("[hooked] ")
             was_hooked = legacy_marker or modern_marker
             clean_desc = desc[len("[hooked] "):] if modern_marker else desc
-            if _slug(clean_desc) == slug:
-                if args.purge:
-                    touched_lesson = True
-                    continue  # drop the line entirely
-                if was_hooked:
-                    touched_lesson = True
-                    out_lines.append(f"{prefix}: {clean_desc}")
-                else:
-                    # Already unmarked — no change needed
-                    out_lines.append(line)
+            match_this = _slug(clean_desc) == slug
+
+            if not match_this:
+                out_lines.append(line)
+                i += 1
+                continue
+
+            if args.purge:
+                # Drop header + all indented follow-on lines belonging to it.
+                touched_lesson = True
+                i += 1
+                while i < len(lines) and lines[i].startswith("  "):
+                    i += 1
+                continue
+
+            # Unmark path: rewrite the header (strip [hooked] prefix) and
+            # rewrite any Metadata: JSON so how_enforced goes back to "injected".
+            if was_hooked:
+                touched_lesson = True
+                out_lines.append(f"{prefix}: {clean_desc}")
             else:
                 out_lines.append(line)
+            i += 1
+            while i < len(lines) and lines[i].startswith("  "):
+                meta_line = lines[i]
+                meta_stripped = meta_line.strip()
+                if meta_stripped.startswith("Metadata:"):
+                    payload = meta_stripped[len("Metadata:"):].strip()
+                    try:
+                        md = _json_meta.loads(payload)
+                    except (ValueError, TypeError):
+                        md = None
+                    if isinstance(md, dict) and md.get("how_enforced") == "hooked":
+                        md["how_enforced"] = "injected"
+                        touched_lesson = True
+                        out_lines.append(f"  Metadata: {_json_meta.dumps(md)}")
+                        i += 1
+                        continue
+                out_lines.append(meta_line)
+                i += 1
         if touched_lesson:
             lessons_file.write_text("\n".join(out_lines) + "\n", encoding="utf-8")
 

--- a/src/gradata/enhancements/rule_to_hook.py
+++ b/src/gradata/enhancements/rule_to_hook.py
@@ -393,6 +393,86 @@ def _log_outcome(brain, source: str, candidate: HookCandidate, result: Generatio
         pass  # never fail graduation on a logging error
 
 
+def promote(
+    description: str,
+    confidence: float,
+    *,
+    brain=None,
+    positive_example: str | None = None,
+    source: str = "promote",
+) -> GenerationResult:
+    """Public entry point: classify + generate + install a hook for a rule.
+
+    Phase 5 auto-promotion: a convenience wrapper around classify_rule +
+    try_generate that callers outside the graduation pipeline (CLI,
+    tests, external tooling) can use to promote a single rule. Callers
+    that need lesson-state round-tripping (setting ``metadata.how_enforced``
+    on the source Lesson) should mutate the lesson themselves after checking
+    ``result.installed`` — promote() intentionally does not touch lessons.md
+    so it stays composable with the graduation loop's own persistence step.
+
+    Returns a GenerationResult. Not-deterministic rules return
+    ``installed=False`` with an explanatory reason; callers should fall back
+    to prompt injection.
+    """
+    candidate = classify_rule(description, confidence)
+    if candidate.determinism == DeterminismCheck.NOT_DETERMINISTIC:
+        return GenerationResult(
+            installed=False,
+            reason=candidate.reason,
+        )
+    return try_generate(
+        candidate,
+        positive_example=positive_example,
+        brain=brain,
+        source=source,
+    )
+
+
+def demote(slug: str, *, brain=None, source: str = "demote") -> GenerationResult:
+    """Remove an installed hook file. Inverse of promote().
+
+    Looks in both pre-tool and post-tool generated directories. Returns a
+    GenerationResult whose ``installed`` field is True iff the file existed
+    and was removed, with ``hook_path`` set to the removed path.
+
+    Does not touch lessons.md — callers should clear
+    ``metadata.how_enforced`` on the matching lesson themselves to re-enable
+    text injection at the next graduation pass.
+    """
+    roots = [_hook_root()]
+    post_override = os.environ.get("GRADATA_HOOK_ROOT_POST")
+    post_root = Path(post_override) if post_override else Path(".claude/hooks/post-tool/generated")
+    roots.append(post_root)
+
+    for root in roots:
+        target = root / f"{slug}.js"
+        if target.exists():
+            try:
+                target.unlink()
+            except OSError as exc:
+                return GenerationResult(
+                    installed=False,
+                    reason=f"unlink failed: {exc}",
+                    hook_path=target,
+                )
+            if brain is not None:
+                with contextlib.suppress(Exception):
+                    brain.emit("RULE_TO_HOOK_REMOVED", source, {
+                        "slug": slug,
+                        "hook_path": str(target),
+                    })
+            return GenerationResult(
+                installed=True,
+                reason=f"removed {target}",
+                hook_path=target,
+            )
+    return GenerationResult(
+        installed=False,
+        reason=f"no hook file found for slug: {slug}",
+    )
+
+
 def try_generate(
     candidate: HookCandidate,
     *,

--- a/src/gradata/enhancements/rule_to_hook.py
+++ b/src/gradata/enhancements/rule_to_hook.py
@@ -5,13 +5,164 @@ from __future__ import annotations
 import contextlib
 import hashlib
 import json
+import logging
 import os
 import re
 import subprocess
 import tempfile
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from pathlib import Path
+
+_log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Event type constants (emitted from CLI + future manifest.demote paths)
+# ---------------------------------------------------------------------------
+
+# Emitted when a hook-enforced rule gets a human-authored text patch that
+# reverts to soft prompt injection (manifest.demote path, cmd_rule_remove).
+RULE_PATCH_REVERTED = "RULE_PATCH_REVERTED"
+# Emitted when an installed generated hook is removed (demote path).
+HOOK_DEMOTED = "HOOK_DEMOTED"
+
+
+# ---------------------------------------------------------------------------
+# Empirical promotion gate (council verdict, Phase 5)
+# ---------------------------------------------------------------------------
+
+PROMOTION_MIN_FIRE_COUNT = 10
+PROMOTION_MIN_DISTINCT_SESSIONS = 3
+PROMOTION_REVERSAL_LOOKBACK_DAYS = 30
+
+
+def _resolve_events_path() -> Path | None:
+    """Best-effort events.jsonl resolution (None when no brain is configured)."""
+    try:
+        from gradata import _paths as _p
+        p = Path(_p.EVENTS_JSONL)
+        return p if p.is_file() else None
+    except Exception:
+        return None
+
+
+def count_distinct_sessions(lesson) -> int:
+    """Count distinct sessions this lesson's correction chain spans.
+
+    Uses the proof-chain IDs on the lesson (``correction_event_ids``) as the
+    activation trail — matches the existing audit.py contract. Falls back to
+    0 when no chain exists or events.jsonl is unreachable.
+    """
+    ids = list(getattr(lesson, "correction_event_ids", []) or [])
+    if not ids:
+        return 0
+    events_path = _resolve_events_path()
+    if events_path is None:
+        return 0
+    target = set(ids)
+    sessions: set[int] = set()
+    try:
+        with events_path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    evt = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if str(evt.get("id")) in target or evt.get("id") in target:
+                    s = evt.get("session")
+                    if s is not None:
+                        sessions.add(s)
+    except OSError as exc:
+        _log.debug("count_distinct_sessions: %s", exc)
+        return 0
+    return len(sessions)
+
+
+def count_human_reversals(rule_id: str, since_days: int = PROMOTION_REVERSAL_LOOKBACK_DAYS) -> int:
+    """Count RULE_PATCH_REVERTED + HOOK_DEMOTED events tied to ``rule_id`` in the window.
+
+    Scans events.jsonl directly so the helper works even when SQLite is
+    unavailable. Missing event file => 0 (no reversals recorded yet).
+    """
+    if not rule_id:
+        return 0
+    events_path = _resolve_events_path()
+    if events_path is None:
+        return 0
+    cutoff = datetime.now(UTC) - timedelta(days=since_days)
+    count = 0
+    try:
+        with events_path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    evt = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if evt.get("type") not in (RULE_PATCH_REVERTED, HOOK_DEMOTED):
+                    continue
+                data = evt.get("data") or {}
+                if data.get("rule_id") != rule_id:
+                    continue
+                ts = evt.get("ts")
+                if ts:
+                    try:
+                        evt_time = datetime.fromisoformat(ts)
+                    except ValueError:
+                        continue
+                    if evt_time < cutoff:
+                        continue
+                count += 1
+    except OSError as exc:
+        _log.debug("count_human_reversals: %s", exc)
+        return 0
+    return count
+
+
+def _passes_empirical_gate(lesson) -> tuple[bool, str]:
+    """Council verdict gate: promotion requires empirical track record.
+
+    Checks:
+      - ``lesson.fire_count >= PROMOTION_MIN_FIRE_COUNT``
+      - distinct sessions across ``correction_event_ids`` >= PROMOTION_MIN_DISTINCT_SESSIONS
+      - zero human reversals in the last PROMOTION_REVERSAL_LOOKBACK_DAYS days
+
+    Returns ``(passed, reason)``. The reason is populated on failure.
+    """
+    if lesson is None:
+        return False, "no lesson provided to empirical gate"
+    fire_count = int(getattr(lesson, "fire_count", 0) or 0)
+    if fire_count < PROMOTION_MIN_FIRE_COUNT:
+        return False, (
+            f"fire_count {fire_count} < {PROMOTION_MIN_FIRE_COUNT} "
+            "(council empirical gate)"
+        )
+    sessions = count_distinct_sessions(lesson)
+    if sessions < PROMOTION_MIN_DISTINCT_SESSIONS:
+        return False, (
+            f"distinct sessions {sessions} < {PROMOTION_MIN_DISTINCT_SESSIONS} "
+            "(council empirical gate)"
+        )
+    # Derive the rule_id the same way rule_engine does.
+    try:
+        from gradata.rules.rule_engine import _make_rule_id
+        rule_id = _make_rule_id(lesson)
+    except Exception:
+        rule_id = ""
+    reversals = count_human_reversals(rule_id, since_days=PROMOTION_REVERSAL_LOOKBACK_DAYS)
+    if reversals > 0:
+        return False, (
+            f"{reversals} human reversal(s) in last "
+            f"{PROMOTION_REVERSAL_LOOKBACK_DAYS}d (council empirical gate)"
+        )
+    return True, "empirical gate passed"
 
 
 class EnforcementType(StrEnum):
@@ -400,6 +551,7 @@ def promote(
     brain=None,
     positive_example: str | None = None,
     source: str = "promote",
+    lesson=None,
 ) -> GenerationResult:
     """Public entry point: classify + generate + install a hook for a rule.
 
@@ -411,6 +563,12 @@ def promote(
     ``result.installed`` — promote() intentionally does not touch lessons.md
     so it stays composable with the graduation loop's own persistence step.
 
+    When ``lesson`` is provided, the council empirical gate runs BEFORE
+    generation: ``fire_count >= 10``, distinct sessions across the
+    correction proof-chain >= 3, and zero human reversals in the last
+    30 days. Failing the gate returns ``installed=False`` with a
+    ``reason`` explaining which check blocked promotion.
+
     Returns a GenerationResult. Not-deterministic rules return
     ``installed=False`` with an explanatory reason; callers should fall back
     to prompt injection.
@@ -421,6 +579,11 @@ def promote(
             installed=False,
             reason=candidate.reason,
         )
+    if lesson is not None:
+        passed, reason = _passes_empirical_gate(lesson)
+        if not passed:
+            _log.debug("promote blocked by empirical gate: %s", reason)
+            return GenerationResult(installed=False, reason=reason)
     return try_generate(
         candidate,
         positive_example=positive_example,
@@ -459,6 +622,16 @@ def demote(slug: str, *, brain=None, source: str = "demote") -> GenerationResult
             if brain is not None:
                 with contextlib.suppress(Exception):
                     brain.emit("RULE_TO_HOOK_REMOVED", source, {
+                        "slug": slug,
+                        "hook_path": str(target),
+                    })
+                # Mirror the removal as a HOOK_DEMOTED event so the
+                # empirical gate's reversal counter can see it. rule_id
+                # is unknown at this layer (callers that have it should
+                # emit RULE_PATCH_REVERTED separately); we tag with slug
+                # so CLI-level emits can correlate.
+                with contextlib.suppress(Exception):
+                    brain.emit(HOOK_DEMOTED, source, {
                         "slug": slug,
                         "hook_path": str(target),
                     })

--- a/src/gradata/enhancements/self_improvement.py
+++ b/src/gradata/enhancements/self_improvement.py
@@ -1194,15 +1194,25 @@ def graduate(
                     candidate = rule_to_hook.classify_rule(
                         desc, confidence=float(lesson.confidence)
                     )
-                    gen_result = rule_to_hook.try_generate(
-                        candidate,
-                        brain=brain,
-                        source="graduate",
-                    )
-                    if gen_result.installed:
-                        if lesson.metadata is None:
-                            lesson.metadata = RuleMetadata()
-                        lesson.metadata.how_enforced = "hooked"
+                    # Council empirical gate: fire_count + distinct sessions
+                    # + zero human reversals (last 30d). If any fails, skip
+                    # hook generation — rule stays as text injection.
+                    passed, gate_reason = rule_to_hook._passes_empirical_gate(lesson)
+                    if not passed:
+                        _log.debug(
+                            "rule-to-hook promotion blocked by empirical gate: %s",
+                            gate_reason,
+                        )
+                    else:
+                        gen_result = rule_to_hook.try_generate(
+                            candidate,
+                            brain=brain,
+                            source="graduate",
+                        )
+                        if gen_result.installed:
+                            if lesson.metadata is None:
+                                lesson.metadata = RuleMetadata()
+                            lesson.metadata.how_enforced = "hooked"
             except Exception:
                 pass  # Hook generation is best-effort; never break graduation.
             continue

--- a/src/gradata/hooks/inject_brain_rules.py
+++ b/src/gradata/hooks/inject_brain_rules.py
@@ -16,9 +16,10 @@ from gradata.hooks._base import resolve_brain_dir, run_hook
 from gradata.hooks._profiles import Profile
 
 try:
-    from gradata.enhancements.self_improvement import parse_lessons
+    from gradata.enhancements.self_improvement import is_hook_enforced, parse_lessons
 except ImportError:
     parse_lessons = None
+    is_hook_enforced = None  # type: ignore[assignment]
 
 try:
     from gradata.enhancements.meta_rules import (
@@ -111,6 +112,13 @@ def main(data: dict) -> dict | None:
         lesson for lesson in all_lessons
         if lesson.state.name in ("RULE", "PATTERN") and lesson.confidence >= MIN_CONFIDENCE
     ]
+    # Phase 5 rule-to-hook auto-promotion: rules enforced by an installed
+    # generated hook (metadata.how_enforced == "hooked", or legacy "[hooked]"
+    # description prefix) are applied deterministically, so injecting them as
+    # text wastes context. Hook removal clears the marker and re-enables text
+    # injection automatically.
+    if is_hook_enforced is not None:
+        filtered = [lesson for lesson in filtered if not is_hook_enforced(lesson)]
     if not filtered:
         return None
 

--- a/src/gradata/hooks/jit_inject.py
+++ b/src/gradata/hooks/jit_inject.py
@@ -34,9 +34,10 @@ if TYPE_CHECKING:
     from gradata._types import Lesson
 
 try:
-    from gradata.enhancements.self_improvement import parse_lessons
+    from gradata.enhancements.self_improvement import is_hook_enforced, parse_lessons
 except ImportError:
     parse_lessons = None  # type: ignore[assignment]
+    is_hook_enforced = None  # type: ignore[assignment]
 
 _log = logging.getLogger(__name__)
 
@@ -190,6 +191,9 @@ def main(data: dict) -> dict | None:
         return None
 
     lessons = parse_lessons(text)
+    # Phase 5: skip rules already enforced deterministically by an installed hook.
+    if is_hook_enforced is not None:
+        lessons = [lesson for lesson in lessons if not is_hook_enforced(lesson)]
     if not lessons:
         return None
 

--- a/tests/test_rule_to_hook.py
+++ b/tests/test_rule_to_hook.py
@@ -311,9 +311,32 @@ class TestGraduateIntegration:
     """Task 7: graduate() should auto-attempt hook install on PATTERN->RULE promotion."""
 
     def test_graduate_promotes_and_installs_hook_for_em_dash(self, tmp_path, monkeypatch):
+        import json as _json
+        from datetime import UTC as _UTC
+        from datetime import datetime as _dt
+
         monkeypatch.setenv("GRADATA_HOOK_ROOT", str(tmp_path))
-        from gradata.enhancements.self_improvement import graduate
+        from gradata import _paths as _p
         from gradata._types import Lesson, LessonState
+        from gradata.enhancements.self_improvement import graduate
+
+        # Council empirical gate: seed events.jsonl with 3 distinct-session
+        # correction IDs so fire_count + distinct sessions + zero reversals
+        # all clear. Without this the gate now blocks promotion.
+        brain_dir = tmp_path / "brain"
+        brain_dir.mkdir()
+        events_jsonl = brain_dir / "events.jsonl"
+        with events_jsonl.open("w", encoding="utf-8") as fh:
+            for i, sess in enumerate((1, 2, 3), start=1):
+                fh.write(_json.dumps({
+                    "id": f"e{i}",
+                    "session": sess,
+                    "type": "CORRECTION",
+                    "ts": _dt.now(_UTC).isoformat(),
+                    "data": {},
+                }) + "\n")
+        monkeypatch.setattr(_p, "EVENTS_JSONL", events_jsonl)
+        monkeypatch.setattr(_p, "BRAIN_DIR", brain_dir)
 
         # Build a lesson at PATTERN tier with high confidence + enough fires
         # to promote to RULE. The description matches rule_to_hook's em-dash
@@ -324,7 +347,8 @@ class TestGraduateIntegration:
             confidence=0.95,
             category="FORMATTING",
             description="Never use em dashes",
-            fire_count=10,  # past MIN_APPLICATIONS_FOR_RULE=5 threshold
+            fire_count=10,  # also satisfies council gate >=10
+            correction_event_ids=["e1", "e2", "e3"],
         )
         active, graduated = graduate([lesson], maturity="MATURE")
 

--- a/tests/test_rule_to_hook_promotion.py
+++ b/tests/test_rule_to_hook_promotion.py
@@ -1,0 +1,335 @@
+"""Phase 5 rule-to-hook auto-promotion tests.
+
+Covers the end-to-end loop:
+  - classify_rule finds a deterministic template for a high-confidence rule
+  - promote() installs a hook file on disk
+  - the injection hooks (inject_brain_rules, jit_inject) skip hook-enforced
+    rules so context isn't wasted once the hook is live
+  - demote() removes the file; the round-trip restores text injection
+
+Shells out to Node for hook self-test, so skip when Node is absent.
+"""
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from gradata._types import Lesson, LessonState, RuleMetadata
+from gradata.enhancements.rule_to_hook import (
+    GenerationResult,
+    classify_rule,
+    demote,
+    promote,
+)
+from gradata.enhancements.self_improvement import (
+    format_lessons,
+    is_hook_enforced,
+    parse_lessons,
+)
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="node not installed — rule-to-hook promotion tests shell out to Node",
+)
+
+
+# ---------------------------------------------------------------------------
+# Classification + promote()
+# ---------------------------------------------------------------------------
+
+
+def test_promote_installs_hook_for_deterministic_rule(tmp_path, monkeypatch):
+    """A deterministic RULE at conf>=0.99 installs a .js file."""
+    hook_dir = tmp_path / "pre-tool" / "generated"
+    monkeypatch.setenv("GRADATA_HOOK_ROOT", str(hook_dir))
+
+    result = promote("Never use em dashes in prose", 0.99)
+
+    assert isinstance(result, GenerationResult)
+    assert result.installed, result.reason
+    assert result.hook_path is not None
+    assert result.hook_path.exists()
+    assert result.hook_path.parent == hook_dir
+
+
+def test_promote_skips_non_deterministic_rule(tmp_path, monkeypatch):
+    """Rules requiring LLM judgment must NOT install a hook."""
+    hook_dir = tmp_path / "pre-tool" / "generated"
+    monkeypatch.setenv("GRADATA_HOOK_ROOT", str(hook_dir))
+
+    result = promote("Always write empathetic replies", 0.99)
+
+    assert not result.installed
+    assert "llm" in result.reason.lower() or "judgment" in result.reason.lower()
+    assert not hook_dir.exists() or not list(hook_dir.glob("*.js"))
+
+
+def test_classify_rule_handles_confidence_boundaries():
+    """classify_rule rejects out-of-range confidence."""
+    with pytest.raises(ValueError):
+        classify_rule("Never use em dashes", 1.5)
+    with pytest.raises(ValueError):
+        classify_rule("Never use em dashes", -0.1)
+
+
+# ---------------------------------------------------------------------------
+# demote() inverse
+# ---------------------------------------------------------------------------
+
+
+def test_demote_removes_installed_hook(tmp_path, monkeypatch):
+    hook_dir = tmp_path / "pre-tool" / "generated"
+    monkeypatch.setenv("GRADATA_HOOK_ROOT", str(hook_dir))
+
+    promoted = promote("Never use em dashes in prose", 0.99)
+    assert promoted.installed
+    slug = promoted.hook_path.stem
+
+    result = demote(slug)
+
+    assert result.installed  # in GenerationResult, installed==True means "removed"
+    assert not (hook_dir / f"{slug}.js").exists()
+
+
+def test_demote_missing_slug_returns_not_found(tmp_path, monkeypatch):
+    hook_dir = tmp_path / "pre-tool" / "generated"
+    monkeypatch.setenv("GRADATA_HOOK_ROOT", str(hook_dir))
+
+    result = demote("no-such-slug")
+
+    assert not result.installed
+    assert "no hook file" in result.reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# Lesson metadata round-trip (is_hook_enforced)
+# ---------------------------------------------------------------------------
+
+
+def _make_hooked_lesson(description: str) -> Lesson:
+    md = RuleMetadata(how_enforced="hooked")
+    return Lesson(
+        date="2026-04-14",
+        state=LessonState.RULE,
+        confidence=0.99,
+        category="FORMATTING",
+        description=description,
+        fire_count=5,
+        metadata=md,
+    )
+
+
+def _make_plain_lesson(description: str) -> Lesson:
+    return Lesson(
+        date="2026-04-14",
+        state=LessonState.RULE,
+        confidence=0.95,
+        category="FORMATTING",
+        description=description,
+        fire_count=5,
+    )
+
+
+def test_is_hook_enforced_reads_structured_metadata():
+    lesson = _make_hooked_lesson("Never use em dashes")
+    assert is_hook_enforced(lesson)
+
+
+def test_is_hook_enforced_legacy_prefix_fallback():
+    """Old lessons.md files use a '[hooked]' description prefix."""
+    lesson = _make_plain_lesson("[hooked] Never use em dashes")
+    assert is_hook_enforced(lesson)
+
+
+def test_is_hook_enforced_false_for_plain_rule():
+    lesson = _make_plain_lesson("Never use em dashes")
+    assert not is_hook_enforced(lesson)
+
+
+def test_metadata_round_trips_through_format_parse():
+    """Round-trip: a lesson flagged as hooked survives format_lessons -> parse_lessons."""
+    original = _make_hooked_lesson("Never use em dashes in prose")
+    text = format_lessons([original])
+    parsed = parse_lessons(text)
+    assert len(parsed) == 1
+    assert is_hook_enforced(parsed[0])
+
+
+# ---------------------------------------------------------------------------
+# Injection pipelines skip hook-enforced rules
+# ---------------------------------------------------------------------------
+
+
+def test_inject_brain_rules_skips_hook_enforced(tmp_path, monkeypatch):
+    """SessionStart hook must not re-inject rules an installed hook already enforces."""
+    from gradata.hooks import inject_brain_rules as ibr
+
+    brain_dir = tmp_path / "brain"
+    brain_dir.mkdir()
+    lessons_path = brain_dir / "lessons.md"
+
+    hooked = _make_hooked_lesson("Never use em dashes in prose")
+    plain = _make_plain_lesson("Always hyperlink the booking CTA")
+    lessons_path.write_text(format_lessons([hooked, plain]), encoding="utf-8")
+
+    monkeypatch.setattr(ibr, "resolve_brain_dir", lambda: brain_dir)
+
+    out = ibr.main({"session_type": "general"})
+
+    assert out is not None
+    # The hooked rule is excluded; the plain rule is present.
+    assert "em dashes" not in out["result"]
+    assert "hyperlink" in out["result"]
+
+
+def test_inject_brain_rules_emits_none_when_all_rules_hooked(tmp_path, monkeypatch):
+    """When every eligible rule is already enforced by a hook, no injection block fires."""
+    from gradata.hooks import inject_brain_rules as ibr
+
+    brain_dir = tmp_path / "brain"
+    brain_dir.mkdir()
+    lessons_path = brain_dir / "lessons.md"
+
+    hooked_a = _make_hooked_lesson("Never use em dashes in prose")
+    hooked_b = _make_hooked_lesson("Never force push to main")
+    lessons_path.write_text(format_lessons([hooked_a, hooked_b]), encoding="utf-8")
+
+    monkeypatch.setattr(ibr, "resolve_brain_dir", lambda: brain_dir)
+
+    out = ibr.main({"session_type": "general"})
+
+    # All rules hooked => nothing to inject
+    assert out is None
+
+
+def test_jit_inject_skips_hook_enforced(tmp_path, monkeypatch):
+    """Per-tool JIT injection must also skip hook-enforced rules."""
+    from gradata.hooks import jit_inject as jit
+
+    brain_dir = tmp_path / "brain"
+    brain_dir.mkdir()
+    lessons_path = brain_dir / "lessons.md"
+
+    hooked = _make_hooked_lesson("Never use em dashes in prose em dash dashes")
+    plain = _make_plain_lesson("Always hyperlink the booking CTA prose em dash dashes")
+    lessons_path.write_text(format_lessons([hooked, plain]), encoding="utf-8")
+
+    monkeypatch.setenv("GRADATA_JIT_ENABLED", "1")
+    monkeypatch.setattr(jit, "resolve_brain_dir", lambda: brain_dir)
+
+    # Payload mirrors real UserPromptSubmit hook data.
+    out = jit.main({
+        "prompt": "Help me draft an email about em dashes and dashes in prose",
+    })
+
+    if out is None:
+        # No rules ranked highly enough for JIT — still valid; the assertion
+        # we care about (no em-dash rule injected) is trivially true.
+        return
+    assert "em dashes" not in out["result"]
+
+
+# ---------------------------------------------------------------------------
+# Graduation round-trip (promote at graduation time)
+# ---------------------------------------------------------------------------
+
+
+def test_graduation_auto_promotes_deterministic_rule(tmp_path, monkeypatch):
+    """graduate() classifies a newly-promoted RULE and installs a hook."""
+    from gradata.enhancements.self_improvement import graduate
+
+    hook_dir = tmp_path / "pre-tool" / "generated"
+    monkeypatch.setenv("GRADATA_HOOK_ROOT", str(hook_dir))
+
+    # A PATTERN that should graduate to RULE on this pass.
+    l = Lesson(
+        date="2026-04-14",
+        state=LessonState.PATTERN,
+        confidence=0.92,
+        category="FORMATTING",
+        description="Never use em dashes in prose",
+        fire_count=5,
+    )
+    _active, graduated = graduate([l])
+
+    # Post-graduation the lesson is in the graduated bucket as a RULE
+    # and its metadata has how_enforced == "hooked".
+    promoted = [x for x in graduated if x.state == LessonState.RULE]
+    assert promoted, "expected the PATTERN to promote to RULE"
+    assert is_hook_enforced(promoted[0])
+    # And the .js hook file landed on disk.
+    assert list(hook_dir.glob("*.js")), "expected a generated hook file"
+
+
+def test_graduation_does_not_hook_non_deterministic_rule(tmp_path, monkeypatch):
+    """A graduating RULE that isn't deterministic stays as soft injection only."""
+    from gradata.enhancements.self_improvement import graduate
+
+    hook_dir = tmp_path / "pre-tool" / "generated"
+    monkeypatch.setenv("GRADATA_HOOK_ROOT", str(hook_dir))
+
+    l = Lesson(
+        date="2026-04-14",
+        state=LessonState.PATTERN,
+        confidence=0.92,
+        category="TONE",
+        description="Write warm, empathetic replies to frustrated users",
+        fire_count=5,
+    )
+    _active, graduated = graduate([l])
+
+    promoted = [x for x in graduated if x.state == LessonState.RULE]
+    if not promoted:
+        # Non-deterministic rules may be blocked by adversarial gates; that's
+        # fine for this test. We only care that *if* it promotes, it's not
+        # marked as hooked.
+        return
+    assert not is_hook_enforced(promoted[0])
+    assert not list(hook_dir.glob("*.js"))
+
+
+# ---------------------------------------------------------------------------
+# Full loop: promote -> inject-skips -> demote -> inject-resumes
+# ---------------------------------------------------------------------------
+
+
+def test_end_to_end_promote_inject_demote_roundtrip(tmp_path, monkeypatch):
+    from gradata.hooks import inject_brain_rules as ibr
+
+    hook_dir = tmp_path / "pre-tool" / "generated"
+    monkeypatch.setenv("GRADATA_HOOK_ROOT", str(hook_dir))
+
+    brain_dir = tmp_path / "brain"
+    brain_dir.mkdir()
+    lessons_path = brain_dir / "lessons.md"
+    monkeypatch.setattr(ibr, "resolve_brain_dir", lambda: brain_dir)
+
+    # 1) Seed a plain RULE, verify it injects.
+    rule = _make_plain_lesson("Never use em dashes in prose")
+    lessons_path.write_text(format_lessons([rule]), encoding="utf-8")
+    out_before = ibr.main({"session_type": "general"})
+    assert out_before is not None
+    assert "em dashes" in out_before["result"]
+
+    # 2) Promote: install a hook and flip the metadata.
+    promoted = promote(rule.description, 0.99)
+    assert promoted.installed
+    rule.metadata = RuleMetadata(how_enforced="hooked")
+    lessons_path.write_text(format_lessons([rule]), encoding="utf-8")
+
+    out_after = ibr.main({"session_type": "general"})
+    # Only rule was hooked => no injection at all.
+    assert out_after is None
+
+    # 3) Demote: remove hook + flip metadata back.
+    slug = promoted.hook_path.stem
+    removed = demote(slug)
+    assert removed.installed
+
+    rule.metadata = RuleMetadata(how_enforced="injected")
+    lessons_path.write_text(format_lessons([rule]), encoding="utf-8")
+
+    out_restored = ibr.main({"session_type": "general"})
+    assert out_restored is not None
+    assert "em dashes" in out_restored["result"]

--- a/tests/test_rule_to_hook_promotion.py
+++ b/tests/test_rule_to_hook_promotion.py
@@ -11,12 +11,16 @@ Shells out to Node for hook self-test, so skip when Node is absent.
 """
 from __future__ import annotations
 
+import json
 import shutil
+from datetime import UTC, datetime
 
 import pytest
 
 from gradata._types import Lesson, LessonState, RuleMetadata
 from gradata.enhancements.rule_to_hook import (
+    HOOK_DEMOTED,
+    RULE_PATCH_REVERTED,
     GenerationResult,
     classify_rule,
     demote,
@@ -27,6 +31,26 @@ from gradata.enhancements.self_improvement import (
     is_hook_enforced,
     parse_lessons,
 )
+
+
+def _seed_events(brain_dir, event_records: list[dict]) -> None:
+    """Write a minimal events.jsonl for empirical-gate tests."""
+    brain_dir.mkdir(parents=True, exist_ok=True)
+    path = brain_dir / "events.jsonl"
+    with path.open("w", encoding="utf-8") as fh:
+        for rec in event_records:
+            fh.write(json.dumps(rec) + "\n")
+
+
+def _bind_brain_dir(monkeypatch, brain_dir):
+    """Point gradata._paths at a tmp brain dir so events.jsonl is discoverable."""
+    from gradata import _paths as _p
+    brain_dir.mkdir(parents=True, exist_ok=True)
+    events_jsonl = brain_dir / "events.jsonl"
+    if not events_jsonl.exists():
+        events_jsonl.touch()
+    monkeypatch.setattr(_p, "EVENTS_JSONL", events_jsonl)
+    monkeypatch.setattr(_p, "BRAIN_DIR", brain_dir)
 
 pytestmark = pytest.mark.skipif(
     shutil.which("node") is None,
@@ -242,6 +266,16 @@ def test_graduation_auto_promotes_deterministic_rule(tmp_path, monkeypatch):
     hook_dir = tmp_path / "pre-tool" / "generated"
     monkeypatch.setenv("GRADATA_HOOK_ROOT", str(hook_dir))
 
+    # Satisfy the council empirical gate: fire_count>=10 and >=3 distinct
+    # sessions in the proof chain, no reversals.
+    brain_dir = tmp_path / "brain"
+    _bind_brain_dir(monkeypatch, brain_dir)
+    _seed_events(brain_dir, [
+        {"id": "e1", "session": 1, "type": "CORRECTION", "ts": datetime.now(UTC).isoformat(), "data": {}},
+        {"id": "e2", "session": 2, "type": "CORRECTION", "ts": datetime.now(UTC).isoformat(), "data": {}},
+        {"id": "e3", "session": 3, "type": "CORRECTION", "ts": datetime.now(UTC).isoformat(), "data": {}},
+    ])
+
     # A PATTERN that should graduate to RULE on this pass.
     l = Lesson(
         date="2026-04-14",
@@ -249,7 +283,8 @@ def test_graduation_auto_promotes_deterministic_rule(tmp_path, monkeypatch):
         confidence=0.92,
         category="FORMATTING",
         description="Never use em dashes in prose",
-        fire_count=5,
+        fire_count=10,
+        correction_event_ids=["e1", "e2", "e3"],
     )
     _active, graduated = graduate([l])
 
@@ -333,3 +368,164 @@ def test_end_to_end_promote_inject_demote_roundtrip(tmp_path, monkeypatch):
     out_restored = ibr.main({"session_type": "general"})
     assert out_restored is not None
     assert "em dashes" in out_restored["result"]
+
+
+# ---------------------------------------------------------------------------
+# Council empirical promotion gate
+# ---------------------------------------------------------------------------
+
+
+def _make_lesson_with_chain(fire_count: int, event_ids: list[str]) -> Lesson:
+    return Lesson(
+        date="2026-04-14",
+        state=LessonState.PATTERN,
+        confidence=0.92,
+        category="FORMATTING",
+        description="Never use em dashes in prose",
+        fire_count=fire_count,
+        correction_event_ids=list(event_ids),
+    )
+
+
+def test_empirical_gate_blocks_when_fire_count_below_threshold(tmp_path, monkeypatch):
+    """fire_count<10 blocks promotion even when sessions + reversals pass."""
+    hook_dir = tmp_path / "pre-tool" / "generated"
+    monkeypatch.setenv("GRADATA_HOOK_ROOT", str(hook_dir))
+    brain_dir = tmp_path / "brain"
+    _bind_brain_dir(monkeypatch, brain_dir)
+    _seed_events(brain_dir, [
+        {"id": "e1", "session": 1, "type": "CORRECTION", "ts": datetime.now(UTC).isoformat(), "data": {}},
+        {"id": "e2", "session": 2, "type": "CORRECTION", "ts": datetime.now(UTC).isoformat(), "data": {}},
+        {"id": "e3", "session": 3, "type": "CORRECTION", "ts": datetime.now(UTC).isoformat(), "data": {}},
+    ])
+
+    lesson = _make_lesson_with_chain(fire_count=9, event_ids=["e1", "e2", "e3"])
+
+    result = promote(lesson.description, 0.99, lesson=lesson)
+
+    assert not result.installed
+    assert "fire_count" in result.reason
+    assert not list(hook_dir.glob("*.js")) if hook_dir.exists() else True
+
+
+def test_empirical_gate_blocks_when_distinct_sessions_below_threshold(tmp_path, monkeypatch):
+    """Distinct sessions<3 blocks promotion even at fire_count>=10."""
+    hook_dir = tmp_path / "pre-tool" / "generated"
+    monkeypatch.setenv("GRADATA_HOOK_ROOT", str(hook_dir))
+    brain_dir = tmp_path / "brain"
+    _bind_brain_dir(monkeypatch, brain_dir)
+    # Only two distinct sessions in the proof chain.
+    _seed_events(brain_dir, [
+        {"id": "e1", "session": 7, "type": "CORRECTION", "ts": datetime.now(UTC).isoformat(), "data": {}},
+        {"id": "e2", "session": 7, "type": "CORRECTION", "ts": datetime.now(UTC).isoformat(), "data": {}},
+        {"id": "e3", "session": 8, "type": "CORRECTION", "ts": datetime.now(UTC).isoformat(), "data": {}},
+    ])
+
+    lesson = _make_lesson_with_chain(fire_count=15, event_ids=["e1", "e2", "e3"])
+
+    result = promote(lesson.description, 0.99, lesson=lesson)
+
+    assert not result.installed
+    assert "distinct sessions" in result.reason
+    assert not list(hook_dir.glob("*.js")) if hook_dir.exists() else True
+
+
+def test_empirical_gate_blocks_when_recent_human_reversal_exists(tmp_path, monkeypatch):
+    """A RULE_PATCH_REVERTED within 30d blocks re-promotion."""
+    from gradata.rules.rule_engine import _make_rule_id
+
+    hook_dir = tmp_path / "pre-tool" / "generated"
+    monkeypatch.setenv("GRADATA_HOOK_ROOT", str(hook_dir))
+    brain_dir = tmp_path / "brain"
+    _bind_brain_dir(monkeypatch, brain_dir)
+
+    lesson = _make_lesson_with_chain(fire_count=12, event_ids=["e1", "e2", "e3"])
+    rule_id = _make_rule_id(lesson)
+
+    _seed_events(brain_dir, [
+        {"id": "e1", "session": 1, "type": "CORRECTION", "ts": datetime.now(UTC).isoformat(), "data": {}},
+        {"id": "e2", "session": 2, "type": "CORRECTION", "ts": datetime.now(UTC).isoformat(), "data": {}},
+        {"id": "e3", "session": 3, "type": "CORRECTION", "ts": datetime.now(UTC).isoformat(), "data": {}},
+        {
+            "id": "r1",
+            "session": 4,
+            "type": RULE_PATCH_REVERTED,
+            "ts": datetime.now(UTC).isoformat(),
+            "data": {"rule_id": rule_id, "slug": "x"},
+        },
+    ])
+
+    result = promote(lesson.description, 0.99, lesson=lesson)
+
+    assert not result.installed
+    assert "reversal" in result.reason
+    assert not list(hook_dir.glob("*.js")) if hook_dir.exists() else True
+
+
+def test_empirical_gate_passes_when_all_criteria_met(tmp_path, monkeypatch):
+    """fire_count>=10, >=3 distinct sessions, zero reversals => hook installs."""
+    hook_dir = tmp_path / "pre-tool" / "generated"
+    monkeypatch.setenv("GRADATA_HOOK_ROOT", str(hook_dir))
+    brain_dir = tmp_path / "brain"
+    _bind_brain_dir(monkeypatch, brain_dir)
+    _seed_events(brain_dir, [
+        {"id": "e1", "session": 1, "type": "CORRECTION", "ts": datetime.now(UTC).isoformat(), "data": {}},
+        {"id": "e2", "session": 2, "type": "CORRECTION", "ts": datetime.now(UTC).isoformat(), "data": {}},
+        {"id": "e3", "session": 3, "type": "CORRECTION", "ts": datetime.now(UTC).isoformat(), "data": {}},
+    ])
+
+    lesson = _make_lesson_with_chain(fire_count=12, event_ids=["e1", "e2", "e3"])
+
+    result = promote(lesson.description, 0.99, lesson=lesson)
+
+    assert result.installed, result.reason
+    assert result.hook_path and result.hook_path.exists()
+
+
+def test_determinism_class_field_exists_and_defaults_none():
+    """determinism_class is reserved for future AST-class routing; unset today."""
+    lesson = Lesson(
+        date="2026-04-14",
+        state=LessonState.RULE,
+        confidence=0.99,
+        category="FORMATTING",
+        description="Never use em dashes",
+    )
+    assert hasattr(lesson, "determinism_class")
+    assert lesson.determinism_class is None
+    # Opt-in assignment works without triggering any behavior.
+    lesson.determinism_class = "ast_shell_substitution"
+    assert lesson.determinism_class == "ast_shell_substitution"
+
+
+def test_hook_demoted_event_emitted_on_demote(tmp_path, monkeypatch):
+    """demote() emits HOOK_DEMOTED alongside RULE_TO_HOOK_REMOVED."""
+    hook_dir = tmp_path / "pre-tool" / "generated"
+    monkeypatch.setenv("GRADATA_HOOK_ROOT", str(hook_dir))
+
+    emitted: list[tuple[str, str, dict]] = []
+
+    class _FakeBrain:
+        def emit(self, event_type, source, data):
+            emitted.append((event_type, source, data))
+
+    brain_dir = tmp_path / "brain"
+    _bind_brain_dir(monkeypatch, brain_dir)
+
+    # Seed an empirical-gate-passing promotion path, then demote.
+    _seed_events(brain_dir, [
+        {"id": "e1", "session": 1, "type": "CORRECTION", "ts": datetime.now(UTC).isoformat(), "data": {}},
+        {"id": "e2", "session": 2, "type": "CORRECTION", "ts": datetime.now(UTC).isoformat(), "data": {}},
+        {"id": "e3", "session": 3, "type": "CORRECTION", "ts": datetime.now(UTC).isoformat(), "data": {}},
+    ])
+    lesson = _make_lesson_with_chain(fire_count=12, event_ids=["e1", "e2", "e3"])
+    promoted = promote(lesson.description, 0.99, lesson=lesson)
+    assert promoted.installed
+
+    slug = promoted.hook_path.stem
+    result = demote(slug, brain=_FakeBrain())
+    assert result.installed
+
+    event_types = [e[0] for e in emitted]
+    assert "RULE_TO_HOOK_REMOVED" in event_types
+    assert HOOK_DEMOTED in event_types


### PR DESCRIPTION
## Summary
PR #26 + #30 shipped hook manifest management. Most of Phase 5 was already built (graduation calls `classify_rule()` + sets `metadata.how_enforced="hooked"`; PreToolUse already honored it). Three real gaps closed here:

1. `inject_brain_rules.py` (SessionStart) was NOT filtering hook-enforced rules — they kept wasting context.
2. `jit_inject.py` (UserPromptSubmit per-call injection) had the same gap.
3. Removal didn't clean up the structured `metadata.how_enforced` field, only the legacy `[hooked]` description prefix.

Follow-up commit `eba3127` adds the council empirical promotion gate (below).

## What ships
- `src/gradata/enhancements/rule_to_hook.py` — public `promote()` / `demote()` API + empirical gate helpers (`count_distinct_sessions`, `count_human_reversals`, `_passes_empirical_gate`) + `RULE_PATCH_REVERTED` / `HOOK_DEMOTED` event constants.
- `src/gradata/enhancements/self_improvement.py` — inline graduation path now runs the empirical gate before installing a hook.
- `src/gradata/hooks/inject_brain_rules.py` — SessionStart skips hook-enforced rules.
- `src/gradata/hooks/jit_inject.py` — JIT skips hook-enforced rules.
- `src/gradata/cli.py:cmd_rule_remove` — round-trips `metadata.how_enforced` back to `"injected"`, emits `RULE_PATCH_REVERTED` + `HOOK_DEMOTED` on demote.
- `src/gradata/_types.py:Lesson.determinism_class` — reserved field for future AST-class routing (unused today).

## Council empirical gate (commit `eba3127`)
Confidence >= 0.99 is necessary but no longer sufficient. Promotion now requires all of:
- `lesson.fire_count >= 10`
- distinct sessions across `correction_event_ids` >= 3
- zero `RULE_PATCH_REVERTED` or `HOOK_DEMOTED` events tied to the rule_id in the last 30 days

Failing lessons stay as text injection with a debug log.

## Determinism classification
Reused existing `DETERMINISTIC_PATTERNS` regex table (8 templates: em-dash, file-size, secret-scan, destructive-block, root-file, auto-test, read-before-edit, fstring-block). Single source of truth.

## Deferred to a separate PR
Per council verdict, out of scope for this PR:
- New deterministic patterns: shell-substitution (e.g. `pip -> uv`) and path-enforcement.
- AST transforms behind a `determinism_class` registry (the `Lesson.determinism_class` field lands here as a typed hook but is not consumed).

## Tests
2422 pass (+6 gate tests). Ruff clean on the new helpers. Existing graduation tests bumped to satisfy the empirical gate (fire_count 10, 3-session proof chain, seeded `events.jsonl`).

## Out of scope (flagged for follow-up)
`middleware/_core.py:RuleSource._ScoredLesson` doesn't carry `how_enforced` — middleware path still injects hooked rules. Separate refactor.

## Commits
- `55f5283` feat(rule-to-hook): close auto-promotion loop in injection paths
- `eba3127` fix(rule-to-hook): empirical promotion gate per council (fire_count + sessions + zero reversals)

Co-Authored-By: Gradata <noreply@gradata.ai>