### PR TITLE
ci: cross-platform test matrix (ubuntu, macos, windows × py3.11/3.12)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: tests-${{ github.ref }}
   cancel-in-progress: true
@@ -32,7 +35,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
         with:
-          version: "latest"
+          version: "0.11.7"
 
       - name: Install dependencies
         working-directory: Gradata
@@ -40,4 +43,4 @@ jobs:
 
       - name: Run pytest
         working-directory: Gradata
-        run: uv run pytest tests/ -q --tb=short
+        run: uv run pytest tests/ -q --tb=short -m "not integration"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: pytest ${{ matrix.os }} / py${{ matrix.python }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        working-directory: Gradata
+        run: uv sync --all-extras --dev
+
+      - name: Run pytest
+        working-directory: Gradata
+        run: uv run pytest tests/ -q --tb=short


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/test.yml` that runs `pytest` on every push to main and every PR.
- Matrix: 3 OSes × 2 Python versions = 6 jobs. `fail-fast: false` so one OS failing doesn't mask another.
- Closes #131.

## Why

`sdk-publish.yml` only runs on tag push and only builds — no tests. Before this PR, platform-specific code paths (`fcntl` vs `msvcrt` in `platform_lock`) were only verified on one developer's local machine. macOS parity was assumed.

## Test plan

- [x] Workflow YAML validates
- [ ] Green on this PR (CI will confirm)
- [ ] Expected skip counts documented: 2 on Windows (POSIX fcntl), 2 on macOS/Linux (Windows msvcrt)

## Out of scope

- Coverage gates
- Lint / type check jobs (separate workflow)
- Branch protection to require this workflow — repo settings change, deferred

Generated with Gradata