### PR TITLE
chore: gitignore cloud/ + sdk/ orphans from #76 split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ token.json
 ~$*
 gradata-plugin/
 
+# Orphans from PR #76 cloud split — dirs removed from repo, remain on disk
+/cloud/
+/sdk/
+
 # OS files
 Thumbs.db
 Desktop.ini


### PR DESCRIPTION
## Summary

One-line hygiene. Both dirs were removed from this repo by PR #76 (cloud split to private Gradata/gradata-cloud) but files remain on local working copies. Adding to \`.gitignore\` stops them cluttering \`git status\`.

Co-Authored-By: Gradata <noreply@gradata.ai>