### PR TITLE
chore: fix 66 ruff violations (unblock SDK CI)

### DIFF
--- a/src/gradata/_core.py
+++ b/src/gradata/_core.py
@@ -989,7 +989,6 @@ def _cloud_sync_session(
     try:
         import hashlib
         import os
-
         from pathlib import Path
 
         # 1. Resolve cloud credentials: ~/.gradata/config.toml or env var

--- a/src/gradata/_events.py
+++ b/src/gradata/_events.py
@@ -414,7 +414,7 @@ class RetainOrchestrator:
     position on the next call.
     """
 
-    def __init__(self, brain_dir: "str | Path") -> None:
+    def __init__(self, brain_dir: str | Path) -> None:
         from pathlib import Path as _Path
         self.brain_dir = _Path(brain_dir)
         self.events_path = self.brain_dir / "events.jsonl"

--- a/src/gradata/cli.py
+++ b/src/gradata/cli.py
@@ -20,6 +20,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import logging
 import sys
@@ -516,7 +517,7 @@ def _sanitize_toml_value(val: str) -> str:
     return val.replace("\n", "").replace("\r", "").replace("[", "").replace("]", "").replace('"', "").replace("\\", "").strip()
 
 
-def _check_config_permissions(config_path: "Path") -> None:
+def _check_config_permissions(config_path: Path) -> None:
     """Finding 4: warn if config file is world-readable (Unix only)."""
     import os
     import stat
@@ -538,17 +539,18 @@ def cmd_login(args):
     import os
     import time
     import webbrowser
+    from urllib.error import HTTPError, URLError
     from urllib.request import Request, urlopen
-    from urllib.error import URLError, HTTPError
 
     api_url = os.environ.get("GRADATA_API_URL", "https://api.gradata.ai/api/v1")
 
     # Finding 5: reject non-HTTPS API URLs (allow localhost for development)
-    if not api_url.startswith("https://"):
-        if not (api_url.startswith("http://localhost") or api_url.startswith("http://127.0.0.1")):
-            print(f"Error: GRADATA_API_URL must use HTTPS (got: {api_url})")
-            print("  HTTP is only allowed for localhost/127.0.0.1 during development.")
-            sys.exit(1)
+    if not api_url.startswith("https://") and not (
+        api_url.startswith("http://localhost") or api_url.startswith("http://127.0.0.1")
+    ):
+        print(f"Error: GRADATA_API_URL must use HTTPS (got: {api_url})")
+        print("  HTTP is only allowed for localhost/127.0.0.1 during development.")
+        sys.exit(1)
 
     # Step 1: Request a device code
     try:
@@ -614,10 +616,9 @@ def cmd_login(args):
             config_path.parent.mkdir(parents=True, exist_ok=True)
 
             # Finding 4: restrict directory permissions (Unix)
-            try:
+            # Windows — os.chmod has limited effect, suppress the error
+            with contextlib.suppress(OSError, AttributeError):
                 os.chmod(config_path.parent, 0o700)
-            except (OSError, AttributeError):
-                pass  # Windows — os.chmod has limited effect
 
             # Finding 12: sanitize values before writing TOML
             safe_key = _sanitize_toml_value(api_key)
@@ -634,16 +635,15 @@ def cmd_login(args):
             )
 
             # Finding 4: restrict file permissions (Unix)
-            try:
+            # Windows — os.chmod has limited effect, suppress the error
+            with contextlib.suppress(OSError, AttributeError):
                 os.chmod(config_path, 0o600)
-            except (OSError, AttributeError):
-                pass  # Windows — os.chmod has limited effect
 
             # Also set in the environment for the current process (so
             # subsequent brain operations in the same shell can auto-sync)
             os.environ["GRADATA_API_KEY"] = api_key
 
-            print(f"  Connected! Your brain will sync to app.gradata.ai")
+            print("  Connected! Your brain will sync to app.gradata.ai")
             print(f"  Config saved to {config_path}")
 
             # Finding 4: check permissions on startup

--- a/src/gradata/correction_detector.py
+++ b/src/gradata/correction_detector.py
@@ -24,7 +24,7 @@ Usage::
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
@@ -149,7 +149,7 @@ class StructuredCorrection:
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "StructuredCorrection":
+    def from_dict(cls, data: dict[str, Any]) -> StructuredCorrection:
         """Deserialize from a plain dict."""
         return cls(
             what_wrong=data.get("what_wrong", ""),
@@ -416,7 +416,6 @@ def extract_structured_correction(
             # one/both of draft/final are empty. Nothing to extract.
             return None
 
-    correction_text = final or context
     full_text = " ".join(filter(None, [context, final]))
 
     what_wrong = _extract_what_wrong(draft, final)

--- a/src/gradata/enhancements/bandits/collaborative_filter.py
+++ b/src/gradata/enhancements/bandits/collaborative_filter.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import hashlib
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 
 @dataclass
@@ -61,7 +61,7 @@ class BrainFingerprint:
     category_distribution: dict[str, int]   # category -> rule count
 
     @classmethod
-    def from_lessons(cls, lessons: list, domain: str = "", total_sessions: int = 0) -> "BrainFingerprint":
+    def from_lessons(cls, lessons: list, domain: str = "", total_sessions: int = 0) -> BrainFingerprint:
         """Build a fingerprint from a list of Lesson objects."""
 
         rules = []
@@ -122,7 +122,7 @@ def compute_brain_similarity(a: BrainFingerprint, b: BrainFingerprint) -> float:
     vec_b = [b.category_distribution.get(c, 0) for c in sorted(all_cats)]
 
     # Cosine similarity
-    dot = sum(x * y for x, y in zip(vec_a, vec_b))
+    dot = sum(x * y for x, y in zip(vec_a, vec_b, strict=True))
     mag_a = math.sqrt(sum(x * x for x in vec_a))
     mag_b = math.sqrt(sum(x * x for x in vec_b))
 

--- a/src/gradata/enhancements/carl.py
+++ b/src/gradata/enhancements/carl.py
@@ -1,6 +1,6 @@
 """Backward-compatibility shim — all code moved to behavioral_engine.py."""
 
-from gradata.enhancements.behavioral_engine import (  # noqa: F401
+from gradata.enhancements.behavioral_engine import (
     BehavioralContract,
     ConstraintViolation,
     ContractRegistry,

--- a/src/gradata/enhancements/clustering.py
+++ b/src/gradata/enhancements/clustering.py
@@ -156,7 +156,7 @@ def promote_instinct_clusters(
         by_category[lesson.category].append(lesson)
 
     promoted: list[str] = []
-    for category, members in by_category.items():
+    for _category, members in by_category.items():
         if len(members) < min_cluster_size:
             continue
 

--- a/src/gradata/enhancements/graduation/agent_graduation.py
+++ b/src/gradata/enhancements/graduation/agent_graduation.py
@@ -48,25 +48,24 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 # Import graduation constants from self_improvement (same research-backed values)
 from gradata.enhancements.self_improvement import (
-    SURVIVAL_BONUS,
     ACCEPTANCE_BONUS,
+    MIN_APPLICATIONS_FOR_PATTERN,
+    MIN_APPLICATIONS_FOR_RULE,
     MISFIRE_PENALTY,
     PATTERN_THRESHOLD,
     RULE_THRESHOLD,
-    MIN_APPLICATIONS_FOR_PATTERN,
-    MIN_APPLICATIONS_FOR_RULE,
-    LessonState,
+    SURVIVAL_BONUS,
     Lesson,
-    parse_lessons,
+    LessonState,
     format_lessons,
     get_maturity_phase,
+    parse_lessons,
 )
-
 
 # ---------------------------------------------------------------------------
 # Approval Gate Thresholds
@@ -250,7 +249,7 @@ def compile_deterministic_rule(lesson: Lesson) -> DeterministicRule | None:
 
 
 def _now() -> str:
-    return datetime.now(timezone.utc).isoformat()
+    return datetime.now(UTC).isoformat()
 
 
 # ---------------------------------------------------------------------------
@@ -450,7 +449,7 @@ class AgentGraduationTracker:
         category = "AGENT_" + profile.agent_type.upper()
         if edit_category:
             category = edit_category.upper()
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        today = datetime.now(UTC).strftime("%Y-%m-%d")
 
         # Check for duplicate (same edit pattern already captured)
         edit_lower = edits.lower()[:100]
@@ -773,7 +772,7 @@ class AgentGraduationTracker:
             "best_agent": best,
         }
 
-    def get_deterministic_rules(self, agent_type: str, task_type: str = "") -> list["DeterministicRule"]:
+    def get_deterministic_rules(self, agent_type: str, task_type: str = "") -> list[DeterministicRule]:
         """Get RULE-tier lessons compiled into enforceable guard logic.
 
         Only RULE-tier lessons with an enforceable pattern are returned.
@@ -820,7 +819,7 @@ class AgentGraduationTracker:
 
         return rules
 
-    def enforce_rules(self, agent_type: str, output: str, task_type: str = "") -> "EnforcementResult":
+    def enforce_rules(self, agent_type: str, output: str, task_type: str = "") -> EnforcementResult:
         """Apply all deterministic RULE-tier guards to agent output.
 
         Returns an EnforcementResult with pass/fail and details of any violations.

--- a/src/gradata/enhancements/graduation/judgment_decay.py
+++ b/src/gradata/enhancements/graduation/judgment_decay.py
@@ -35,11 +35,10 @@ from dataclasses import dataclass
 from typing import Any
 
 from gradata.enhancements.self_improvement import (
-    LessonState,
-    Lesson,
     PATTERN_THRESHOLD,
+    Lesson,
+    LessonState,
 )
-
 
 # Decay constants
 DECAY_PER_IDLE_SESSION = 0.02

--- a/src/gradata/enhancements/meta_rules.py
+++ b/src/gradata/enhancements/meta_rules.py
@@ -681,7 +681,7 @@ def _try_llm_principle(rules: list[Lesson], category: str) -> str | None:
                 api_base=b,
                 model=os.environ.get("GRADATA_LLM_MODEL", "gpt-4o-mini"),
             )
-        except Exception as exc:  # noqa: BLE001 -- degrade to deterministic
+        except Exception as exc:
             _log.debug("OpenAI-compat synthesis failed for %s: %s", category, exc)
             return None
 

--- a/src/gradata/enhancements/profiling/tone_profile.py
+++ b/src/gradata/enhancements/profiling/tone_profile.py
@@ -33,7 +33,6 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
-
 # ---------------------------------------------------------------------------
 # Tone Feature Extraction
 # ---------------------------------------------------------------------------
@@ -118,7 +117,7 @@ class ToneFeatures:
         }
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> "ToneFeatures":
+    def from_dict(cls, d: dict[str, Any]) -> ToneFeatures:
         """Deserialize from dict."""
         return cls(**{k: v for k, v in d.items() if k in cls.__dataclass_fields__})
 
@@ -250,7 +249,7 @@ class ToneProfile:
         }
 
     @classmethod
-    def from_dict(cls, d: dict[str, Any]) -> "ToneProfile":
+    def from_dict(cls, d: dict[str, Any]) -> ToneProfile:
         features = ToneFeatures.from_dict(d.get("features", {}))
         return cls(
             task_type=d["task_type"],

--- a/src/gradata/enhancements/rule_pipeline.py
+++ b/src/gradata/enhancements/rule_pipeline.py
@@ -187,7 +187,7 @@ Apply this directive when working on tasks related to: {lesson.category}
     return skill_path
 
 
-def review_generated_skill(skill_path: "Path") -> dict:
+def review_generated_skill(skill_path: Path) -> dict:
     """Review a generated skill file for quality issues.
 
     Returns dict with:
@@ -370,8 +370,9 @@ def run_rule_pipeline(
                 )
                 if already_exists:
                     continue
-                from gradata._types import Lesson as _Lesson
                 from datetime import date as _date
+
+                from gradata._types import Lesson as _Lesson
                 candidate = _Lesson(
                     date=_date.today().isoformat(),
                     state=LessonState.INSTINCT,
@@ -404,18 +405,26 @@ def run_rule_pipeline(
     # ── Phase 2: Atomic writes ────────────────────────────────────────────────
     # Graduate rules, update confidence, create meta-rules.
     for lesson in all_lessons:
-        if lesson.state.name == "INSTINCT" and lesson.confidence >= PATTERN_THRESHOLD:
-            if lesson.fire_count >= MIN_APPLICATIONS_FOR_PATTERN:
-                lesson.state = LessonState.PATTERN
-                result.graduated.append(f"{lesson.category}:{lesson.description[:30]}")
-        elif lesson.state.name == "PATTERN" and lesson.confidence >= RULE_THRESHOLD:
-            if lesson.fire_count >= MIN_APPLICATIONS_FOR_RULE:
-                lesson.state = LessonState.RULE
-                result.graduated.append(f"{lesson.category}:{lesson.description[:30]}")
+        if (
+            lesson.state.name == "INSTINCT"
+            and lesson.confidence >= PATTERN_THRESHOLD
+            and lesson.fire_count >= MIN_APPLICATIONS_FOR_PATTERN
+        ):
+            lesson.state = LessonState.PATTERN
+            result.graduated.append(f"{lesson.category}:{lesson.description[:30]}")
+        elif (
+            lesson.state.name == "PATTERN"
+            and lesson.confidence >= RULE_THRESHOLD
+            and lesson.fire_count >= MIN_APPLICATIONS_FOR_RULE
+        ):
+            lesson.state = LessonState.RULE
+            result.graduated.append(f"{lesson.category}:{lesson.description[:30]}")
 
     # Synthesize meta-rules from graduated rules
     try:
-        from gradata.enhancements.meta_rules import synthesize_meta_rules_agentic  # type: ignore[import]
+        from gradata.enhancements.meta_rules import (
+            synthesize_meta_rules_agentic,  # type: ignore[import]
+        )
         from gradata.enhancements.meta_rules_storage import (  # type: ignore[import]
             load_meta_rules,
             save_meta_rules,
@@ -470,7 +479,9 @@ def run_rule_pipeline(
 
     # Disposition updates from this session's corrections
     try:
-        from gradata.enhancements.behavioral_engine import DispositionTracker  # type: ignore[import]
+        from gradata.enhancements.behavioral_engine import (
+            DispositionTracker,  # type: ignore[import]
+        )
 
         tracker = DispositionTracker()
         disp_path = lessons_path.parent / "disposition.json"
@@ -613,7 +624,9 @@ def build_knowledge_graph(lessons_path: Path, db_path: Path) -> dict:
 
     # Cross-domain candidates
     try:
-        from gradata.enhancements.meta_rules import detect_cross_domain_candidates  # type: ignore[import]
+        from gradata.enhancements.meta_rules import (
+            detect_cross_domain_candidates,  # type: ignore[import]
+        )
         graph["cross_domain"] = detect_cross_domain_candidates(lessons)
     except (ImportError, Exception):
         pass

--- a/src/gradata/enhancements/scoring/brain_scores.py
+++ b/src/gradata/enhancements/scoring/brain_scores.py
@@ -21,11 +21,6 @@ from __future__ import annotations
 import sqlite3
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    pass
-
 
 # ---------------------------------------------------------------------------
 # Data model
@@ -233,7 +228,7 @@ def compute_brain_scores(
     """
     # Primary path: delegate to the authoritative implementation
     try:
-        import gradata._events as _events  # noqa: PLC0415
+        import gradata._events as _events
 
         _fn = getattr(_events, "compute_brain_scores", None)
         if _fn is None:

--- a/src/gradata/enhancements/scoring/calibration.py
+++ b/src/gradata/enhancements/scoring/calibration.py
@@ -28,8 +28,7 @@ of Probability." Monthly Weather Review.
 
 from __future__ import annotations
 
-import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 
 @dataclass

--- a/src/gradata/enhancements/scoring/correction_tracking.py
+++ b/src/gradata/enhancements/scoring/correction_tracking.py
@@ -15,11 +15,6 @@ import math
 import sqlite3
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    pass
-
 
 # ---------------------------------------------------------------------------
 # Data model

--- a/src/gradata/enhancements/scoring/gate_calibration.py
+++ b/src/gradata/enhancements/scoring/gate_calibration.py
@@ -31,7 +31,7 @@ Reference: Anthropic, "Demystifying Evals for AI Agents" (2025).
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 
 @dataclass

--- a/src/gradata/enhancements/scoring/loop_intelligence.py
+++ b/src/gradata/enhancements/scoring/loop_intelligence.py
@@ -16,15 +16,15 @@ Layer: enhancements/ (Layer 1) — imports from patterns/ only.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import sqlite3
 from collections import defaultdict
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from gradata._events import emit as _emit_event_fn
-
 
 # ═══════════════════════════════════════════════════════════════════
 # Registries (domain-agnostic defaults, override via register_*)
@@ -126,10 +126,8 @@ def _init_tables(conn: sqlite3.Connection) -> None:
     # Migration: add columns if missing from older schema
     for table in ("activity_log", "prep_outcomes"):
         for col in ("session", "timestamp"):
-            try:
+            with contextlib.suppress(sqlite3.OperationalError):
                 conn.execute(f"ALTER TABLE {table} ADD COLUMN {col} TEXT DEFAULT NULL")
-            except sqlite3.OperationalError:
-                pass
 
 
 def log_activity(
@@ -140,13 +138,13 @@ def log_activity(
     detail: str = "",
     prep_level: int = 0,
     source: str = "claude_assisted",
-    session: Optional[int] = None,
-    date: Optional[str] = None,
+    session: int | None = None,
+    date: str | None = None,
     emit_event: bool = True,
 ) -> dict[str, Any]:
     """Log an activity (email, call, meeting, deal change)."""
-    today = date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    now = datetime.now(timezone.utc).isoformat()
+    today = date or datetime.now(UTC).strftime("%Y-%m-%d")
+    now = datetime.now(UTC).isoformat()
 
     conn = _get_db(db_path)
     _init_tables(conn)
@@ -162,7 +160,8 @@ def log_activity(
     conn.close()
 
     if emit_event:
-        try:
+        # Never break the logging path on emit failure
+        with contextlib.suppress(Exception):
             _emit_event_fn(
                 "DELTA_TAG", "loop_intelligence",
                 {
@@ -180,8 +179,6 @@ def log_activity(
                 ] if t],
                 session=session,
             )
-        except Exception:
-            pass  # Never break the logging path
 
     return {
         "id": row_id,
@@ -194,12 +191,12 @@ def log_prep(
     prospect: str,
     prep_type: str,
     prep_level: int = 0,
-    session: Optional[int] = None,
-    date: Optional[str] = None,
+    session: int | None = None,
+    date: str | None = None,
 ) -> dict[str, Any]:
     """Log prep work for a prospect (before outcome is known)."""
-    today = date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    now = datetime.now(timezone.utc).isoformat()
+    today = date or datetime.now(UTC).strftime("%Y-%m-%d")
+    now = datetime.now(UTC).isoformat()
 
     conn = _get_db(db_path)
     _init_tables(conn)
@@ -226,10 +223,10 @@ def log_outcome(
     prep_type: str,
     outcome: str,
     days: int = 0,
-    date: Optional[str] = None,
+    date: str | None = None,
 ) -> dict[str, Any]:
     """Link an outcome to the most recent unresolved prep for this prospect+type."""
-    today = date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    today = date or datetime.now(UTC).strftime("%Y-%m-%d")
 
     conn = _get_db(db_path)
     _init_tables(conn)
@@ -266,7 +263,7 @@ def log_outcome(
             """INSERT INTO prep_outcomes
                (date, prospect, prep_type, prep_level, outcome, days_to_outcome, claude_assisted, timestamp)
                VALUES (?, ?, ?, 0, ?, ?, 1, ?)""",
-            (today, prospect, prep_type, outcome, days, datetime.now(timezone.utc).isoformat()),
+            (today, prospect, prep_type, outcome, days, datetime.now(UTC).isoformat()),
         )
         conn.commit()
         conn.close()
@@ -282,10 +279,10 @@ def detect_manual(
     gmail_sent: int = 0,
     crm_updates: int = 0,
     session_logged: int = 0,
-    date: Optional[str] = None,
+    date: str | None = None,
 ) -> dict[str, Any]:
     """Detect manual activities by comparing external counts vs session-logged counts."""
-    today = date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    today = date or datetime.now(UTC).strftime("%Y-%m-%d")
 
     conn = _get_db(db_path)
     _init_tables(conn)
@@ -328,7 +325,7 @@ def get_activity_stats(db_path: str | Path, days: int = 30) -> dict[str, Any]:
     conn = _get_db(db_path)
     _init_tables(conn)
 
-    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
+    cutoff = (datetime.now(UTC) - timedelta(days=days)).strftime("%Y-%m-%d")
 
     by_source = {
         r["source"]: r["c"]
@@ -391,7 +388,7 @@ def get_activity_stats(db_path: str | Path, days: int = 30) -> dict[str, Any]:
 
 def query_tagged_interactions(
     db_path: str | Path,
-    session: Optional[int] = None,
+    session: int | None = None,
     exclude_sources: tuple[str, ...] = ("instantly",),
 ) -> list[dict[str, str]]:
     """Query DELTA_TAG events with structured tags for pattern analysis."""
@@ -440,7 +437,7 @@ def query_tagged_interactions(
 def aggregate_by_key(
     interactions: list[dict[str, str]],
     key: str,
-    positive_outcomes: Optional[set[str]] = None,
+    positive_outcomes: set[str] | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Aggregate interactions by a key field. Returns {value: {sent, replies, rate, confidence}}."""
     pos = positive_outcomes or _POSITIVE_OUTCOMES
@@ -536,7 +533,7 @@ def update_markdown_table(
 def update_patterns_file(
     db_path: str | Path,
     patterns_file: str | Path,
-    session: Optional[int] = None,
+    session: int | None = None,
     dry_run: bool = False,
 ) -> dict[str, Any]:
     """Main entry: update a patterns markdown file from tagged events."""

--- a/src/gradata/enhancements/scoring/memory_extraction.py
+++ b/src/gradata/enhancements/scoring/memory_extraction.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 
 @dataclass
@@ -110,7 +110,7 @@ class MemoryExtractor:
             List of ExtractedFact objects.
         """
         facts: list[ExtractedFact] = []
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(UTC).isoformat()
 
         for msg in messages:
             role = msg.get("role", "user")
@@ -211,7 +211,7 @@ class MemoryExtractor:
                     op="invalidate",
                     fact=candidate,
                     target_id=match.get("id"),
-                    reason=f"Superseded by newer information",
+                    reason="Superseded by newer information",
                     supersedes=match.get("id"),
                 ))
                 actions.append(ReconcileAction(

--- a/src/gradata/enhancements/scoring/reports.py
+++ b/src/gradata/enhancements/scoring/reports.py
@@ -17,7 +17,7 @@ import io
 import json
 import sqlite3
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -143,7 +143,7 @@ def generate_health_report(db_path: Path) -> HealthReport:
         first_draft_acceptance=fda,
         rules_active=rules_count,
         lessons_active=lessons_count,
-        timestamp=datetime.now(timezone.utc).isoformat(),
+        timestamp=datetime.now(UTC).isoformat(),
         issues=issues,
     )
 

--- a/src/gradata/enhancements/self_improvement.py
+++ b/src/gradata/enhancements/self_improvement.py
@@ -16,9 +16,6 @@ from __future__ import annotations
 
 import logging
 import re
-from dataclasses import dataclass, field
-from enum import StrEnum
-from pathlib import Path
 
 from gradata._types import (
     CorrectionType,

--- a/src/gradata/hooks/self_review.py
+++ b/src/gradata/hooks/self_review.py
@@ -35,8 +35,8 @@ _rules_cache: dict[tuple[str, float], list[dict]] = {}
 def _load_mandatory_rules(brain_dir: str) -> list[dict]:
     """Load RULE-tier mandatory lessons, cached by file mtime."""
     try:
-        from gradata.enhancements.self_improvement import parse_lessons
         from gradata._types import LessonState
+        from gradata.enhancements.self_improvement import parse_lessons
 
         lessons_path = Path(brain_dir) / "lessons.md"
         if not lessons_path.is_file():


### PR DESCRIPTION
## Summary
Clears 66 pre-existing ruff violations that had been failing `SDK CI` on every push to `main`. No behavior change — auto-fixes + mechanical rewrites only.

### Breakdown
- **57 auto-fixed** via `ruff check --fix`: UP017 datetime.UTC modernization, I001 import sorting, F401 unused imports, UP037 quoted annotations, UP045 PEP-604 Optional, RUF100 stale noqa, F541 placeholderless f-strings, TC005 empty TC blocks.
- **9 manual**:
  - `cli.py`: collapse nested HTTPS-URL guard into single condition; 2× chmod `try/except` → `contextlib.suppress(OSError, AttributeError)`.
  - `correction_detector.py`: drop unused `correction_text` local.
  - `collaborative_filter.py`: `zip(..., strict=True)` for cosine sim vectors.
  - `clustering.py`: rename loop var to `_category` where only `members` is used.
  - `rule_pipeline.py`: collapse INSTINCT→PATTERN and PATTERN→RULE nested-if pairs into single `and` chains.
  - `loop_intelligence.py`: 2× `try/except/pass` → `contextlib.suppress`.

### Verification
- `ruff check src/` → **All checks passed**.
- `pytest tests/` → 2875 pass, 19 skipped, 2 xfailed. The 2 failures in `test_scoped_brains.py` exist on `main` without this PR and are brain-data bleed into unit tests (test fixture pollution), unrelated.
- `pyright src/` → clean.

### Why
Unblocks normal-CI merge for PR #98 (RetainOrchestrator dedup) and PR #99 (SDK hook daemon) — those landed behind a red `SDK CI` that had to be admin-bypassed for #97.

Generated with Gradata