### PR TITLE
chore: wire dormant rules.injected emit + gitignore S105 orphans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,18 @@ docs/launch-post.md
 docs/public-launch-narrative.md
 docs/RELEASE-*-DRAFT.md
 
+# Orphaned dirs from S105 splits — cloud/ moved to private
+# Gradata/gradata-cloud in #76, sdk/ superseded by the flattened repo
+# layout in #65. Left on disk as untracked copies that keep showing
+# up in `git status` and sometimes get accidentally re-added.
+/cloud/
+/sdk/
+
+# Railway config for the cloud API now lives in the private
+# gradata-cloud repo at cloud/railway.toml — the root-level copy
+# here is a stale leftover from before the split.
+/railway.toml
+
+# Sales exports — should live in brain/leads, never in the SDK repo.
+apollo-leads-*.csv
+

--- a/src/gradata/brain.py
+++ b/src/gradata/brain.py
@@ -886,6 +886,18 @@ class Brain(BrainInspectionMixin):
 
         result = format_rules_for_prompt(applied)
         self._rule_cache.put(cache_key, result)
+
+        # Fires the in-memory bus so SessionHistory (integrations/session_history.py)
+        # can track per-session rule effectiveness — it subscribes to rules.injected
+        # but the emitter was never wired, leaving compute_effectiveness() dormant.
+        # Cache hits above skip this intentionally: SessionHistory uses a set so
+        # replays are idempotent within a session, and the cache is per-scope
+        # so repeated injects in the same scope yield the same rule set.
+        if applied:
+            self.bus.emit("rules.injected", {
+                "rules": [{"id": a.rule_id} for a in applied],
+                "task": task,
+            })
         return result
 
     def scoped_rules(

--- a/tests/test_session_history.py
+++ b/tests/test_session_history.py
@@ -45,3 +45,29 @@ class TestSessionHistory:
         payload = {}
         sh.on_session_ended(payload)
         assert "rule_effectiveness" in payload
+
+    def test_apply_brain_rules_emits_rules_injected(self, tmp_path):
+        """Regression: brain.apply_brain_rules() must fire rules.injected on the
+        in-memory bus. Without this emit, SessionHistory's effectiveness tracking
+        stays dormant — all three of its handlers subscribe, but rules.injected
+        is the one with no emitter elsewhere in the codebase."""
+        from gradata.brain import Brain
+
+        brain = Brain.init(str(tmp_path), domain="Test")
+        # Generate at least one graduated rule.
+        for i in range(6):
+            brain.correct(
+                draft=f"Dear Sir or Madam, about item {i}",
+                final=f"Hey, about item {i}",
+                category="TONE",
+            )
+        brain.end_session()
+
+        sh = SessionHistory()
+        sh.subscribe_to_bus(brain.bus)
+
+        rules_text = brain.apply_brain_rules("write an email")
+        assert rules_text, "expected graduated rule text"
+        assert len(sh.injected_this_session) >= 1, (
+            "rules.injected did not fire — SessionHistory is dormant"
+        )


### PR DESCRIPTION
Follow-ups to the Railway fix ([gradata-cloud#1](https://github.com/Gradata/gradata-cloud/pull/1), [#2](https://github.com/Gradata/gradata-cloud/pull/2), 54f2841 direct-to-main) — the (b) and (c) in our audit plan.

## (c) Wire dormant rules.injected emit

integrations/session_history.py subscribes to three events:
- correction.created — emitted at _core.py:138, 574
- session.ended — emitted at _core.py:854
- rules.injected — zero emitters anywhere in the tree

Result: SessionHistory.compute_effectiveness() is silently dead. Rules get injected every call but nothing records which ones, so per-session effectiveness tracking never runs.

Fix: brain.apply_brain_rules() now emits rules.injected on the in-memory bus after format_rules_for_prompt(applied). Cache hits skip intentionally — SessionHistory dedups via a set, the rule cache is per-scope, fresh scopes hit the compute path.

## (b) Gitignore on-disk orphans

- /cloud/ — moved to private Gradata/gradata-cloud in #76
- /sdk/ — superseded by the flat layout in #65
- /railway.toml — now lives in gradata-cloud/cloud/railway.toml
- apollo-leads-*.csv

## Tests

- tests/test_session_history.py — 7 pass (1 new)
- test_loop_and_security, test_integrations, test_nervous_system_integration — 64 pass

## Follow-ups not here

- Publish gradata 0.5.0 to PyPI so gradata-cloud can drop the SHA-tarball pin
- ~2000 LOC dead-code prune — deferred as its own initiative
- Physically delete the three orphan dirs on disk (gitignore only stops them recurring)

🤖 Generated with Claude Code