### PR TITLE
release: bump version to 0.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gradata"
-version = "0.6.0"
+version = "0.6.1"
 description = "AI that learns your judgment. Corrections become behavioral rules that converge on your style."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Bumps `pyproject.toml` from 0.6.0 → 0.6.1
- Changelog already landed in #115; this aligns package metadata with the release tag

## Release checklist

- [ ] Merge this PR
- [ ] Tag `v0.6.1` on main, push tag
- [ ] `uv build` → `uv publish` (manual; CI release workflow was removed in #104)
- [ ] Verify `pip install gradata==0.6.1` resolves the new version

## Test plan

- [x] `grep ^version pyproject.toml` → `0.6.1`
- [x] No other source of truth needs changing — `__init__.py` reads via `importlib.metadata`

Generated with Gradata