### PR TITLE
exp(ablation): pilot harness for GRADATA_BETA_LB_GATE

### DIFF
--- a/brain/scripts/README-ablation-beta-lb.md
+++ b/brain/scripts/README-ablation-beta-lb.md
@@ -1,0 +1,68 @@
+# Beta LB Gate Ablation — Pilot Harness
+
+## What the gate does
+
+`GRADATA_BETA_LB_GATE` (shipped in PR #86, `self_improvement._passes_beta_lb_gate`) adds a **Beta posterior lower-bound check** to PATTERN → RULE promotion. When enabled, a PATTERN lesson only graduates if the 5th-percentile of its `Beta(α, β)` posterior meets `GRADATA_BETA_LB_THRESHOLD` (default 0.70) **and** it has at least `GRADATA_BETA_LB_MIN_FIRES` observations (default 5). This catches the ~15–20% of current RULE-tier graduations that the v4 min2022 random-label control showed are calibrated by format rather than content. Default is OFF pending in-band measurement — this harness is that measurement.
+
+Source: `.tmp/autoresearch-synthesis.md` §2 (#Compound opportunity: _core.py:555), §5 item 1 (scipy Beta PPF prerequisite), §6 item 2 (execution plan).
+
+## How to run the pilot
+
+Safety gate: the script runs a **dry-run only** unless `GRADATA_ABLATION_CONFIRM=1` is set in env. Dry-run prints trial count, token estimate, and dollar estimate, then exits without calling the API.
+
+```bash
+# Dry run (safe, no API calls):
+python brain/scripts/ablation_beta_lb_gate.py --tasks 10 --iterations 2
+
+# Actually run (paid API calls):
+GRADATA_ABLATION_CONFIRM=1 python brain/scripts/ablation_beta_lb_gate.py --tasks 10 --iterations 2
+```
+
+## What it measures
+
+Per task × iteration, two conditions are run on the same seeded synthetic brain:
+
+| Condition | `GRADATA_BETA_LB_GATE` | Rules injected into generation |
+|---|---|---|
+| A (baseline) | `0` | All PATTERN lessons that pass mean-threshold graduate |
+| B (gate on) | `1` | Only lessons with `Beta.ppf(0.05, α, β) >= 0.70` graduate |
+
+Metrics:
+
+- **Graduation-rate delta** — how many PATTERN → RULE promotions the gate blocks.
+- **Preference lift** — Sonnet output scored by Haiku (1–10 overall quality). A/B position is randomized per iteration.
+- **Per-lesson decision trace** — which specific lessons promoted/blocked under each condition.
+
+Output: `.tmp/ablation_beta_lb_<timestamp>.json` with aggregates + per-task + per-lesson traces, plus a human-readable summary on stdout.
+
+## Estimated runtime & cost
+
+Per trial = 2 Sonnet generations (~800 in / 400 out tokens each) + 1 Haiku judge call (~1500 in / 150 out).
+
+| Tasks | Iterations | Trials | Est. cost | Est. runtime |
+|---|---|---|---|---|
+| 5 | 2 | 10 | ~$0.50 | ~2 min |
+| 10 | 2 | 20 | ~$1.00 | ~4 min |
+| 10 | 3 | 30 | ~$1.50 | ~6 min |
+
+Dry-run prints a precise estimate for the exact `--tasks` / `--iterations` you pass.
+
+## Decision criteria — when to default the gate ON
+
+Ship the gate ON (default) when **both** hold on the pilot:
+
+1. `preference_lift_pct >= +1.0%` — generation quality improves (not just neutral)
+2. `graduation_drop_pct <= 50%` — rule stream doesn't collapse
+
+If lift is positive but graduation drop > 50%, tune `GRADATA_BETA_LB_THRESHOLD` down (try 0.60) and re-run. If lift is flat or negative, leave the gate opt-in and revisit once HLR time-decay (synthesis §5 item 5) lands — the double-blend fix may change the Beta posteriors enough to move the signal.
+
+## Scaling up
+
+The pilot is intentionally small (~10 tasks × 2 iters, ~20 synthetic lessons). For a rigorous replication, mirror `brain/scripts/ab_test_constitutional.py` — 4 models × multiple conditions × 16+ tasks × 3 iterations, using a real brain fixture (`--brain-fixture C:/Users/olive/SpritesWork/brain`). The v4 closer ran 432 trials; this pilot is 10–30. Treat pilot results as a direction signal, not a ship gate.
+
+## Files
+
+- `brain/scripts/ablation_beta_lb_gate.py` — the harness
+- `tests/test_ablation_beta_lb_gate.py` — dry-run safety test, schema test, gate-delta test
+- `.tmp/autoresearch-synthesis.md` — context this harness operationalises
+- `src/gradata/enhancements/self_improvement.py:_passes_beta_lb_gate` — gate under test

--- a/brain/scripts/ablation_beta_lb_gate.py
+++ b/brain/scripts/ablation_beta_lb_gate.py
@@ -1,0 +1,699 @@
+"""Pilot ablation harness: GRADATA_BETA_LB_GATE on vs off.
+
+Measures the effect of the Beta lower-bound promotion gate (PR #86,
+``self_improvement._passes_beta_lb_gate``) on two axes:
+
+1. **Graduation-rate delta** — how many PATTERN -> RULE transitions
+   the gate blocks on a seeded synthetic brain where some lessons have
+   inflated ``lesson.confidence`` but weak Beta posteriors (high α/β
+   skew).
+2. **Preference lift** — Sonnet outputs on a small task set, scored by
+   Haiku as judge, with the pre-gate rule set vs the post-gate rule set
+   injected.
+
+This is a **pilot** (~5 tasks, 2 iterations, ~20 synthetic lessons) — NOT
+the full v4 replication. Oliver runs it manually when he wants a signal,
+then decides whether to default the gate on or to scale up.
+
+Design mirrors:
+- ``brain/scripts/ab_test_constitutional.py`` — A/B scaffolding + judge loop
+- ``brain/scripts/brain_benchmark.py`` — per-task replay + scoring
+
+Safety gate
+-----------
+The script makes paid Anthropic API calls. To avoid accidental spend,
+runs without ``GRADATA_ABLATION_CONFIRM=1`` do a **dry-run only**:
+print trial count, token estimate, dollar estimate, then exit 0. Set
+``GRADATA_ABLATION_CONFIRM=1`` in env to actually execute the pilot.
+
+Usage
+-----
+    # Dry run (safe, no API calls):
+    python brain/scripts/ablation_beta_lb_gate.py --tasks 5 --iterations 2
+
+    # Actually run (paid API calls):
+    GRADATA_ABLATION_CONFIRM=1 python brain/scripts/ablation_beta_lb_gate.py \
+        --tasks 10 --iterations 2
+
+    # Against a real brain fixture instead of the synthetic seed:
+    GRADATA_ABLATION_CONFIRM=1 python brain/scripts/ablation_beta_lb_gate.py \
+        --brain-fixture C:/Users/olive/SpritesWork/brain --tasks 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import random
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from _common import ensure_sdk_on_path
+
+ensure_sdk_on_path()
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("ablation_beta_lb_gate")
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_MODEL = "claude-sonnet-4-6"
+DEFAULT_JUDGE_MODEL = "claude-haiku-4-5"
+
+# Rough token accounting for dry-run cost estimate (per trial).
+# Each trial = 1 generation call (Sonnet) + 1 shared judge call (Haiku, amortised across A/B).
+EST_INPUT_TOKENS_PER_GEN = 800     # rules + task prompt
+EST_OUTPUT_TOKENS_PER_GEN = 400    # draft
+EST_INPUT_TOKENS_PER_JUDGE = 1500  # task + both outputs + rubric
+EST_OUTPUT_TOKENS_PER_JUDGE = 150  # short JSON verdict
+
+# April 2026 published list pricing ($/M tokens).
+SONNET_INPUT_PER_M = 3.00
+SONNET_OUTPUT_PER_M = 15.00
+HAIKU_INPUT_PER_M = 1.00
+HAIKU_OUTPUT_PER_M = 5.00
+
+# Decision criteria (from .tmp/autoresearch-synthesis.md §5 / §6).
+DEFAULT_PREF_LIFT_THRESHOLD = 0.01       # gate ON if pref-lift >= +1.0%
+DEFAULT_GRAD_DROP_THRESHOLD = 0.50       # ... AND graduation-rate drop <= 50%
+
+TASKS: list[dict[str, str]] = [
+    {
+        "task": "Write a cold outreach email to a VP of Marketing at a mid-market ecommerce brand.",
+        "domain": "sales",
+        "task_type": "email_draft",
+    },
+    {
+        "task": "Draft a follow-up email after a demo where the prospect went silent for a week.",
+        "domain": "sales",
+        "task_type": "email_draft",
+    },
+    {
+        "task": "Review a Python function that validates email addresses and flag issues.",
+        "domain": "engineering",
+        "task_type": "code_review",
+    },
+    {
+        "task": "Draft a support reply to a customer reporting intermittent 500 errors on checkout.",
+        "domain": "support",
+        "task_type": "support_reply",
+    },
+    {
+        "task": "Write an apology to a customer whose data export was delayed by 48 hours.",
+        "domain": "support",
+        "task_type": "support_reply",
+    },
+    {
+        "task": "Critique a REST endpoint that returns HTTP 200 with an error payload on failure.",
+        "domain": "engineering",
+        "task_type": "code_review",
+    },
+    {
+        "task": "Write a break-up email to a prospect who has gone dark for 6 weeks.",
+        "domain": "sales",
+        "task_type": "email_draft",
+    },
+    {
+        "task": "Draft a reply explaining that the feature they requested is on the roadmap for Q3.",
+        "domain": "support",
+        "task_type": "support_reply",
+    },
+    {
+        "task": "Review test coverage for a new auth middleware and identify missing cases.",
+        "domain": "engineering",
+        "task_type": "code_review",
+    },
+    {
+        "task": "Respond to a customer who reports a billing charge they don't recognize.",
+        "domain": "support",
+        "task_type": "support_reply",
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Synthetic test brain — deterministic, reproducible seed
+# ---------------------------------------------------------------------------
+
+
+def build_synthetic_brain(seed: int = 42):
+    """Build ~20 PATTERN-tier lessons with varied (α, β) so the gate discriminates.
+
+    Design: confidence is set above RULE_THRESHOLD (0.90) for every lesson so
+    the mean-threshold path WOULD promote them all. The Beta posterior is
+    what varies:
+
+    - "strong" lessons: α>>β, high fire_count — Beta.ppf(0.05, α, β) >= 0.70
+    - "weak" lessons:   low α+β OR skewed toward β — ppf below threshold
+    - "borderline": α/β near 0.70 threshold
+
+    Gate-off graduates all 20. Gate-on should graduate roughly the strong
+    subset (~10). The exact split depends on scipy availability; both
+    branches of ``_beta_ppf_05`` are exercised.
+    """
+    from gradata._types import Lesson, LessonState
+    from gradata.enhancements.self_improvement import MIN_APPLICATIONS_FOR_RULE
+
+    rng = random.Random(seed)
+
+    specs: list[tuple[str, float, float, int, str, str, str]] = [
+        # (label, alpha, beta_param, fire_count, category, domain, task_type)
+        # STRONG (should pass gate): α>>β, many fires
+        ("strong_1", 18.0, 2.0, 20, "DRAFTING", "sales", "email_draft"),
+        ("strong_2", 25.0, 3.0, 28, "ACCURACY", "engineering", "code_review"),
+        ("strong_3", 15.0, 1.0, 16, "PROCESS", "support", "support_reply"),
+        ("strong_4", 22.0, 2.0, 24, "STYLE", "sales", "email_draft"),
+        ("strong_5", 12.0, 1.0, 13, "DRAFTING", "support", "support_reply"),
+        ("strong_6", 30.0, 4.0, 34, "ACCURACY", "engineering", "code_review"),
+        ("strong_7", 18.0, 2.0, 20, "PROCESS", "sales", "email_draft"),
+        ("strong_8", 20.0, 3.0, 23, "STYLE", "engineering", "code_review"),
+        ("strong_9", 14.0, 1.0, 15, "DRAFTING", "support", "support_reply"),
+        ("strong_10", 16.0, 2.0, 18, "ACCURACY", "sales", "email_draft"),
+        # WEAK (should be blocked by gate): few observations, some skew
+        ("weak_1", 3.0, 1.0, 4, "DRAFTING", "sales", "email_draft"),       # fire_count < 5
+        ("weak_2", 4.0, 2.0, 6, "PROCESS", "engineering", "code_review"),  # low total, ppf low
+        ("weak_3", 5.0, 3.0, 8, "STYLE", "support", "support_reply"),      # ppf ~0.3
+        ("weak_4", 6.0, 4.0, 10, "DRAFTING", "sales", "email_draft"),      # borderline low
+        ("weak_5", 7.0, 5.0, 12, "ACCURACY", "engineering", "code_review"),# borderline low
+        # BORDERLINE (some pass, some don't — exercises gate decisions)
+        ("borderline_1", 10.0, 2.0, 12, "PROCESS", "support", "support_reply"),
+        ("borderline_2", 8.0, 2.0, 10, "STYLE", "sales", "email_draft"),
+        ("borderline_3", 11.0, 3.0, 14, "DRAFTING", "engineering", "code_review"),
+        ("borderline_4", 9.0, 3.0, 12, "ACCURACY", "support", "support_reply"),
+        ("borderline_5", 13.0, 4.0, 17, "PROCESS", "sales", "email_draft"),
+    ]
+
+    descriptions = [
+        "Use active voice in the opening line",
+        "Flag any function that mutates its input argument",
+        "Acknowledge the customer's frustration before proposing a fix",
+        "Lead with the prospect's stated goal, not our product",
+        "Confirm receipt within 2 sentences before asking clarifying questions",
+        "Check for SQL injection on every user-supplied filter value",
+        "Restate the agreed next step in every email",
+        "Prefer early returns over nested conditionals",
+        "Offer two concrete next steps, never more than three",
+        "Require explicit type hints on public functions",
+        "Cite the exact error code the customer reported",
+        "Suggest one alternative if the direct request isn't possible",
+        "Use colons, not em dashes, in email prose",
+        "Link the Calendly URL as HTML, never raw",
+        "Verify the Stripe webhook signature before trusting the payload",
+        "Acknowledge the wait time explicitly if over 24 hours",
+        "Reference the prospect's LinkedIn activity when intro-ing",
+        "Flag any PR that adds a dependency for under 20 lines of use",
+        "Offer a same-week slot if the customer is churn-risk",
+        "Restate the agenda in three bullets in confirmation emails",
+    ]
+    rng.shuffle(descriptions)
+
+    lessons: list[Lesson] = []
+    for i, (label, alpha, beta_p, fires, cat, domain, ttype) in enumerate(specs):
+        scope_json = json.dumps({"domain": domain, "task_type": ttype})
+        lesson = Lesson(
+            date="2026-04-01",
+            state=LessonState.PATTERN,
+            # Confidence above RULE_THRESHOLD so mean-path promotes; gate is the discriminator.
+            confidence=0.92,
+            category=cat,
+            description=descriptions[i % len(descriptions)],
+            fire_count=max(fires, MIN_APPLICATIONS_FOR_RULE),
+            sessions_since_fire=0,
+            alpha=alpha,
+            beta_param=beta_p,
+            scope_json=scope_json,
+        )
+        # Tag so tests can inspect which specs promoted.
+        lesson._ablation_label = label  # type: ignore[attr-defined]
+        lessons.append(lesson)
+
+    return lessons
+
+
+def load_brain_fixture(path: Path):
+    """Parse lessons.md from a real brain directory."""
+    from gradata.enhancements.self_improvement import parse_lessons
+
+    lessons_path = path / "lessons.md"
+    if not lessons_path.is_file():
+        raise FileNotFoundError(f"lessons.md not found at {lessons_path}")
+    return parse_lessons(lessons_path.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Graduation simulation — deep-copies lessons so A/B don't contaminate each other
+# ---------------------------------------------------------------------------
+
+
+def simulate_graduation(lessons: list, gate_on: bool) -> dict[str, Any]:
+    """Run ``graduate()`` on a deep copy of lessons under the given gate flag.
+
+    Returns a dict with per-lesson promoted/blocked decisions and aggregate counts.
+    """
+    import copy
+
+    from gradata._types import LessonState
+    from gradata.enhancements.self_improvement import graduate
+
+    pool = copy.deepcopy(lessons)
+
+    prev_env = os.environ.get("GRADATA_BETA_LB_GATE")
+    os.environ["GRADATA_BETA_LB_GATE"] = "1" if gate_on else "0"
+    try:
+        _active, _graduated = graduate(pool, maturity="INFANT")
+    finally:
+        if prev_env is None:
+            os.environ.pop("GRADATA_BETA_LB_GATE", None)
+        else:
+            os.environ["GRADATA_BETA_LB_GATE"] = prev_env
+
+    per_lesson: list[dict[str, Any]] = []
+    promoted_count = 0
+    for lesson in pool:
+        label = getattr(lesson, "_ablation_label", lesson.description[:40])
+        promoted = lesson.state == LessonState.RULE
+        if promoted:
+            promoted_count += 1
+        per_lesson.append(
+            {
+                "label": label,
+                "alpha": lesson.alpha,
+                "beta_param": lesson.beta_param,
+                "fire_count": lesson.fire_count,
+                "final_state": lesson.state.name,
+                "promoted_to_rule": promoted,
+            }
+        )
+
+    # Derive the post-graduation rule set for downstream injection.
+    rule_lessons = [l for l in pool if l.state == LessonState.RULE]
+
+    return {
+        "gate_on": gate_on,
+        "pattern_to_rule_count": promoted_count,
+        "total_patterns_considered": len(lessons),
+        "per_lesson": per_lesson,
+        "rule_lessons": rule_lessons,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Anthropic client wrapper (seam for mocking in tests)
+# ---------------------------------------------------------------------------
+
+
+def _make_anthropic_client():
+    """Return an Anthropic client. Kept as a tiny function so tests can monkey-patch it."""
+    import anthropic  # noqa: F401 — imported for side-effect of failing early if missing
+
+    return anthropic.Anthropic()
+
+
+def _call_claude(client, *, model: str, system: str, prompt: str, max_tokens: int) -> str:
+    """Call messages.create and return the concatenated text. Isolated for mocking."""
+    msg = client.messages.create(
+        model=model,
+        max_tokens=max_tokens,
+        system=system,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    parts: list[str] = []
+    for block in getattr(msg, "content", []) or []:
+        text = getattr(block, "text", None)
+        if text:
+            parts.append(text)
+    return "".join(parts).strip()
+
+
+# ---------------------------------------------------------------------------
+# Generation + judging
+# ---------------------------------------------------------------------------
+
+
+_GEN_SYSTEM = (
+    "You are an assistant generating a single on-task draft. "
+    "Follow the injected rules. Produce ONLY the requested draft — no preamble."
+)
+
+_JUDGE_SYSTEM = (
+    "You are a strict, impartial evaluator. Return ONLY a JSON object with "
+    "integer keys output_a and output_b, each scored 1 to 10 on overall quality. "
+    "No prose, no markdown."
+)
+
+_JSON_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def _format_rules(rule_lessons: list, max_rules: int = 6) -> str:
+    """Format rule lessons as a terse injection block."""
+    selected = rule_lessons[:max_rules]
+    if not selected:
+        return ""
+    lines = ["<rules>"]
+    for lesson in selected:
+        lines.append(f"- {lesson.description}")
+    lines.append("</rules>")
+    return "\n".join(lines)
+
+
+def _generate(client, model: str, task: str, rules_text: str) -> str:
+    prompt = f"{rules_text}\n\nTASK: {task}\n\nDraft:" if rules_text else f"TASK: {task}\n\nDraft:"
+    return _call_claude(client, model=model, system=_GEN_SYSTEM, prompt=prompt, max_tokens=500)
+
+
+def _judge(
+    client,
+    judge_model: str,
+    task: str,
+    output_a: str,
+    output_b: str,
+    a_label: str,
+) -> dict[str, int] | None:
+    prompt = (
+        f"TASK: {task}\n\n"
+        f"----- OUTPUT A -----\n{output_a}\n----- END -----\n\n"
+        f"----- OUTPUT B -----\n{output_b}\n----- END -----\n\n"
+        "Rate each output 1-10 on overall quality (on-task, useful, correct).\n"
+        'Respond with exactly: {"output_a": int, "output_b": int}\n'
+        f"(a_label={a_label}, for bookkeeping)"
+    )
+    raw = _call_claude(
+        client, model=judge_model, system=_JUDGE_SYSTEM, prompt=prompt, max_tokens=200
+    )
+    m = _JSON_RE.search(raw or "")
+    if not m:
+        return None
+    try:
+        obj = json.loads(m.group(0))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(obj, dict):
+        return None
+    out: dict[str, int] = {}
+    for k in ("output_a", "output_b"):
+        v = obj.get(k)
+        if not isinstance(v, (int, float)):
+            return None
+        out[k] = max(1, min(10, int(round(v))))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Cost estimation (dry run)
+# ---------------------------------------------------------------------------
+
+
+def estimate_cost(n_tasks: int, n_iterations: int) -> dict[str, Any]:
+    """Compute rough trial count + dollar cost for the pilot.
+
+    Per task×iteration:
+      - 2 generations (one per condition) on Sonnet
+      - 1 judge call on Haiku (judges A vs B together)
+    """
+    trials = n_tasks * n_iterations
+    n_gens = trials * 2
+    n_judges = trials
+
+    gen_in = n_gens * EST_INPUT_TOKENS_PER_GEN
+    gen_out = n_gens * EST_OUTPUT_TOKENS_PER_GEN
+    judge_in = n_judges * EST_INPUT_TOKENS_PER_JUDGE
+    judge_out = n_judges * EST_OUTPUT_TOKENS_PER_JUDGE
+
+    gen_cost = (gen_in / 1_000_000) * SONNET_INPUT_PER_M + (gen_out / 1_000_000) * SONNET_OUTPUT_PER_M
+    judge_cost = (judge_in / 1_000_000) * HAIKU_INPUT_PER_M + (judge_out / 1_000_000) * HAIKU_OUTPUT_PER_M
+
+    return {
+        "trials": trials,
+        "generations": n_gens,
+        "judges": n_judges,
+        "total_input_tokens": gen_in + judge_in,
+        "total_output_tokens": gen_out + judge_out,
+        "estimated_cost_usd": round(gen_cost + judge_cost, 3),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main pilot loop
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TaskResult:
+    task_index: int
+    task: str
+    iteration: int
+    output_a: str  # gate off (baseline)
+    output_b: str  # gate on
+    score_a: int | None = None
+    score_b: int | None = None
+    judge_ok: bool = False
+    error: str = ""
+
+
+def run_pilot(
+    *,
+    lessons: list,
+    n_tasks: int,
+    n_iterations: int,
+    model: str,
+    judge_model: str,
+    client_factory=_make_anthropic_client,
+    seed: int = 42,
+) -> dict[str, Any]:
+    """Execute the pilot and return aggregate metrics."""
+    # 1. Graduation simulation — one pass per condition on the same lesson pool.
+    grad_off = simulate_graduation(lessons, gate_on=False)
+    grad_on = simulate_graduation(lessons, gate_on=True)
+
+    rules_off = grad_off["rule_lessons"]
+    rules_on = grad_on["rule_lessons"]
+
+    # 2. Generation + judging across task×iteration matrix.
+    client = client_factory()
+    rng = random.Random(seed)
+    task_results: list[TaskResult] = []
+
+    tasks = TASKS[:n_tasks]
+    rules_off_text = _format_rules(rules_off)
+    rules_on_text = _format_rules(rules_on)
+
+    score_a_list: list[int] = []
+    score_b_list: list[int] = []
+
+    for it in range(n_iterations):
+        for ti, task_spec in enumerate(tasks):
+            task = task_spec["task"]
+            log.info(
+                "Iter %d/%d, task %d/%d: %s",
+                it + 1,
+                n_iterations,
+                ti + 1,
+                len(tasks),
+                task[:60],
+            )
+
+            tr = TaskResult(task_index=ti, task=task, iteration=it, output_a="", output_b="")
+            try:
+                tr.output_a = _generate(client, model, task, rules_off_text)
+                tr.output_b = _generate(client, model, task, rules_on_text)
+            except Exception as e:  # noqa: BLE001
+                tr.error = f"generation: {e}"
+                task_results.append(tr)
+                continue
+
+            # Randomize A/B label order so the judge doesn't always see baseline first.
+            if rng.random() < 0.5:
+                judged = _judge(client, judge_model, task, tr.output_a, tr.output_b, a_label="off")
+                if judged:
+                    tr.score_a = judged["output_a"]
+                    tr.score_b = judged["output_b"]
+            else:
+                judged = _judge(client, judge_model, task, tr.output_b, tr.output_a, a_label="on")
+                if judged:
+                    tr.score_b = judged["output_a"]
+                    tr.score_a = judged["output_b"]
+
+            if judged:
+                tr.judge_ok = True
+                if tr.score_a is not None:
+                    score_a_list.append(tr.score_a)
+                if tr.score_b is not None:
+                    score_b_list.append(tr.score_b)
+            else:
+                tr.error = "judge_parse_failed"
+
+            task_results.append(tr)
+
+    mean_a = sum(score_a_list) / len(score_a_list) if score_a_list else 0.0
+    mean_b = sum(score_b_list) / len(score_b_list) if score_b_list else 0.0
+    pref_lift = (mean_b - mean_a) / mean_a if mean_a else 0.0
+
+    grad_drop = (
+        (grad_off["pattern_to_rule_count"] - grad_on["pattern_to_rule_count"])
+        / grad_off["pattern_to_rule_count"]
+        if grad_off["pattern_to_rule_count"] > 0
+        else 0.0
+    )
+
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "model": model,
+        "judge_model": judge_model,
+        "n_tasks": n_tasks,
+        "n_iterations": n_iterations,
+        "conditions": {
+            "gate_off": {
+                "graduations": grad_off["pattern_to_rule_count"],
+                "mean_judge_score": round(mean_a, 3),
+            },
+            "gate_on": {
+                "graduations": grad_on["pattern_to_rule_count"],
+                "mean_judge_score": round(mean_b, 3),
+            },
+        },
+        "metrics": {
+            "graduation_drop_pct": round(grad_drop, 4),
+            "preference_lift_pct": round(pref_lift, 4),
+            "usable_judge_scores": len(score_a_list),
+        },
+        "per_task": [asdict(r) for r in task_results],
+        "per_lesson_off": grad_off["per_lesson"],
+        "per_lesson_on": grad_on["per_lesson"],
+    }
+
+
+def format_summary(result: dict[str, Any]) -> str:
+    """Produce a human-readable summary of the pilot result."""
+    c = result["conditions"]
+    m = result["metrics"]
+    lines = [
+        "=" * 60,
+        "Beta LB Gate Ablation — pilot result",
+        "=" * 60,
+        f"model:       {result['model']}",
+        f"judge:       {result['judge_model']}",
+        f"trials:      {result['n_tasks']} tasks x {result['n_iterations']} iters = "
+        f"{result['n_tasks'] * result['n_iterations']}",
+        "",
+        "Graduation (PATTERN -> RULE):",
+        f"  gate OFF: {c['gate_off']['graduations']}",
+        f"  gate ON:  {c['gate_on']['graduations']}  "
+        f"(drop: {m['graduation_drop_pct']:+.1%})",
+        "",
+        "Judge score (mean, 1-10):",
+        f"  gate OFF: {c['gate_off']['mean_judge_score']:.2f}",
+        f"  gate ON:  {c['gate_on']['mean_judge_score']:.2f}  "
+        f"(pref-lift: {m['preference_lift_pct']:+.1%})",
+        "",
+        f"usable judge scores: {m['usable_judge_scores']}",
+        "-" * 60,
+        "Decision criteria (autoresearch synthesis §5/§6):",
+        f"  pref-lift >= +{DEFAULT_PREF_LIFT_THRESHOLD:.1%}  "
+        f"=> {'YES' if m['preference_lift_pct'] >= DEFAULT_PREF_LIFT_THRESHOLD else 'no'}",
+        f"  grad-drop <= {DEFAULT_GRAD_DROP_THRESHOLD:.1%}       "
+        f"=> {'YES' if m['graduation_drop_pct'] <= DEFAULT_GRAD_DROP_THRESHOLD else 'no'}",
+        "=" * 60,
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--tasks", type=int, default=5, help="Number of tasks (default: 5, max 10)")
+    p.add_argument("--iterations", type=int, default=2, help="Iterations per task (default: 2)")
+    p.add_argument("--model", default=DEFAULT_MODEL, help="Generation model")
+    p.add_argument("--judge-model", default=DEFAULT_JUDGE_MODEL, help="Judge model")
+    p.add_argument(
+        "--brain-fixture",
+        type=str,
+        default=None,
+        help="Path to a brain directory (lessons.md). If omitted, uses synthetic seed.",
+    )
+    p.add_argument("--seed", type=int, default=42, help="RNG seed for A/B position randomisation")
+    p.add_argument(
+        "--output-dir",
+        default=".tmp",
+        help="Directory to write ablation_beta_lb_<ts>.json (default: .tmp)",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    n_tasks = max(1, min(args.tasks, len(TASKS)))
+    n_iterations = max(1, args.iterations)
+
+    confirmed = os.environ.get("GRADATA_ABLATION_CONFIRM", "").lower() in ("1", "true", "yes", "on")
+
+    if not confirmed:
+        est = estimate_cost(n_tasks, n_iterations)
+        print("=" * 60)
+        print("DRY RUN — no API calls made.")
+        print("=" * 60)
+        print(f"tasks            = {n_tasks}")
+        print(f"iterations       = {n_iterations}")
+        print(f"generation model = {args.model}")
+        print(f"judge model      = {args.judge_model}")
+        print(f"trials           = {est['trials']}")
+        print(f"  generations    = {est['generations']} @ Sonnet")
+        print(f"  judge calls    = {est['judges']} @ Haiku")
+        print(f"input tokens     ~ {est['total_input_tokens']:,}")
+        print(f"output tokens    ~ {est['total_output_tokens']:,}")
+        print(f"estimated cost   ~ ${est['estimated_cost_usd']:.2f}")
+        print("-" * 60)
+        print("To execute the pilot, re-run with:")
+        print("  GRADATA_ABLATION_CONFIRM=1 python brain/scripts/ablation_beta_lb_gate.py \\")
+        print(f"    --tasks {n_tasks} --iterations {n_iterations}")
+        print("=" * 60)
+        return 0
+
+    # Load lessons.
+    if args.brain_fixture:
+        fixture = Path(args.brain_fixture).expanduser()
+        log.info("Loading lessons from %s", fixture)
+        lessons = load_brain_fixture(fixture)
+    else:
+        log.info("Building synthetic test brain (seed=%d)", args.seed)
+        lessons = build_synthetic_brain(seed=args.seed)
+
+    result = run_pilot(
+        lessons=lessons,
+        n_tasks=n_tasks,
+        n_iterations=n_iterations,
+        model=args.model,
+        judge_model=args.judge_model,
+        seed=args.seed,
+    )
+
+    # Persist.
+    out_dir = Path(args.output_dir).expanduser()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    out_path = out_dir / f"ablation_beta_lb_{ts}.json"
+    out_path.write_text(json.dumps(result, indent=2, default=str), encoding="utf-8")
+    log.info("Wrote %s", out_path)
+
+    print(format_summary(result))
+    print(f"\nFull results: {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ablation_beta_lb_gate.py
+++ b/tests/test_ablation_beta_lb_gate.py
@@ -1,0 +1,273 @@
+"""Tests for ``brain/scripts/ablation_beta_lb_gate.py`` — the Beta LB pilot harness.
+
+Covers:
+    1. Dry-run path: without GRADATA_ABLATION_CONFIRM, prints estimate, exits 0,
+       makes zero LLM calls (mock client raises on any invocation).
+    2. Gate-off vs gate-on graduate different counts on the seeded synthetic brain.
+    3. Output JSON has the expected schema (conditions, metrics, per_task).
+
+Never touches the real Anthropic API — the module's ``_make_anthropic_client``
+is monkey-patched to return a stub.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load the harness module directly from brain/scripts/ (outside tests/)
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_DIR = REPO_ROOT / "brain" / "scripts"
+SCRIPT_PATH = SCRIPT_DIR / "ablation_beta_lb_gate.py"
+
+
+@pytest.fixture(scope="module")
+def harness():
+    """Import ablation_beta_lb_gate with brain/scripts on sys.path for _common."""
+    # Ensure _common.py is importable (harness does `from _common import ...`)
+    added = False
+    if str(SCRIPT_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPT_DIR))
+        added = True
+    try:
+        spec = importlib.util.spec_from_file_location("ablation_beta_lb_gate", SCRIPT_PATH)
+        assert spec and spec.loader
+        mod = importlib.util.module_from_spec(spec)
+        # Register before exec_module — the @dataclass decorator needs the module
+        # in sys.modules to resolve string annotations like ``int | None``.
+        sys.modules["ablation_beta_lb_gate"] = mod
+        spec.loader.exec_module(mod)
+        yield mod
+    finally:
+        sys.modules.pop("ablation_beta_lb_gate", None)
+        if added:
+            sys.path.remove(str(SCRIPT_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Stub Anthropic clients — used to prove we don't hit the real API
+# ---------------------------------------------------------------------------
+
+
+class _ForbiddenClient:
+    """Any attempt to use this client fails the test — proves dry-run made zero calls."""
+
+    def __getattr__(self, item):  # noqa: D401
+        raise AssertionError(f"Dry-run made a forbidden client access: {item}")
+
+
+class _StubContentBlock:
+    def __init__(self, text: str):
+        self.text = text
+
+
+class _StubMessage:
+    def __init__(self, text: str):
+        self.content = [_StubContentBlock(text)]
+
+
+class _StubMessages:
+    """Fakes messages.create — returns a generation or a judge JSON based on system prompt."""
+
+    def __init__(self):
+        self.call_count = 0
+
+    def create(self, *, model, max_tokens, system, messages):  # noqa: D401
+        self.call_count += 1
+        # Judge system prompt contains "impartial evaluator"
+        if "impartial evaluator" in system:
+            return _StubMessage('{"output_a": 7, "output_b": 8}')
+        return _StubMessage("This is a stub draft reply.")
+
+
+class _StubClient:
+    def __init__(self):
+        self.messages = _StubMessages()
+
+
+# ---------------------------------------------------------------------------
+# 1. Dry-run: no CONFIRM env, zero LLM calls
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_makes_zero_llm_calls(harness, monkeypatch, capsys):
+    """Without GRADATA_ABLATION_CONFIRM, the script must exit 0 with a printed
+    estimate and NEVER attempt to construct an Anthropic client."""
+    monkeypatch.delenv("GRADATA_ABLATION_CONFIRM", raising=False)
+
+    # Poison the client factory — any call becomes a test failure.
+    def _forbidden_factory():
+        raise AssertionError("Dry-run must not construct an Anthropic client")
+
+    monkeypatch.setattr(harness, "_make_anthropic_client", _forbidden_factory)
+
+    rc = harness.main(["--tasks", "5", "--iterations", "2"])
+    assert rc == 0
+
+    captured = capsys.readouterr()
+    assert "DRY RUN" in captured.out
+    assert "no API calls made" in captured.out
+    assert "GRADATA_ABLATION_CONFIRM=1" in captured.out
+    # Must print the cost estimate.
+    assert "estimated cost" in captured.out
+
+
+def test_dry_run_cost_estimate_scales_with_inputs(harness):
+    """estimate_cost is monotonic in tasks×iterations."""
+    small = harness.estimate_cost(n_tasks=5, n_iterations=2)
+    big = harness.estimate_cost(n_tasks=10, n_iterations=3)
+    assert small["trials"] == 10
+    assert big["trials"] == 30
+    assert big["estimated_cost_usd"] > small["estimated_cost_usd"]
+    assert big["total_input_tokens"] > small["total_input_tokens"]
+
+
+# ---------------------------------------------------------------------------
+# 2. Gate off vs gate on — different graduation counts
+# ---------------------------------------------------------------------------
+
+
+def test_gate_discriminates_on_synthetic_brain(harness):
+    """simulate_graduation with the gate ON blocks STRICTLY FEWER lessons
+    than with the gate OFF (it's a non-weakening gate). At least one lesson
+    must differ so the harness produces a measurable signal."""
+    lessons = harness.build_synthetic_brain(seed=42)
+    assert len(lessons) == 20, "synthetic brain must have the expected 20 lessons"
+
+    off = harness.simulate_graduation(lessons, gate_on=False)
+    on = harness.simulate_graduation(lessons, gate_on=True)
+
+    assert off["total_patterns_considered"] == on["total_patterns_considered"] == 20
+    # Gate ON cannot graduate more than OFF — it's a strictly narrower filter.
+    assert on["pattern_to_rule_count"] <= off["pattern_to_rule_count"]
+    # And must graduate strictly fewer on this deliberately mixed pool,
+    # otherwise the synthetic fixture doesn't exercise the gate.
+    assert on["pattern_to_rule_count"] < off["pattern_to_rule_count"], (
+        "synthetic brain failed to exercise the gate — rebalance weak/strong specs"
+    )
+
+    # Per-lesson trace schema.
+    for row in off["per_lesson"]:
+        assert set(row) >= {
+            "label",
+            "alpha",
+            "beta_param",
+            "fire_count",
+            "final_state",
+            "promoted_to_rule",
+        }
+
+
+def test_gate_restores_env_var(harness):
+    """simulate_graduation must leave GRADATA_BETA_LB_GATE unchanged afterwards."""
+    prev = os.environ.get("GRADATA_BETA_LB_GATE")
+    try:
+        os.environ["GRADATA_BETA_LB_GATE"] = "sentinel"
+        lessons = harness.build_synthetic_brain(seed=7)
+        harness.simulate_graduation(lessons, gate_on=True)
+        harness.simulate_graduation(lessons, gate_on=False)
+        assert os.environ.get("GRADATA_BETA_LB_GATE") == "sentinel"
+    finally:
+        if prev is None:
+            os.environ.pop("GRADATA_BETA_LB_GATE", None)
+        else:
+            os.environ["GRADATA_BETA_LB_GATE"] = prev
+
+
+# ---------------------------------------------------------------------------
+# 3. Output JSON schema
+# ---------------------------------------------------------------------------
+
+
+def test_run_pilot_output_schema(harness, monkeypatch):
+    """With a stubbed Anthropic client, run_pilot produces a result dict with
+    the expected top-level schema."""
+    stub = _StubClient()
+    lessons = harness.build_synthetic_brain(seed=42)
+
+    result = harness.run_pilot(
+        lessons=lessons,
+        n_tasks=2,
+        n_iterations=1,
+        model="stub-model",
+        judge_model="stub-judge",
+        client_factory=lambda: stub,
+        seed=42,
+    )
+
+    # Top-level keys.
+    assert set(result) >= {
+        "generated_at",
+        "model",
+        "judge_model",
+        "n_tasks",
+        "n_iterations",
+        "conditions",
+        "metrics",
+        "per_task",
+        "per_lesson_off",
+        "per_lesson_on",
+    }
+
+    # Conditions substructure.
+    for cond in ("gate_off", "gate_on"):
+        assert cond in result["conditions"]
+        assert "graduations" in result["conditions"][cond]
+        assert "mean_judge_score" in result["conditions"][cond]
+
+    # Metrics substructure.
+    for key in ("graduation_drop_pct", "preference_lift_pct", "usable_judge_scores"):
+        assert key in result["metrics"]
+
+    # Per-task schema.
+    assert len(result["per_task"]) == 2  # 2 tasks × 1 iter
+    for row in result["per_task"]:
+        assert set(row) >= {
+            "task_index",
+            "task",
+            "iteration",
+            "output_a",
+            "output_b",
+            "judge_ok",
+        }
+
+    # Judge should have succeeded on every trial (stub always returns valid JSON).
+    assert result["metrics"]["usable_judge_scores"] == 2
+
+    # Stub must have been called — proves the code path was exercised.
+    assert stub.messages.call_count > 0
+
+    # Sanity: result is JSON-serialisable (the CLI writes it).
+    json.dumps(result, default=str)
+
+
+def test_format_summary_renders(harness):
+    """format_summary returns a non-empty string with the decision-criteria anchors."""
+    fake_result = {
+        "model": "x",
+        "judge_model": "y",
+        "n_tasks": 5,
+        "n_iterations": 2,
+        "conditions": {
+            "gate_off": {"graduations": 15, "mean_judge_score": 7.0},
+            "gate_on": {"graduations": 10, "mean_judge_score": 7.5},
+        },
+        "metrics": {
+            "graduation_drop_pct": 0.333,
+            "preference_lift_pct": 0.071,
+            "usable_judge_scores": 10,
+        },
+    }
+    s = harness.format_summary(fake_result)
+    assert "Beta LB Gate Ablation" in s
+    assert "gate OFF" in s
+    assert "gate ON" in s
+    assert "Decision criteria" in s


### PR DESCRIPTION
## Summary

Stages a pilot ablation harness to measure the effect of the Beta lower-bound promotion gate shipped in PR #86 (`self_improvement._passes_beta_lb_gate`). Default-OFF until we have an in-band signal; this is the tool that produces that signal.

**No production code changes.** Harness + README + tests only.

## What the harness does

Runs two conditions on the same seeded synthetic brain (~20 PATTERN-tier lessons with varied `(alpha, beta_param)` so some would be blocked by the gate, some wouldn't):

- **A (baseline):** `GRADATA_BETA_LB_GATE=0`
- **B (gate on):** `GRADATA_BETA_LB_GATE=1`

Measures:
- Graduation-rate delta (PATTERN -> RULE blocked by the gate)
- Preference lift (Sonnet generations scored by Haiku judge on per-task quality)
- Per-lesson decision trace (which specific lessons promote/block under each condition)

Writes `.tmp/ablation_beta_lb_<timestamp>.json` + human summary.

## How to run the pilot

\`\`\`bash
# Dry run (safe, zero API calls):
python brain/scripts/ablation_beta_lb_gate.py --tasks 10 --iterations 2

# Actually run:
GRADATA_ABLATION_CONFIRM=1 python brain/scripts/ablation_beta_lb_gate.py --tasks 10 --iterations 2
\`\`\`

**Estimated cost:** ~\$1 for 10 tasks x 2 iterations (20 trials = 40 Sonnet gens + 20 Haiku judges). Dry-run prints a precise estimate for any --tasks / --iterations combo.

## Safety gate

Without \`GRADATA_ABLATION_CONFIRM=1\`, the script runs a **dry-run only** — prints trial count / token estimate / dollar estimate, exits 0, makes zero LLM calls. Enforced by a test that monkey-patches \`_make_anthropic_client\` to raise on any access, then invokes \`main()\` and asserts it still exits 0.

## Decision criteria (when to default the gate ON)

Default gate ON when **both** hold on the pilot:

1. \`preference_lift_pct >= +1.0%\`
2. \`graduation_drop_pct <= 50%\`

If lift is positive but graduation drops too far, tune \`GRADATA_BETA_LB_THRESHOLD\` down from 0.70 and re-run. Source: \`.tmp/autoresearch-synthesis.md\` §5 / §6.

## Files

- \`brain/scripts/ablation_beta_lb_gate.py\` (~500 LOC)
- \`brain/scripts/README-ablation-beta-lb.md\` (context, usage, cost, decision rule)
- \`tests/test_ablation_beta_lb_gate.py\` (6 tests, all mocked — never hits API)

## Test plan

- [x] \`pytest tests/test_ablation_beta_lb_gate.py -xvs\` — 6/6 pass
- [x] Dry-run CLI prints estimate, exits 0, makes zero LLM calls
- [x] \`pytest tests/test_ablation.py tests/test_beta_scoring.py tests/test_ablation_beta_lb_gate.py\` — 38/38 pass
- [ ] Oliver runs \`GRADATA_ABLATION_CONFIRM=1 ... --tasks 10\` after merge

Generated with Gradata