### PR TITLE
fix: undo #88 duplicates that collided with #86/#87

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,13 +203,6 @@ docs/launch-post.md
 docs/public-launch-narrative.md
 docs/RELEASE-*-DRAFT.md
 
-# Orphaned dirs from S105 splits — cloud/ moved to private
-# Gradata/gradata-cloud in #76, sdk/ superseded by the flattened repo
-# layout in #65. Left on disk as untracked copies that keep showing
-# up in `git status` and sometimes get accidentally re-added.
-/cloud/
-/sdk/
-
 # Railway config for the cloud API now lives in the private
 # gradata-cloud repo at cloud/railway.toml — the root-level copy
 # here is a stale leftover from before the split.

--- a/src/gradata/brain.py
+++ b/src/gradata/brain.py
@@ -916,18 +916,6 @@ class Brain(BrainInspectionMixin):
 
         result = format_rules_for_prompt(applied)
         self._rule_cache.put(cache_key, result)
-
-        # Fires the in-memory bus so SessionHistory (integrations/session_history.py)
-        # can track per-session rule effectiveness — it subscribes to rules.injected
-        # but the emitter was never wired, leaving compute_effectiveness() dormant.
-        # Cache hits above skip this intentionally: SessionHistory uses a set so
-        # replays are idempotent within a session, and the cache is per-scope
-        # so repeated injects in the same scope yield the same rule set.
-        if applied:
-            self.bus.emit("rules.injected", {
-                "rules": [{"id": a.rule_id} for a in applied],
-                "task": task,
-            })
         return result
 
     def scoped_rules(


### PR DESCRIPTION
## Context

#88 merged at 17:40 UTC, ~50 min after #86 (16:48) and #87 (16:52) from a parallel session. Git merged without line conflicts but the *diffs overlap*:

| Area | #86/#87 | #88 | Action |
|---|---|---|---|
| `brain.py:apply_brain_rules` rules.injected emit | #86 wired it (rich payload, try/except) | #88 added a second thinner emit after cache.put | Remove #88's emit |
| `.gitignore` `/cloud/` + `/sdk/` | #87 added | #88 re-added | Remove #88's duplicates |
| `.gitignore` `/railway.toml` + `apollo-leads-*.csv` | — | #88 added | Keep |
| `tests/test_session_history.py` regression test | — | #88 added | Keep (complements #86's `test_wiring_compound.py`) |

## Net effect before this PR

Double-fire of `rules.injected` on every fresh compute. Harmless in practice — `SessionHistory.injected_this_session` is a set so dedup is automatic — but wrong, and other subscribers could be confused by the inconsistent payload shape between the two emits.

## Tests

`pytest tests/test_session_history.py tests/test_wiring_compound.py tests/test_integrations.py` → 50 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)