### PR TITLE
ci: restore SDK publish workflow (OIDC trusted publishing)

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -1,0 +1,157 @@
+name: SDK Publish
+
+# Triggers:
+#   - push of a v* tag (e.g. v0.6.1) — auto-publish on release
+#   - workflow_dispatch with a `ref` input — manual re-run for an existing tag
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v0.6.1). Must already exist."
+        required: true
+        type: string
+
+concurrency:
+  group: sdk-publish-${{ github.event.inputs.tag || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      is_prerelease: ${{ steps.meta.outputs.is_prerelease }}
+      already_published: ${{ steps.check.outputs.already_published }}
+
+    steps:
+      - name: Checkout (tag)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Derive version from tag
+        id: meta
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          VERSION="${TAG#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          if [[ "${VERSION}" =~ (rc|a|b|dev|alpha|beta) ]]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "Tag:     ${TAG}"
+          echo "Version: ${VERSION}"
+
+      - name: Verify tag matches pyproject.toml version
+        run: |
+          PYPROJECT_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          TAG_VERSION="${{ steps.meta.outputs.version }}"
+          if [ "${PYPROJECT_VERSION}" != "${TAG_VERSION}" ]; then
+            echo "::error::Tag version (${TAG_VERSION}) does not match pyproject.toml version (${PYPROJECT_VERSION})."
+            exit 1
+          fi
+          echo "Version match confirmed: ${PYPROJECT_VERSION}"
+
+      - name: Check if version already exists on PyPI
+        id: check
+        run: |
+          VERSION="${{ steps.meta.outputs.version }}"
+          IS_PRE="${{ steps.meta.outputs.is_prerelease }}"
+          if [ "${IS_PRE}" = "true" ]; then
+            INDEX_URL="https://test.pypi.org/pypi/gradata/json"
+          else
+            INDEX_URL="https://pypi.org/pypi/gradata/json"
+          fi
+          HTTP_STATUS=$(curl -s -o /tmp/pypi.json -w "%{http_code}" "${INDEX_URL}" || echo "000")
+          if [ "${HTTP_STATUS}" = "404" ]; then
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "${HTTP_STATUS}" != "200" ]; then
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if python -c "import json,sys; d=json.load(open('/tmp/pypi.json')); sys.exit(0 if '${VERSION}' in d.get('releases',{}) else 1)"; then
+            echo "::warning::gradata==${VERSION} is already published. Skipping."
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build wheel and sdist
+        if: steps.check.outputs.already_published != 'true'
+        run: |
+          rm -rf dist/
+          uv build
+          ls -la dist/
+
+      - name: Upload distributions
+        if: steps.check.outputs.already_published != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-testpypi:
+    name: Publish to TestPyPI (pre-release)
+    needs: build
+    if: needs.build.outputs.is_prerelease == 'true' && needs.build.outputs.already_published != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    if: needs.build.outputs.is_prerelease == 'false' && needs.build.outputs.already_published != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
+  skipped:
+    name: Publish skipped (version already on index)
+    needs: build
+    if: needs.build.outputs.already_published == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "::warning::gradata==${{ needs.build.outputs.version }} already exists on target index."


### PR DESCRIPTION
## Summary

Restores the OIDC trusted-publish workflow removed in #104, so v0.6.1+ can publish to PyPI without an API token. Adapted for the current `v*` tag convention and adds `workflow_dispatch` for manual re-runs.

**Unblocks v0.6.1 PyPI release** — the tag is already pushed but no workflow was listening for it. After this PR merges, I can fire `gh workflow run sdk-publish.yml -f tag=v0.6.1` to publish.

## Test plan

- [ ] Merge this PR
- [ ] Trigger: `gh workflow run sdk-publish.yml -f tag=v0.6.1`
- [ ] Verify `pip install gradata==0.6.1` resolves the new version

Generated with Gradata