### PR TITLE
docs: v0.6.1 changelog

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,7 +22,7 @@ The canonical changelog lives in [`CHANGELOG.md`](https://github.com/Gradata/gra
 - `integrations/` collapsed into `middleware/` with deprecation shims
 - `self_improvement.py` split into `_confidence` + `_graduation` submodules
 - `rule_engine.py` split into 5-file package
-- GRADATA_* env var access centralized in `_env.py`
+- Most `GRADATA_*` env var access centralized in `_env.py` (exception: `GRADATA_RULE_VERIFIER`, still read directly in `rule_pipeline.py` — migration pending)
 
 ### Fixed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,43 @@
 
 The canonical changelog lives in [`CHANGELOG.md`](https://github.com/Gradata/gradata/blob/main/CHANGELOG.md) in the repo. A mirror is below for convenience.
 
+## [0.6.1] — 2026-04-19
+
+### Added
+
+- `gradata seed` + `gradata mine` CLI commands for seeding rules and extracting corrections from session logs (#sdk)
+- BM25 context relevance scoring for JIT rule ranking; Beta lower-bound default raised to 0.85 (#101)
+- Meta-Harness A–D: per-rule injection anchors, pipeline rewriter, agent-rewritten graduation scoring, synthesized prompt injection (#hooks)
+- Multi-tenant SDK: `tenant_id`, visibility, cluster, and `sync_state` columns; env-first brain resolution (#102)
+- SDK-native hook daemon (opt-in) (#99)
+- `rule_verifier` wired into rule pipeline behind `GRADATA_RULE_VERIFIER` flag
+- RetainOrchestrator + dedup-safe `emit()` writes (#98)
+- 100% test coverage for calibration, failure detectors, gate calibration, memory extraction, reports, and success conditions
+
+### Changed
+
+- `gradata.patterns` is **deprecated** — emits `DeprecationWarning` on first import. Migrate to `gradata.contrib.patterns` or `gradata.rules`. Will be removed in **v0.8.0**. (#110)
+- `Alert` canonical definition consolidated to `gradata.enhancements.quality_monitoring`; duplicate removed from `gradata.patterns`. (#109)
+- `integrations/` collapsed into `middleware/` with deprecation shims
+- `self_improvement.py` split into `_confidence` + `_graduation` submodules
+- `rule_engine.py` split into 5-file package
+- GRADATA_* env var access centralized in `_env.py`
+
+### Fixed
+
+- Scope domain leakage in `agent_precontext` (#hooks)
+- 4 confidence-math bugs in graduation pipeline
+- Windows-safe atomic append via `msvcrt.locking`
+- 67 + 66 ruff violations across SDK (#103, #100)
+- `__version__` now reads from installed package metadata
+
+### Security
+
+- HTTPS enforced at all `CloudClient` network boundaries
+- Cloud→local rule injection vector removed
+- Lesson text sanitized at all trust-boundary crossings
+- SDK pen-test findings 4, 5, 11, 12 resolved
+
 ## [0.5.0] — 2026-04-10
 
 ### Added


### PR DESCRIPTION
## Summary

- Adds v0.6.1 entry to `docs/changelog.md` covering all changes merged to main since v0.6.0
- Key callout: `gradata.patterns` deprecated in v0.6.1, removal target v0.8.0
- Covers Meta-Harness A–D, multi-tenant SDK, BM25 JIT, gradata seed/mine CLI, rule_verifier, security hardening, and ruff-violation cleanup

## Test plan

- [ ] Verify `docs/changelog.md` renders correctly in GitHub preview
- [ ] No code changes — docs-only PR, no tests needed

Generated with Gradata