### PR TITLE
docs: fix dev setup instructions for Gradata/ subfolder

### DIFF
--- a/Gradata/CONTRIBUTING.md
+++ b/Gradata/CONTRIBUTING.md
@@ -6,10 +6,12 @@ Thanks for your interest in contributing.
 
 ```bash
 git clone https://github.com/Gradata/gradata.git
-cd gradata
+cd gradata/Gradata
 pip install -e ".[dev]"
 pytest tests/
 ```
+
+The SDK lives under the `Gradata/` subfolder of the repo; the repo root holds workspace-level scaffolding. All SDK commands run from `Gradata/`.
 
 ## Running Tests
 

--- a/Gradata/docs/contributing.md
+++ b/Gradata/docs/contributing.md
@@ -6,12 +6,12 @@ Thanks for your interest in contributing to Gradata. This page covers the dev se
 
 ```bash
 git clone https://github.com/Gradata/gradata.git
-cd gradata
+cd gradata/Gradata
 pip install -e ".[dev]"
 pytest tests/
 ```
 
-The `dev` extra installs pytest, hypothesis, pyright, bandit, ruff, and coverage.
+The SDK lives under the `Gradata/` subfolder of the repo; all SDK commands run from there. The `dev` extra installs pytest, hypothesis, pyright, bandit, ruff, and coverage.
 
 On Windows, use PowerShell or WSL. The hooks invoke Python directly (`python -m gradata.hooks.*`), so Python must be on your `PATH`.
 


### PR DESCRIPTION
## Summary
After Phase B (#121) the SDK lives under `Gradata/` rather than the repo root. The documented install steps (`cd gradata && pip install -e .`) would fail because `pyproject.toml` is one level deeper. Updating `CONTRIBUTING.md` and `docs/contributing.md` to `cd gradata/Gradata` and noting the subfolder layout.

## Test plan
- [x] `cd gradata/Gradata && pip install -e .` works (verified post-#121)
Generated with Gradata