### PR TITLE
test(bug_fixes): silence Pyright unused-import warnings

### DIFF
--- a/tests/test_bug_fixes.py
+++ b/tests/test_bug_fixes.py
@@ -348,6 +348,9 @@ class TestBug9MissingClasses:
         from gradata import Brain, BrainContext, Lesson, LessonState, __version__
 
         assert Brain is not None
+        assert BrainContext is not None
+        assert Lesson is not None
+        assert LessonState is not None
         assert __version__ is not None
 
     def test_pattern_exports_from_submodule(self):
@@ -361,7 +364,7 @@ class TestBug9MissingClasses:
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            from gradata.patterns import (  # noqa: F401
+            from gradata.patterns import (
                 SmartRAG,
                 NaiveRAG,
                 HumanLoopGate,
@@ -377,8 +380,22 @@ class TestBug9MissingClasses:
                 AudienceTier,
             )
 
-            assert SmartRAG is not None
-            assert Pipeline is not None
+            for sym in (
+                SmartRAG,
+                NaiveRAG,
+                HumanLoopGate,
+                RuleApplication,
+                Pipeline,
+                Stage,
+                ParallelBatch,
+                EpisodicMemory,
+                InputGuard,
+                OutputGuard,
+                MCPBridge,
+                Delegation,
+                AudienceTier,
+            ):
+                assert sym is not None
             # DeprecationWarning may already have fired earlier in the session
             # (module-level _WARNED flag), so we don't strictly require it here —
             # the forwarding correctness is the invariant this test guards.
@@ -401,7 +418,9 @@ class TestBug9MissingClasses:
             # import fires and the warning is captured.
             sys.modules.pop("gradata.patterns", None)
             importlib.import_module("gradata.patterns")
-            from gradata.patterns import Pipeline  # noqa: F401
+            from gradata.patterns import Pipeline
+
+            assert Pipeline is not None
 
         shim_warnings = [
             w


### PR DESCRIPTION
## Summary
- Asserts each imported symbol is not None in `test_top_level_exports`, `test_pattern_exports_from_submodule`, and `test_patterns_shim_emits_deprecation_warning`.
- Removes `# noqa: F401` escapes; the intent (importability check) is now explicit.
- No behavior change. Local run: 28 passed, 1 skipped.

## Why
Pyright flagged 11+ imports as unused across these tests. The tests exist precisely to verify the symbols import — asserting `is not None` makes that invariant explicit and satisfies the type checker.

## Test plan
- [x] `pytest tests/test_bug_fixes.py` — 28 passed, 1 skipped
- [ ] Pyright: no unused-import warnings on the modified file

Generated with Gradata