### PR TITLE
fix(types): pyright cleanup on jit_inject + rule_context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,6 @@ design-system/
 .gstack/
 .gitnexus
 .superpowers/
+
+# uv lock file (not committed; regenerated per environment)
+uv.lock

--- a/src/gradata/hooks/jit_inject.py
+++ b/src/gradata/hooks/jit_inject.py
@@ -26,6 +26,7 @@ import re
 import time
 from pathlib import Path
 
+from gradata._types import Lesson
 from gradata.hooks._base import extract_message, resolve_brain_dir, run_hook
 from gradata.hooks._profiles import Profile
 
@@ -96,13 +97,13 @@ def _float_env(name: str, default: float) -> float:
 
 
 def rank_rules_for_draft(
-    lessons: list,
+    lessons: list[Lesson],
     draft_text: str,
     *,
     k: int = DEFAULT_MAX_RULES,
     min_confidence: float = DEFAULT_MIN_CONFIDENCE,
     min_similarity: float = DEFAULT_MIN_SIMILARITY,
-) -> list[tuple[object, float]]:
+) -> list[tuple[Lesson, float]]:
     """Score each lesson against draft_text and return top-k above threshold.
 
     Returns a list of (lesson, similarity) tuples, highest first. A rule
@@ -117,7 +118,7 @@ def rank_rules_for_draft(
     if not draft_tokens:
         return []
 
-    scored: list[tuple[object, float]] = []
+    scored: list[tuple[Lesson, float]] = []
     for lesson in lessons:
         conf = getattr(lesson, "confidence", 0.0)
         if conf < min_confidence:

--- a/src/gradata/rules/rule_context.py
+++ b/src/gradata/rules/rule_context.py
@@ -64,7 +64,9 @@ def _rule_matches_domain(rule: GraduatedRule, domain_norm: str) -> bool:
     if str(scope.get("domain", "")).strip().lower() == domain_norm:
         return True
     applies = str(scope.get("applies_to", "")).strip().lower()
-    return applies == domain_norm or (applies and applies.startswith(f"{domain_norm}:"))
+    if applies == domain_norm:
+        return True
+    return bool(applies) and applies.startswith(f"{domain_norm}:")
 
 
 class RuleContext:


### PR DESCRIPTION
## Summary
Restore green pyright on main. Two type errors slipped in via PR #68 (jit-rule-injection) and PR #78 (scoped brains).

## Errors fixed
1. `src/gradata/hooks/jit_inject.py:216` — `r.state.name` etc. accessed attributes on `object` because `rank_rules_for_draft` returned `list[tuple[object, float]]`. Tightened to `list[tuple[Lesson, float]]` plus `lessons: list[Lesson]` parameter + Lesson import. Tuple invariance forced clean propagation.
2. `src/gradata/rules/rule_context.py:67` — `_rule_matches_domain` returned `bool | Literal['']` because `applies and applies.startswith(...)` short-circuits to empty string. Wrapped in `bool(applies) and ...` and split into two statements for a clean `bool` return.

## Side fix
`uv.lock` got auto-created by the local pyright run; added to `.gitignore` (not previously listed; not in main).

## Verify
`uv run pyright src/gradata/hooks/jit_inject.py src/gradata/rules/rule_context.py` -> 0 errors.

No behavior change.

Co-Authored-By: Gradata <noreply@gradata.ai>