### PR TITLE
feat: SDK-native hook daemon (opt-in)

### DIFF
--- a/src/gradata/hooks/client.py
+++ b/src/gradata/hooks/client.py
@@ -1,0 +1,77 @@
+"""Daemon-aware hook entrypoint. Used as ``python -m gradata.hooks.client <name>``.
+
+Tries the local hook daemon first (fast: no Python spawn cost); falls back to
+direct module import if the daemon isn't running. Used by ``settings.json``
+hook commands so users can opt in to the daemon without any config change
+other than changing the command to route through this module.
+
+Exits 0 on success, 127 on unknown hook, 1 on transport errors (after
+fallback also fails).
+"""
+from __future__ import annotations
+
+import importlib
+import io
+import json
+import sys
+import urllib.error
+import urllib.request
+
+from gradata.hooks.daemon import HOST, PORT
+
+
+def _try_daemon(name: str, body: str, timeout: float = 5.0) -> dict | None:
+    """POST the hook payload to the running daemon. Returns None on failure."""
+    data = body.encode("utf-8")
+    req = urllib.request.Request(
+        f"http://{HOST}:{PORT}/hook/{name}",
+        data=data,
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, json.JSONDecodeError):
+        return None
+
+
+def _fallback_inline(name: str, body: str) -> int:
+    """Invoke the hook module directly, same as 'python -m gradata.hooks.<name>'."""
+    try:
+        mod = importlib.import_module(f"gradata.hooks.{name}")
+    except ImportError:
+        sys.stderr.write(f"unknown hook: {name}\n")
+        return 127
+    if not hasattr(mod, "main"):
+        sys.stderr.write(f"hook {name} has no main()\n")
+        return 127
+    try:
+        data = json.loads(body) if body else {}
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"invalid JSON stdin: {exc}\n")
+        return 2
+    result = mod.main(data)
+    if isinstance(result, dict):
+        sys.stdout.write(json.dumps(result))
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        sys.stderr.write("usage: python -m gradata.hooks.client <hook_name>\n")
+        return 2
+    name = sys.argv[1]
+    body = sys.stdin.read() if not sys.stdin.isatty() else ""
+
+    resp = _try_daemon(name, body)
+    if resp is not None:
+        sys.stdout.write(resp.get("stdout", ""))
+        sys.stderr.write(resp.get("stderr", ""))
+        return int(resp.get("exit_code", 0))
+
+    return _fallback_inline(name, body)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/gradata/hooks/client.py
+++ b/src/gradata/hooks/client.py
@@ -11,7 +11,6 @@ fallback also fails).
 from __future__ import annotations
 
 import importlib
-import io
 import json
 import sys
 import urllib.error

