### PR TITLE
fix(graduation): session-count-aware state for backfilled patterns

### DIFF
--- a/src/gradata/enhancements/rule_pipeline.py
+++ b/src/gradata/enhancements/rule_pipeline.py
@@ -45,19 +45,40 @@ def _normalize_pattern_description(text: str) -> str:
     return text
 
 
+def _state_for_sessions(distinct_sessions: int) -> tuple[LessonState, float]:
+    """Map mined-pattern session count onto (state, confidence).
+
+    Aligns backfilled correction_patterns with the live graduation hierarchy
+    (MIN_APPLICATIONS_FOR_PATTERN=3, MIN_APPLICATIONS_FOR_RULE=5). Previously
+    every candidate was teleported to RULE@0.92 regardless of session count —
+    a 2-session pattern ended up with the same standing as a 50-session rule.
+
+    Mapping:
+      - 2 sessions     → PATTERN @ 0.70 (weak but promising)
+      - 3-4 sessions   → PATTERN @ 0.80 (stronger, one step from RULE)
+      - 5+ sessions    → RULE    @ 0.92 (meets live fire-count floor)
+    """
+    if distinct_sessions >= 5:
+        return LessonState.RULE, 0.92
+    if distinct_sessions >= 3:
+        return LessonState.PATTERN, 0.80
+    return LessonState.PATTERN, 0.70
+
+
 def _patterns_to_graduated_lessons(
     db_path: Path,
     current_session: int,
     min_sessions: int = 2,
     min_score: float = 3.0,
 ) -> list[Lesson]:
-    """Lift graduated correction_patterns into synthetic RULE-state lessons.
+    """Lift correction_patterns into lessons matching the live graduation hierarchy.
 
-    Before this wiring the 437-row correction_patterns table was orphaned --
-    query_graduation_candidates had no production caller, so meta-rule
-    synthesis never saw the real user corrections. This bridges the gap:
-    clusters that already hit (sessions >= min_sessions, weight >= min_score)
-    are lifted directly to RULE state for synthesis.
+    Originally this bridge lifted every qualifying candidate directly to RULE
+    state with confidence 0.92 to populate a cold brain. That bypassed the
+    INSTINCT → PATTERN → RULE gates and over-promoted 2-session patterns to
+    the same standing as battle-tested rules. ``_state_for_sessions`` now
+    assigns state + confidence based on the session-count evidence so
+    backfilled lessons respect the same bar as live-graduated ones.
     """
     try:
         from gradata.enhancements.meta_rules_storage import (  # type: ignore[import]
@@ -92,13 +113,15 @@ def _patterns_to_graduated_lessons(
             continue
         seen.add(dedup_key)
         first_seen = str(row.get("first_seen") or "")[:10] or "2026-01-01"
+        distinct_sessions = int(row.get("distinct_sessions") or 2)
+        state, confidence = _state_for_sessions(distinct_sessions)
         lessons.append(Lesson(
             date=first_seen,
-            state=LessonState.RULE,
-            confidence=0.92,
+            state=state,
+            confidence=confidence,
             category=category,
             description=desc,
-            fire_count=int(row.get("distinct_sessions") or 2),
+            fire_count=distinct_sessions,
         ))
     return lessons
 

--- a/tests/test_rule_pipeline.py
+++ b/tests/test_rule_pipeline.py
@@ -548,6 +548,7 @@ def _seed_correction_patterns(db_path: Path, rows: list[tuple]) -> None:
 
 
 def test_patterns_to_graduated_lessons_lifts_qualifying_clusters(tmp_path):
+    """2-session patterns lift to PATTERN (weak evidence), not RULE."""
     from gradata.enhancements.rule_pipeline import _patterns_to_graduated_lessons
 
     db_path = tmp_path / "system.db"
@@ -563,8 +564,35 @@ def test_patterns_to_graduated_lessons_lifts_qualifying_clusters(tmp_path):
     cats = sorted(l.category for l in lessons)
     assert cats == ["DEMO_PREP", "LEADS"]
     for l in lessons:
-        assert l.state == LessonState.RULE
-        assert l.confidence >= 0.90
+        # 2 distinct sessions => PATTERN @ 0.70 under the session-aware mapping
+        assert l.state == LessonState.PATTERN
+        assert 0.65 <= l.confidence <= 0.75
+
+
+def test_patterns_to_graduated_lessons_session_count_drives_state(tmp_path):
+    """Session count maps to state: 2→PATTERN@0.70, 3-4→PATTERN@0.80, 5+→RULE@0.92."""
+    from gradata.enhancements.rule_pipeline import _patterns_to_graduated_lessons
+
+    db_path = tmp_path / "system.db"
+    rows: list[tuple] = []
+    # 2-session pattern → PATTERN @ 0.70
+    for sid in (10, 11):
+        rows.append(("hA", "LEADS", "weak evidence pattern", sid, "major", 2.0, f"2026-04-{sid:02d}"))
+    # 3-session pattern → PATTERN @ 0.80
+    for sid in (20, 21, 22):
+        rows.append(("hB", "TONE", "moderate evidence pattern", sid, "major", 2.0, f"2026-04-{sid:02d}"))
+    # 5-session pattern → RULE @ 0.92
+    for sid in (30, 31, 32, 33, 34):
+        rows.append(("hC", "DRAFTING", "strong evidence pattern", sid, "major", 2.0, f"2026-04-{sid:02d}"))
+    _seed_correction_patterns(db_path, rows)
+
+    lessons = {l.category: l for l in _patterns_to_graduated_lessons(db_path, current_session=40)}
+    assert lessons["LEADS"].state == LessonState.PATTERN
+    assert lessons["LEADS"].confidence == 0.70
+    assert lessons["TONE"].state == LessonState.PATTERN
+    assert lessons["TONE"].confidence == 0.80
+    assert lessons["DRAFTING"].state == LessonState.RULE
+    assert lessons["DRAFTING"].confidence == 0.92
 
 
 def test_patterns_to_graduated_lessons_strips_noise(tmp_path):


### PR DESCRIPTION
## Summary

Cherry-picked from a local commit on the main worktree (`40f33e5a`, authored 2026-04-19 by Oliver) — promoting it to a reviewable PR so it can land cleanly before the v0.6.1 tag.

`_patterns_to_graduated_lessons` previously teleported every qualifying `correction_pattern` directly to RULE@0.92, bypassing the INSTINCT→PATTERN→RULE graduation gates. A 2-session pattern ended up with the same standing as a 50-session rule. Live brain showed **18 RULEs / 0 PATTERNs / 2 INSTINCTs** — all 18 RULEs came from weak 2-session evidence.

## Fix

`_state_for_sessions` now maps evidence → state:
- 2 sessions  → PATTERN @ 0.70
- 3-4         → PATTERN @ 0.80
- 5+          → RULE    @ 0.92

Aligns backfill with live graduation thresholds (`MIN_APPLICATIONS_FOR_PATTERN=3`, `MIN_APPLICATIONS_FOR_RULE=5`). Backfill still filters single-session patterns (`min_sessions=2`).

## Test plan

- [x] `pytest tests/test_rule_pipeline.py` — 26 passed in 0.56s
- [ ] After merge, re-backfill live brain and confirm state distribution is no longer 18/0/2

## Why now

Needed before cutting the v0.6.1 tag — without this, any brain backfilled on 0.6.1 will replicate the over-promotion bug. Blocker for #117.

Generated with Gradata