--- a/src/gradata/hooks/daemon.py
+++ b/src/gradata/hooks/daemon.py
@@ -1,0 +1,207 @@
+"""Persistent HTTP daemon for Gradata hooks -- eliminates Python spawn overhead.
+
+On Windows, each hook invocation pays ~300ms process startup. With 20+ hooks
+per session that's ~6s of pure overhead. This daemon keeps the gradata module
+tree warm in-process; hook calls become localhost HTTP requests (~1ms).
+
+Protocol
+--------
+POST /hook/<name>   body=stdin JSON, runs ``gradata.hooks.<name>.main(data)``
+GET  /health        liveness probe
+GET  /shutdown      graceful stop
+
+Usage
+-----
+Start::
+    python -m gradata.hooks.daemon              # foreground
+    python -m gradata.hooks.daemon --start      # background (writes PID)
+    python -m gradata.hooks.daemon --stop
+
+Clients should use :mod:`gradata.hooks.client` which auto-falls-back to
+direct invocation when the daemon is not running.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib
+import io
+import json
+import logging
+import os
+import sys
+import tempfile
+import time
+import traceback
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+_log = logging.getLogger(__name__)
+
+PORT = int(os.environ.get("GRADATA_HOOK_DAEMON_PORT", "7819"))
+HOST = "127.0.0.1"
+PID_FILE = Path(tempfile.gettempdir()) / "gradata-hook-daemon.pid"
+
+_START_TIME = time.time()
+_MODULE_CACHE: dict[str, object] = {}
+
+
+def _get_hook_module(name: str) -> object | None:
+    """Dynamically import ``gradata.hooks.<name>`` and cache it."""
+    if name in _MODULE_CACHE:
+        return _MODULE_CACHE[name]
+    try:
+        mod = importlib.import_module(f"gradata.hooks.{name}")
+    except ImportError:
+        return None
+    _MODULE_CACHE[name] = mod
+    return mod
+
+
+def _run_hook(name: str, body: str) -> dict:
+    mod = _get_hook_module(name)
+    if mod is None or not hasattr(mod, "main"):
+        return {"error": f"unknown hook: {name}", "exit_code": 127}
+
+    try:
+        data = json.loads(body) if body else {}
+    except json.JSONDecodeError as exc:
+        return {"error": f"invalid JSON: {exc}", "exit_code": 2}
+
+    old_stdout, old_stderr = sys.stdout, sys.stderr
+    out, err = io.StringIO(), io.StringIO()
+    try:
+        sys.stdout, sys.stderr = out, err
+        result = mod.main(data)  # type: ignore[attr-defined]
+    except SystemExit as e:
+        return {"stdout": out.getvalue(), "stderr": err.getvalue(),
+                "exit_code": int(e.code) if isinstance(e.code, int) else 0}
+    except Exception:
+        return {"stdout": out.getvalue(),
+                "stderr": err.getvalue() + traceback.format_exc(),
+                "exit_code": 1}
+    finally:
+        sys.stdout, sys.stderr = old_stdout, old_stderr
+
+    # main() returning a dict: emit as JSON stdout so the client relays it
+    stdout = out.getvalue()
+    if isinstance(result, dict) and not stdout:
+        stdout = json.dumps(result)
+    return {"stdout": stdout, "stderr": err.getvalue(), "exit_code": 0}
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):  # silence default HTTP access log
+        pass
+
+    def _reply(self, status: int, payload: dict) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path == "/health":
+            self._reply(200, {
+                "status": "ok",
+                "uptime_s": round(time.time() - _START_TIME, 1),
+                "pid": os.getpid(),
+                "cached_modules": sorted(_MODULE_CACHE.keys()),
+            })
+        elif self.path == "/shutdown":
+            self._reply(200, {"status": "shutting_down"})
+            import threading
+            threading.Thread(target=lambda: (time.sleep(0.1), self.server.shutdown()), daemon=True).start()
+        else:
+            self._reply(404, {"error": "not found"})
+
+    def do_POST(self):
+        if not self.path.startswith("/hook/"):
+            self._reply(404, {"error": "not found"})
+            return
+        name = self.path[len("/hook/"):]
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length).decode("utf-8") if length else ""
+        result = _run_hook(name, body)
+        self._reply(200, result)
+
+
+def _write_pid() -> None:
+    PID_FILE.write_text(str(os.getpid()), encoding="utf-8")
+
+
+def _clear_pid() -> None:
+    try:
+        PID_FILE.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _running_pid() -> int | None:
+    if not PID_FILE.is_file():
+        return None
+    try:
+        pid = int(PID_FILE.read_text(encoding="utf-8").strip())
+    except (OSError, ValueError):
+        return None
+    # Liveness check via HTTP since PSUtil isn't a dep
+    import urllib.error
+    import urllib.request
+    try:
+        with urllib.request.urlopen(f"http://{HOST}:{PORT}/health", timeout=0.5):
+            return pid
+    except (urllib.error.URLError, OSError):
+        return None
+
+
+def run_foreground() -> None:
+    server = HTTPServer((HOST, PORT), _Handler)
+    _write_pid()
+    try:
+        _log.info("hook daemon listening on %s:%d (pid=%d)", HOST, PORT, os.getpid())
+        server.serve_forever()
+    finally:
+        _clear_pid()
+
+
+def stop_daemon() -> bool:
+    import urllib.error
+    import urllib.request
+    try:
+        urllib.request.urlopen(f"http://{HOST}:{PORT}/shutdown", timeout=2).read()
+        return True
+    except (urllib.error.URLError, OSError):
+        return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--start", action="store_true", help="Start in background (detached)")
+    parser.add_argument("--stop", action="store_true", help="Stop the running daemon")
+    parser.add_argument("--status", action="store_true", help="Report status")
+    args = parser.parse_args()
+
+    if args.status:
+        pid = _running_pid()
+        print(json.dumps({"running": pid is not None, "pid": pid, "port": PORT}))
+        return 0
+    if args.stop:
+        return 0 if stop_daemon() else 1
+    if args.start:
+        # Re-spawn ourselves detached. Relies on `python -m gradata.hooks.daemon`
+        # (no --start) to run the foreground loop.
+        import subprocess
+        subprocess.Popen(
+            [sys.executable, "-m", "gradata.hooks.daemon"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            creationflags=getattr(subprocess, "DETACHED_PROCESS", 0) | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0),
+        )
+        return 0
+
+    run_foreground()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/gradata/hooks/daemon.py
+++ b/src/gradata/hooks/daemon.py
@@ -23,6 +23,7 @@ direct invocation when the daemon is not running.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import importlib
 import io
 import json
@@ -132,10 +133,8 @@ def _write_pid() -> None:
 
 
 def _clear_pid() -> None:
-    try:
+    with contextlib.suppress(FileNotFoundError):
         PID_FILE.unlink()
-    except FileNotFoundError:
-        pass
 
 
 def _running_pid() -> int | None:


### PR DESCRIPTION
## Summary
Ship a self-contained hook daemon inside the SDK so users can eliminate per-invocation Python spawn overhead (~300ms × 20 hooks/session on Windows).

### Why not reuse brain/scripts/hook_daemon.py
The existing daemon in the brain vault references a dead `.claude/hooks/reflect/` layout and a wrong `SDK_SRC` path. Its HOOK_ROUTES don't include the current 20 gradata.hooks.* modules. Repairing it is out-of-scope and lives outside this repo.

### What's here
- **`gradata.hooks.daemon`** — localhost:7819 HTTP server. Dynamically imports `gradata.hooks.<name>`, runs `main(data)` in-process with stdout/stderr capture. `GET /health`, `GET /shutdown`, `POST /hook/<name>`. `--start` detaches a background process and writes PID to `gradata-hook-daemon.pid`.
- **`gradata.hooks.client`** — thin CLI: `python -m gradata.hooks.client <hook_name>`. Tries daemon first, falls back to direct module import if daemon isn't up. Drop-in for settings.json commands.

### Enabling
Opt-in — settings.json unchanged by this PR. To turn on:
```jsonc
"command": "python -m gradata.hooks.client auto_correct"  // was: gradata.hooks.auto_correct
```
Plus one-time `python -m gradata.hooks.daemon --start`.

### Verified
Live `--start` → `/health` {uptime_s: 1.8, pid: 72444} → `POST /hook/config_validate` (via client) → `--stop` all work.

### Next step (not in this PR)
Flip settings.json for the hot-path hooks (auto_correct, tool_failure_emit, secret_scan) after a day of dogfooding. Pyright clean. No tests yet — daemon is opt-in, existing hook tests still exercise the inline path.

Generated with Gradata