### PR TITLE
feat(hooks): kill switches, tacit signals, cloud URL fix, emit refactor

### DIFF
--- a/.claude/hooks/session-start/handoff-inject.js
+++ b/.claude/hooks/session-start/handoff-inject.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * handoff-inject.js — SessionStart hook
+ *
+ * Pairs with user-prompt/handoff-watchdog.js: when the previous session
+ * crossed GRADATA_HANDOFF_THRESHOLD and wrote a handoff doc to
+ * <BRAIN_DIR>/handoffs/, this hook injects it on the next session's
+ * SessionStart and moves the file to handoffs/consumed/ so it only
+ * fires once.
+ *
+ * Mirrors gradata.contrib.patterns.handoff.pick_latest_unconsumed +
+ * consume_handoff so SDK consumers and Claude Code agree on the file layout.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const cfg = require('../config.js');
+
+const handoffDir = path.join(cfg.BRAIN_DIR, 'handoffs');
+if (!fs.existsSync(handoffDir)) process.exit(0);
+
+// Pick latest *.handoff.md at the top level (skip consumed/).
+let latest = null;
+try {
+  const entries = fs.readdirSync(handoffDir, { withFileTypes: true });
+  let best = 0;
+  for (const e of entries) {
+    if (!e.isFile() || !e.name.endsWith('.handoff.md')) continue;
+    const p = path.join(handoffDir, e.name);
+    const m = fs.statSync(p).mtimeMs;
+    if (m > best) { best = m; latest = p; }
+  }
+} catch (_) { process.exit(0); }
+
+if (!latest) process.exit(0);
+
+let body = '';
+try { body = fs.readFileSync(latest, 'utf-8'); } catch (_) { process.exit(0); }
+if (!body.trim()) process.exit(0);
+
+// Move to consumed/ (preserve for audit — matches SDK consume_handoff).
+try {
+  const consumedDir = path.join(handoffDir, 'consumed');
+  fs.mkdirSync(consumedDir, { recursive: true });
+  fs.renameSync(latest, path.join(consumedDir, path.basename(latest)));
+} catch (_) { /* best-effort: a stale file is preferable to breaking startup */ }
+
+const injection = [
+  '<handoff from-prev-session path="' + latest + '">',
+  body.trim(),
+  '</handoff>',
+  '',
+  'The previous session crossed the context-pressure threshold and left this',
+  'handoff. Resume from "Next action" — do not re-plan.',
+].join('\n');
+
+process.stdout.write(JSON.stringify({ result: injection }));

--- a/.claude/hooks/user-prompt/handoff-watchdog.js
+++ b/.claude/hooks/user-prompt/handoff-watchdog.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * handoff-watchdog.js — UserPromptSubmit hook
+ *
+ * Wires the Python SDK's HandoffWatchdog pattern (contrib/patterns/handoff.py,
+ * issue #127) into Claude Code's runtime.
+ *
+ * Statusline already writes used_pct to a bridge file each render; we read it
+ * here instead of re-estimating from the transcript. When pressure crosses
+ * GRADATA_HANDOFF_THRESHOLD (default 0.65), emit a directive telling the
+ * current agent to write a handoff doc to <BRAIN_DIR>/handoffs/ before the
+ * context compacts. Fires once per session (sentinel in os.tmpdir()).
+ *
+ * Silent on failure. Never blocks the prompt.
+ */
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const cfg = require('../config.js');
+
+let input = '';
+try { input = fs.readFileSync(0, 'utf-8'); } catch (_) { process.exit(0); }
+
+let session = '';
+try {
+  const parsed = JSON.parse(input);
+  session = parsed.session_id || '';
+} catch (_) { /* silent */ }
+if (!session) process.exit(0);
+
+// Read threshold (default 0.65, overridable via env). Clamp to [0.10, 0.95]
+// to match the SDK's HandoffWatchdog bounds.
+function readThreshold() {
+  const raw = process.env.GRADATA_HANDOFF_THRESHOLD;
+  if (!raw) return 0.65;
+  const v = parseFloat(raw);
+  if (Number.isNaN(v) || v < 0.10 || v > 0.95) return 0.65;
+  return v;
+}
+const threshold = readThreshold();
+
+// Statusline bridge file — written on each render, carries buffer-normalized
+// used_pct. If absent, the statusline hasn't run yet this session; bail.
+const bridgePath = path.join(os.tmpdir(), `claude-ctx-${session}.json`);
+if (!fs.existsSync(bridgePath)) process.exit(0);
+
+let usedPct = 0;
+try {
+  const bridge = JSON.parse(fs.readFileSync(bridgePath, 'utf-8'));
+  usedPct = Number(bridge.used_pct) || 0;
+} catch (_) { process.exit(0); }
+
+if (usedPct / 100 < threshold) process.exit(0);
+
+const handoffDir = path.join(cfg.BRAIN_DIR, 'handoffs');
+try { fs.mkdirSync(handoffDir, { recursive: true }); } catch (_) { /* silent */ }
+const handoffPath = path.join(handoffDir, `${session}.handoff.md`);
+
+// Self-healing: the handoff is "done" only when the file actually exists on
+// disk. If the agent ignored the directive on the first fire, we keep
+// nagging on every subsequent prompt until the file is written. The sentinel
+// just tracks whether we've *ever* fired so we can soften the wording on
+// retries.
+if (fs.existsSync(handoffPath)) process.exit(0);
+
+const sentinel = path.join(os.tmpdir(), `gradata-handoff-fired-${session}.flag`);
+const isRetry = fs.existsSync(sentinel);
+try { fs.writeFileSync(sentinel, String(Date.now())); } catch (_) { /* silent */ }
+
+// Emit directive — the current agent sees this as system context and writes
+// the handoff doc itself. Shape mirrors gradata.contrib.patterns.handoff
+// so the SessionStart injector can parse it back on the next session.
+const directive = [
+  '<handoff-watchdog threshold="' + Math.round(threshold * 100) + '" used="' + usedPct + '"' + (isRetry ? ' retry="true"' : '') + '>',
+  (isRetry
+    ? 'REMINDER: the handoff doc was requested on a previous prompt but has not been written yet. Write it now before responding — context pressure is still at ' + usedPct + '%.'
+    : 'Context pressure has crossed the handoff threshold (' + usedPct + '% used, threshold ' + Math.round(threshold * 100) + '%).'),
+  'Write a compact resume doc to:',
+  '  ' + handoffPath,
+  '',
+  'Shape (match exactly so the next session can parse it):',
+  '  # Handoff — <task-id>',
+  '  _from_: <agent-name>  _at_: <ISO-timestamp>',
+  '  _rules_ts_: <ISO-timestamp>',
+  '',
+  '  ## Where we left off',
+  '  <2-4 sentences on current state>',
+  '',
+  '  ## Next action',
+  '  <the exact next step — command, file, or decision>',
+  '',
+  '  ## Open questions',
+  '  - <anything unresolved>',
+  '',
+  '  ## Artifacts',
+  '  - <PRs, file paths, commit SHAs>',
+  '',
+  'Do this now, then continue with the user\'s current message. The next',
+  'Claude Code session will inject this doc on SessionStart so you pick up',
+  'exactly where this one left off.',
+  '</handoff-watchdog>',
+].join('\n');
+
+process.stdout.write(JSON.stringify({ result: directive }));

--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -1,0 +1,42 @@
+name: SDK CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Gradata/**"
+      - ".github/workflows/sdk-ci.yml"
+  pull_request:
+    paths:
+      - "Gradata/**"
+      - ".github/workflows/sdk-ci.yml"
+
+concurrency:
+  group: sdk-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: pytest (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    defaults:
+      run:
+        working-directory: Gradata
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run pytest
+        run: python -m pytest tests/ -q

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,21 @@ Desktop.ini
 .obsidian/
 .codex/
 .claude/
+# Track the handoff watchdog hooks so future sessions (and fresh clones)
+# keep the context-pressure watchdog wired into Claude Code. Everything
+# else under .claude/ stays local.
+!.claude/
+.claude/*
+!.claude/hooks/
+.claude/hooks/*
+!.claude/hooks/dispatcher-user-prompt.js
+!.claude/hooks/dispatcher-session-start.js
+!.claude/hooks/user-prompt/
+!.claude/hooks/session-start/
+.claude/hooks/user-prompt/*
+!.claude/hooks/user-prompt/handoff-watchdog.js
+.claude/hooks/session-start/*
+!.claude/hooks/session-start/handoff-inject.js
 .claude-octopus/
 .agents/
 .opencli/

--- a/.gitignore
+++ b/.gitignore
@@ -82,15 +82,15 @@ Desktop.ini
 .obsidian/
 .codex/
 .claude/
-# Track the handoff watchdog hooks so future sessions (and fresh clones)
-# keep the context-pressure watchdog wired into Claude Code. Everything
-# else under .claude/ stays local.
+# Track only the two handoff-watchdog hook files so future sessions (and
+# fresh clones) keep the context-pressure watchdog code under version
+# control. Wiring them into the dispatcher/settings is machine-local —
+# see Gradata/src/gradata/hooks/_installer.py for the portable install
+# path (TODO: add watchdog to installer assets).
 !.claude/
 .claude/*
 !.claude/hooks/
 .claude/hooks/*
-!.claude/hooks/dispatcher-user-prompt.js
-!.claude/hooks/dispatcher-session-start.js
 !.claude/hooks/user-prompt/
 !.claude/hooks/session-start/
 .claude/hooks/user-prompt/*

--- a/Gradata/src/gradata/_brain_manifest.py
+++ b/Gradata/src/gradata/_brain_manifest.py
@@ -59,12 +59,16 @@ def generate_manifest(*, domain: str = "General", ctx: "BrainContext | None" = N
 
     # Cross-check session count: prefer DB max if higher than VERSION.md
     try:
+        import contextlib as _ctxlib
+
         db = ctx.db_path if ctx else _p.DB_PATH
-        conn = get_connection(db)
-        db_max = conn.execute(
-            "SELECT MAX(session) FROM events WHERE typeof(session)='integer'"
-        ).fetchone()[0] or 0
-        conn.close()
+        with _ctxlib.closing(get_connection(db)) as conn:
+            db_max = (
+                conn.execute(
+                    "SELECT MAX(session) FROM events WHERE typeof(session)='integer'"
+                ).fetchone()[0]
+                or 0
+            )
         if db_max > version_info["sessions_trained"]:
             version_info["sessions_trained"] = db_max
     except Exception:
@@ -110,10 +114,22 @@ def generate_manifest(*, domain: str = "General", ctx: "BrainContext | None" = N
             },
         },
         "bootstrap": [
-            {"step": "set_env_vars", "desc": "Set BRAIN_DIR, WORKING_DIR, DOMAIN_DIR", "required": True},
+            {
+                "step": "set_env_vars",
+                "desc": "Set BRAIN_DIR, WORKING_DIR, DOMAIN_DIR",
+                "required": True,
+            },
             {"step": "init_db", "command": "python start.py init", "required": True},
-            {"step": "embed_brain", "command": "python embed.py --full", "required": rag.get("active", False)},
-            {"step": "rebuild_fts", "command": "python -c \"from query import fts_rebuild; fts_rebuild()\"", "required": True},
+            {
+                "step": "embed_brain",
+                "command": "python embed.py --full",
+                "required": rag.get("active", False),
+            },
+            {
+                "step": "rebuild_fts",
+                "command": 'python -c "from query import fts_rebuild; fts_rebuild()"',
+                "required": True,
+            },
             {"step": "validate", "command": "python config_validator.py", "required": False},
         ],
         "compatibility": {

--- a/Gradata/src/gradata/_events.py
+++ b/Gradata/src/gradata/_events.py
@@ -58,9 +58,27 @@ def _locked_append(path: Path, line: str) -> None:
     _locked_append_many(path, [line])
 
 
+# Process-level cache: once we've initialized the schema on a given db path
+# in this process, subsequent emit()/supersede() calls skip the 10+ DDL
+# statements and single commit. SQLite parses CREATE IF NOT EXISTS etc. on
+# every call otherwise, adding measurable latency to hot write paths.
+_schema_initialized: set[str] = set()
+
+
 def _ensure_table(conn: sqlite3.Connection):
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA busy_timeout=5000")
+    # Skip DDL if this process already ensured the schema for this db file.
+    # The conn-level PRAGMAs above still need to run per-connection.
+    try:
+        db_file = next(
+            (row[2] for row in conn.execute("PRAGMA database_list").fetchall() if row[1] == "main"),
+            None,
+        )
+    except sqlite3.Error:
+        db_file = None
+    if db_file and db_file in _schema_initialized:
+        return
     conn.execute("""
         CREATE TABLE IF NOT EXISTS events (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -106,11 +124,21 @@ def _ensure_table(conn: sqlite3.Connection):
     with contextlib.suppress(sqlite3.OperationalError):
         conn.execute("CREATE INDEX IF NOT EXISTS idx_events_tenant ON events(tenant_id)")
     conn.commit()
+    if db_file:
+        _schema_initialized.add(db_file)
 
 
-def emit(event_type: str, source: str, data: dict | None = None, tags: list | None = None,
-         session: int | None = None, valid_from: str | None = None, valid_until: str | None = None,
-         ctx: BrainContext | None = None, ts: str | None = None):
+def emit(
+    event_type: str,
+    source: str,
+    data: dict | None = None,
+    tags: list | None = None,
+    session: int | None = None,
+    valid_from: str | None = None,
+    valid_until: str | None = None,
+    ctx: BrainContext | None = None,
+    ts: str | None = None,
+):
     """Emit an event to the brain's event log.
 
     Args:
@@ -141,10 +169,12 @@ def emit(event_type: str, source: str, data: dict | None = None, tags: list | No
     enriched_tags = tags or []
     try:
         from gradata._tag_taxonomy import enrich_tags, validate_tags
+
         enriched_tags = enrich_tags(enriched_tags, event_type, data or {})
         issues = validate_tags(enriched_tags, event_type)
         if issues:
             import logging
+
             _logger = logging.getLogger("gradata.events")
             for issue in issues[:2]:
                 _logger.debug("tag validation: %s", issue)
@@ -152,9 +182,14 @@ def emit(event_type: str, source: str, data: dict | None = None, tags: list | No
         pass
 
     event = {
-        "ts": ts, "session": session, "type": event_type, "source": source,
-        "data": data or {}, "tags": enriched_tags,
-        "valid_from": valid_from, "valid_until": valid_until,
+        "ts": ts,
+        "session": session,
+        "type": event_type,
+        "source": source,
+        "data": data or {},
+        "tags": enriched_tags,
+        "valid_from": valid_from,
+        "valid_until": valid_until,
     }
 
     # Dual-write: JSONL (portable) + SQLite (queryable).
@@ -181,8 +216,17 @@ def emit(event_type: str, source: str, data: dict | None = None, tags: list | No
                 "INSERT OR IGNORE INTO events "
                 "(ts, session, type, source, data_json, tags_json, valid_from, valid_until, tenant_id, schema_version) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1)",
-                (ts, session, event_type, source, json.dumps(data or {}),
-                 json.dumps(enriched_tags), valid_from, valid_until, _tid),
+                (
+                    ts,
+                    session,
+                    event_type,
+                    source,
+                    json.dumps(data or {}),
+                    json.dumps(enriched_tags),
+                    valid_from,
+                    valid_until,
+                    _tid,
+                ),
             )
             if cursor.rowcount == 1:
                 event["id"] = cursor.lastrowid
@@ -199,6 +243,7 @@ def emit(event_type: str, source: str, data: dict | None = None, tags: list | No
 
     if not jsonl_ok and not sqlite_ok:
         from gradata.exceptions import EventPersistenceError
+
         raise EventPersistenceError(
             f"Event {event_type} failed to persist to BOTH JSONL and SQLite. "
             "Learning data lost. Check file permissions and disk space."
@@ -208,25 +253,47 @@ def emit(event_type: str, source: str, data: dict | None = None, tags: list | No
     return event
 
 
-
-def emit_gate_result(gate_name: str, result: str, sources_checked: list | None = None, detail: str = "") -> dict:
+def emit_gate_result(
+    gate_name: str, result: str, sources_checked: list | None = None, detail: str = ""
+) -> dict:
     sources = sources_checked or []
-    return emit("GATE_RESULT", "gate:execution", {
-        "gate": gate_name, "result": result, "sources_checked": sources,
-        "sources_complete": len(sources) > 0, "detail": detail,
-    }, tags=[f"gate:{gate_name}"])
+    return emit(
+        "GATE_RESULT",
+        "gate:execution",
+        {
+            "gate": gate_name,
+            "result": result,
+            "sources_checked": sources,
+            "sources_complete": len(sources) > 0,
+            "detail": detail,
+        },
+        tags=[f"gate:{gate_name}"],
+    )
 
 
 def emit_gate_override(gate_name: str, reason: str, steps_skipped: list | None = None) -> dict:
-    return emit("GATE_OVERRIDE", "gate:override", {
-        "gate": gate_name, "reason": reason,
-        "steps_skipped": steps_skipped or [], "override_type": "explicit",
-    }, tags=[f"gate:{gate_name}", "override:explicit"])
+    return emit(
+        "GATE_OVERRIDE",
+        "gate:override",
+        {
+            "gate": gate_name,
+            "reason": reason,
+            "steps_skipped": steps_skipped or [],
+            "override_type": "explicit",
+        },
+        tags=[f"gate:{gate_name}", "override:explicit"],
+    )
 
 
-def query(event_type: str | None = None, session: int | None = None, last_n_sessions: int | None = None,
-          limit: int = 100, as_of: str | None = None, active_only: bool = False,
-          ctx: BrainContext | None = None) -> list:
+def query(
+    event_type: str | None = None,
+    session: int | None = None,
+    last_n_sessions: int | None = None,
+    limit: int = 100,
+    as_of: str | None = None,
+    active_only: bool = False,
+    ctx: BrainContext | None = None,
+) -> list:
     db_path = ctx.db_path if ctx else _p.DB_PATH
     with contextlib.closing(sqlite3.connect(str(db_path))) as conn:
         conn.row_factory = sqlite3.Row
@@ -261,19 +328,28 @@ def query(event_type: str | None = None, session: int | None = None, last_n_sess
 
     return [
         {
-            "id": r["id"], "ts": r["ts"], "session": r["session"],
-            "type": r["type"], "source": r["source"],
+            "id": r["id"],
+            "ts": r["ts"],
+            "session": r["session"],
+            "type": r["type"],
+            "source": r["source"],
             "data": json.loads(r["data_json"]) if r["data_json"] else {},
             "tags": json.loads(r["tags_json"]) if r["tags_json"] else [],
-            "valid_from": r["valid_from"], "valid_until": r["valid_until"],
+            "valid_from": r["valid_from"],
+            "valid_until": r["valid_until"],
         }
         for r in rows
     ]
 
 
-def supersede(event_id: int, new_data: dict | None = None, new_tags: list | None = None,
-              source: str = "supersede", new_valid_from: str | None = None,
-              ctx: BrainContext | None = None):
+def supersede(
+    event_id: int,
+    new_data: dict | None = None,
+    new_tags: list | None = None,
+    source: str = "supersede",
+    new_valid_from: str | None = None,
+    ctx: BrainContext | None = None,
+):
     now = datetime.now(UTC).isoformat()
     db = ctx.db_path if ctx else _p.DB_PATH
     with contextlib.closing(sqlite3.connect(str(db))) as conn:
@@ -286,9 +362,12 @@ def supersede(event_id: int, new_data: dict | None = None, new_tags: list | None
         conn.commit()
     orig_tags = json.loads(original["tags_json"]) if original["tags_json"] else []
     replacement = emit(
-        event_type=original["type"], source=source,
+        event_type=original["type"],
+        source=source,
         data=new_data or (json.loads(original["data_json"]) if original["data_json"] else {}),
-        tags=new_tags or orig_tags, session=_detect_session(ctx=ctx), valid_from=new_valid_from or now,
+        tags=new_tags or orig_tags,
+        session=_detect_session(ctx=ctx),
+        valid_from=new_valid_from or now,
         ctx=ctx,
     )
     replacement["superseded_id"] = event_id
@@ -299,11 +378,14 @@ def correction_rate(last_n_sessions: int = 5, ctx: BrainContext | None = None) -
     db = ctx.db_path if ctx else _p.DB_PATH
     with contextlib.closing(sqlite3.connect(str(db))) as conn:
         _ensure_table(conn)
-        rows = conn.execute("""
+        rows = conn.execute(
+            """
             SELECT session, COUNT(*) as count FROM events WHERE type = 'CORRECTION'
             AND session >= (SELECT COALESCE(MAX(session), 0) - ? FROM events)
             GROUP BY session ORDER BY session
-        """, (last_n_sessions - 1,)).fetchall()
+        """,
+            (last_n_sessions - 1,),
+        ).fetchall()
     return {r[0]: r[1] for r in rows}
 
 
@@ -312,8 +394,10 @@ def compute_leading_indicators(session: int, ctx: BrainContext | None = None) ->
     with contextlib.closing(sqlite3.connect(str(db))) as conn:
         _ensure_table(conn)
         result = {
-            "first_draft_acceptance": 0.0, "correction_density": 0.0,
-            "avg_time_to_deliverable_ms": 0.0, "source_coverage": 0.0,
+            "first_draft_acceptance": 0.0,
+            "correction_density": 0.0,
+            "avg_time_to_deliverable_ms": 0.0,
+            "source_coverage": 0.0,
             "confidence_calibration": 1.0,
         }
         outputs = conn.execute(
@@ -328,7 +412,9 @@ def compute_leading_indicators(session: int, ctx: BrainContext | None = None) ->
             "SELECT COUNT(*) FROM events WHERE type = 'CORRECTION' AND session = ?", (session,)
         ).fetchone()[0]
         output_count = len(outputs) if outputs else 0
-        result["correction_density"] = min(corrections / output_count, 1.0) if output_count > 0 else 0.0
+        result["correction_density"] = (
+            min(corrections / output_count, 1.0) if output_count > 0 else 0.0
+        )
 
         gates = conn.execute(
             "SELECT data_json FROM events WHERE type = 'GATE_RESULT' AND session = ?", (session,)
@@ -364,7 +450,9 @@ def compute_leading_indicators(session: int, ctx: BrainContext | None = None) ->
                 # v1 format: delta-based (legacy)
                 total_cal = len(delta_events)
                 within_range = sum(1 for d in delta_events if abs(d.get("delta", 0)) <= 2)
-                result["confidence_calibration"] = within_range / total_cal if total_cal > 0 else 1.0
+                result["confidence_calibration"] = (
+                    within_range / total_cal if total_cal > 0 else 1.0
+                )
 
     return result
 
@@ -397,7 +485,6 @@ def _detect_session(ctx: BrainContext | None = None) -> int:
 # ── Brain-quality functions (promoted from brain shim) ────────────────
 
 
-
 def find_contradictions(event_type: str | None = None, tag_prefix: str | None = None) -> list:
     """Find events that may contradict each other — same tags, overlapping validity.
 
@@ -418,16 +505,19 @@ def find_contradictions(event_type: str | None = None, tag_prefix: str | None = 
 
     conflicts = []
     for i, a in enumerate(events):
-        for b in events[i + 1:]:
+        for b in events[i + 1 :]:
             # Check tag overlap
             shared_tags = set(a.get("tags", [])) & set(b.get("tags", []))
             if shared_tags and a["type"] == b["type"]:
-                conflicts.append({
-                    "event_a": {"id": a["id"], "ts": a["ts"], "data": a["data"]},
-                    "event_b": {"id": b["id"], "ts": b["ts"], "data": b["data"]},
-                    "shared_tags": list(shared_tags),
-                    "both_active": a.get("valid_until") is None and b.get("valid_until") is None,
-                })
+                conflicts.append(
+                    {
+                        "event_a": {"id": a["id"], "ts": a["ts"], "data": a["data"]},
+                        "event_b": {"id": b["id"], "ts": b["ts"], "data": b["data"]},
+                        "shared_tags": list(shared_tags),
+                        "both_active": a.get("valid_until") is None
+                        and b.get("valid_until") is None,
+                    }
+                )
 
     return conflicts
 
@@ -437,12 +527,15 @@ def audit_trend(last_n_sessions: int = 5, ctx: BrainContext | None = None) -> li
     db = ctx.db_path if ctx else _p.DB_PATH
     with contextlib.closing(sqlite3.connect(str(db))) as conn:
         _ensure_table(conn)
-        rows = conn.execute("""
+        rows = conn.execute(
+            """
             SELECT session, data_json FROM events
             WHERE type = 'AUDIT_SCORE'
             AND session >= (SELECT COALESCE(MAX(session), 0) - ? FROM events)
             ORDER BY session
-        """, (last_n_sessions - 1,)).fetchall()
+        """,
+            (last_n_sessions - 1,),
+        ).fetchall()
     return [{"session": r[0], "data": json.loads(r[1])} for r in rows]
 
 
@@ -467,6 +560,7 @@ class RetainOrchestrator:
 
     def __init__(self, brain_dir: str | Path) -> None:
         from pathlib import Path as _Path
+
         self.brain_dir = _Path(brain_dir)
         self.events_path = self.brain_dir / "events.jsonl"
         self.db_path = self.brain_dir / "system.db"
@@ -545,19 +639,13 @@ class RetainOrchestrator:
                             continue
             result["phases"]["read"] = {
                 "existing_keys": len(existing_keys),
-                "new": sum(
-                    1 for e in self._pending
-                    if self._event_key(e) not in existing_keys
-                ),
+                "new": sum(1 for e in self._pending if self._event_key(e) not in existing_keys),
             }
         except Exception as exc:
             result["errors"].append(f"Phase 1: {exc}")
             # Fall through with empty existing_keys — safer than aborting
 
-        new_events = [
-            e for e in self._pending
-            if self._event_key(e) not in existing_keys
-        ]
+        new_events = [e for e in self._pending if self._event_key(e) not in existing_keys]
 
         if not new_events:
             self._pending.clear()
@@ -569,8 +657,7 @@ class RetainOrchestrator:
             # multi-process interleaving on Windows (msvcrt.locking) and POSIX
             # (fcntl.flock). Single lock + single fsync for the whole batch.
             lines = [
-                json.dumps(event, default=str, ensure_ascii=False) + "\n"
-                for event in new_events
+                json.dumps(event, default=str, ensure_ascii=False) + "\n" for event in new_events
             ]
             _locked_append_many(self.events_path, lines)
             result["written"] = len(new_events)
@@ -620,6 +707,7 @@ class RetainOrchestrator:
         try:
             try:
                 from gradata._brain_manifest import update_manifest  # type: ignore[import]
+
                 update_manifest(self.brain_dir)
                 manifest_updated = True
             except (ImportError, Exception):

--- a/Gradata/src/gradata/_manifest_helpers.py
+++ b/Gradata/src/gradata/_manifest_helpers.py
@@ -5,6 +5,7 @@ Shared constants and utility functions for manifest generation.
 Split from _brain_manifest.py for file size compliance (<500 lines).
 """
 
+import contextlib
 import re
 from typing import TYPE_CHECKING
 
@@ -21,9 +22,12 @@ HIGH_SEVERITY = frozenset({"moderate", "major", "discarded"})
 
 def _session_window(conn, window: int = 20) -> tuple[int, int]:
     """Return (max_session, min_session) for a recent window. Shared helper."""
-    max_session = conn.execute(
-        "SELECT MAX(session) FROM events WHERE typeof(session)='integer'"
-    ).fetchone()[0] or 0
+    max_session = (
+        conn.execute("SELECT MAX(session) FROM events WHERE typeof(session)='integer'").fetchone()[
+            0
+        ]
+        or 0
+    )
     return max_session, max(1, max_session - window + 1)
 
 
@@ -51,12 +55,11 @@ def _count_events(ctx: "BrainContext | None" = None) -> dict:
     result = {"total": 0, "by_type": {}}
     try:
         db = ctx.db_path if ctx else _p.DB_PATH
-        conn = get_connection(db)
-        rows = conn.execute("SELECT type, COUNT(*) as cnt FROM events GROUP BY type").fetchall()
-        for row in rows:
-            result["by_type"][row["type"]] = row["cnt"]
-            result["total"] += row["cnt"]
-        conn.close()
+        with contextlib.closing(get_connection(db)) as conn:
+            rows = conn.execute("SELECT type, COUNT(*) as cnt FROM events GROUP BY type").fetchall()
+            for row in rows:
+                result["by_type"][row["type"]] = row["cnt"]
+                result["total"] += row["cnt"]
     except Exception:
         pass
     return result
@@ -65,9 +68,10 @@ def _count_events(ctx: "BrainContext | None" = None) -> dict:
 def _get_tables(ctx: "BrainContext | None" = None) -> list[str]:
     try:
         db = ctx.db_path if ctx else _p.DB_PATH
-        conn = get_connection(db)
-        rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").fetchall()
-        conn.close()
+        with contextlib.closing(get_connection(db)) as conn:
+            rows = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+            ).fetchall()
         return [r[0] for r in rows]
     except Exception:
         return []
@@ -121,10 +125,21 @@ def _sdk_capabilities() -> dict:
         ("git_backfill", "gradata.enhancements.git_backfill", "gradata"),
         ("auto_correct_hook", "gradata.hooks.auto_correct", "gradata"),
         ("reporting", "gradata.enhancements.reporting", "fest.build-inspired+gradata"),
-        ("quality_monitoring", "gradata.enhancements.quality_monitoring", "jarvis-inspired+gradata"),
+        (
+            "quality_monitoring",
+            "gradata.enhancements.quality_monitoring",
+            "jarvis-inspired+gradata",
+        ),
     ]
 
-    all_modules = _paul_modules + _ruflo_modules + _deerflow_modules + _ecc_modules + _everos_modules + _core_modules
+    all_modules = (
+        _paul_modules
+        + _ruflo_modules
+        + _deerflow_modules
+        + _ecc_modules
+        + _everos_modules
+        + _core_modules
+    )
 
     for name, module_path, source in all_modules:
         try:
@@ -143,6 +158,7 @@ def _sdk_capabilities() -> dict:
 def _tag_taxonomy() -> dict:
     try:
         from gradata._tag_taxonomy import get_taxonomy_summary
+
         return get_taxonomy_summary()
     except ImportError:
         return {}

--- a/Gradata/src/gradata/_manifest_metrics.py
+++ b/Gradata/src/gradata/_manifest_metrics.py
@@ -7,7 +7,24 @@ Split from _brain_manifest.py for file size compliance (<500 lines).
 
 import re
 import statistics
-from datetime import datetime
+from datetime import UTC, datetime
+
+
+def _parse_ts_utc(raw: str) -> datetime:
+    """Parse an ISO-8601 timestamp and coerce to aware UTC.
+
+    SQLite stores timestamps as raw text, so the same column can yield
+    both naive (``2026-04-01T12:00:00``) and aware
+    (``2026-04-01T12:00:00+00:00`` / ``...Z``) values. Subtracting a
+    naive from an aware datetime raises; coerce both sides here so
+    callers can subtract freely.
+    """
+    dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
 from typing import TYPE_CHECKING
 
 import gradata._paths as _p
@@ -149,8 +166,8 @@ def _temporal_provenance(ctx: "BrainContext | None" = None) -> dict:
         result["distinct_days"] = days
         if agg[1] and agg[2]:
             try:
-                t0 = datetime.fromisoformat(str(agg[1]).replace("Z", "+00:00"))
-                t1 = datetime.fromisoformat(str(agg[2]).replace("Z", "+00:00"))
+                t0 = _parse_ts_utc(str(agg[1]))
+                t1 = _parse_ts_utc(str(agg[2]))
                 result["session_spread_days"] = max(0, (t1 - t0).days)
             except (ValueError, TypeError):
                 pass
@@ -190,10 +207,8 @@ def _temporal_provenance(ctx: "BrainContext | None" = None) -> dict:
             gaps = []
             for i in range(1, len(session_starts)):
                 try:
-                    t0 = datetime.fromisoformat(
-                        str(session_starts[i - 1][0]).replace("Z", "+00:00")
-                    )
-                    t1 = datetime.fromisoformat(str(session_starts[i][0]).replace("Z", "+00:00"))
+                    t0 = _parse_ts_utc(str(session_starts[i - 1][0]))
+                    t1 = _parse_ts_utc(str(session_starts[i][0]))
                     gaps.append((t1 - t0).total_seconds() / 3600)
                 except (ValueError, TypeError):
                     continue

--- a/Gradata/src/gradata/_manifest_metrics.py
+++ b/Gradata/src/gradata/_manifest_metrics.py
@@ -30,18 +30,27 @@ if TYPE_CHECKING:
     from gradata._paths import BrainContext
 
 
-def _lesson_distribution(ctx: "BrainContext | None" = None) -> dict[str, int]:
-    """Count lessons by state from lessons.md."""
+def _lesson_distribution(
+    ctx: "BrainContext | None" = None,
+    lessons_text: str | None = None,
+) -> dict[str, int]:
+    """Count lessons by state from lessons.md.
+
+    If ``lessons_text`` is provided, it is used directly — avoids a second
+    read_text() in the manifest generation path (see _quality_metrics).
+    """
     dist: dict[str, int] = {}
-    lessons_file = ctx.lessons_file if ctx else _p.LESSONS_FILE
     try:
-        if lessons_file.exists():
-            text = lessons_file.read_text(encoding="utf-8")
+        text = lessons_text
+        if text is None:
+            lessons_file = ctx.lessons_file if ctx else _p.LESSONS_FILE
+            if lessons_file.exists():
+                text = lessons_file.read_text(encoding="utf-8")
+        if text:
             for state in ("INSTINCT", "PATTERN", "RULE", "UNTESTABLE"):
-                count = len(re.findall(
-                    rf"^\[20\d{{2}}-\d{{2}}-\d{{2}}\]\s+\[{state}",
-                    text, re.MULTILINE
-                ))
+                count = len(
+                    re.findall(rf"^\[20\d{{2}}-\d{{2}}-\d{{2}}\]\s+\[{state}", text, re.MULTILINE)
+                )
                 if count > 0:
                     dist[state] = count
     except Exception:
@@ -61,14 +70,20 @@ def _correction_rate_trend(ctx: "BrainContext | None" = None, window: int = 10) 
             return None
 
         def _cro(min_s, max_s):
-            outputs = conn.execute(
-                "SELECT COUNT(*) FROM events WHERE type='OUTPUT' AND session BETWEEN ? AND ?",
-                (min_s, max_s)
-            ).fetchone()[0] or 0
-            corrections = conn.execute(
-                "SELECT COUNT(*) FROM events WHERE type='CORRECTION' AND session BETWEEN ? AND ?",
-                (min_s, max_s)
-            ).fetchone()[0] or 0
+            outputs = (
+                conn.execute(
+                    "SELECT COUNT(*) FROM events WHERE type='OUTPUT' AND session BETWEEN ? AND ?",
+                    (min_s, max_s),
+                ).fetchone()[0]
+                or 0
+            )
+            corrections = (
+                conn.execute(
+                    "SELECT COUNT(*) FROM events WHERE type='CORRECTION' AND session BETWEEN ? AND ?",
+                    (min_s, max_s),
+                ).fetchone()[0]
+                or 0
+            )
             return round(corrections / outputs, 4) if outputs > 0 else None
 
         current = _cro(max_session - window + 1, max_session)
@@ -78,7 +93,11 @@ def _correction_rate_trend(ctx: "BrainContext | None" = None, window: int = 10) 
         if current is None or baseline is None:
             return None
 
-        direction = "improving" if current < baseline else ("stable" if current == baseline else "degrading")
+        direction = (
+            "improving"
+            if current < baseline
+            else ("stable" if current == baseline else "degrading")
+        )
         return {
             "current_window": current,
             "baseline_window": baseline,
@@ -137,7 +156,14 @@ def _temporal_provenance(ctx: "BrainContext | None" = None) -> dict:
                 pass
 
         # Query 2: source counts grouped -- filter in Python, no second query
-        internal_prefixes = ("event:", "correction_detector", "brain", "session", "gate", "supersede")
+        internal_prefixes = (
+            "event:",
+            "correction_detector",
+            "brain",
+            "session",
+            "gate",
+            "supersede",
+        )
         source_rows = conn.execute("""
             SELECT source, COUNT(*) as cnt FROM events
             WHERE source IS NOT NULL AND source != ''
@@ -161,11 +187,12 @@ def _temporal_provenance(ctx: "BrainContext | None" = None) -> dict:
             ORDER BY session
         """).fetchall()
         if len(session_starts) >= 2:
-
             gaps = []
             for i in range(1, len(session_starts)):
                 try:
-                    t0 = datetime.fromisoformat(str(session_starts[i - 1][0]).replace("Z", "+00:00"))
+                    t0 = datetime.fromisoformat(
+                        str(session_starts[i - 1][0]).replace("Z", "+00:00")
+                    )
                     t1 = datetime.fromisoformat(str(session_starts[i][0]).replace("Z", "+00:00"))
                     gaps.append((t1 - t0).total_seconds() / 3600)
                 except (ValueError, TypeError):
@@ -185,8 +212,12 @@ def _temporal_provenance(ctx: "BrainContext | None" = None) -> dict:
         gap_score = min(1.0, result["avg_gap_hours"] / 8) if result["avg_gap_hours"] > 0 else 0.0
 
         result["provenance_score"] = round(
-            0.25 * day_score + 0.20 * spread_score + 0.20 * external_score
-            + 0.15 * ratio_score + 0.20 * gap_score, 3
+            0.25 * day_score
+            + 0.20 * spread_score
+            + 0.20 * external_score
+            + 0.15 * ratio_score
+            + 0.20 * gap_score,
+            3,
         )
 
     except Exception:
@@ -218,7 +249,6 @@ def _outcome_correlation(ctx: "BrainContext | None" = None, window: int = 20) ->
         if len(rows) < 5:
             return None
 
-        [r[0] for r in rows]
         values = [float(r[1]) for r in rows]
 
         # Compute trend direction for outcomes
@@ -234,7 +264,9 @@ def _outcome_correlation(ctx: "BrainContext | None" = None, window: int = 20) ->
         if sx == 0 or sy == 0:
             r = 0.0
         else:
-            r = sum((xi - mx) * (vi - my) for xi, vi in zip(x, values, strict=False)) / ((n - 1) * sx * sy)
+            r = sum((xi - mx) * (vi - my) for xi, vi in zip(x, values, strict=False)) / (
+                (n - 1) * sx * sy
+            )
 
         return {
             "outcome_trend_slope": round(slope, 4),
@@ -279,22 +311,31 @@ def _quality_metrics(ctx: "BrainContext | None" = None) -> dict:
         # Use top-N real sessions (by event count) to avoid phantom session IDs
         db = ctx.db_path if ctx else _p.DB_PATH
         conn = get_connection(db)
-        recent_sessions = [r[0] for r in conn.execute("""
+        recent_sessions = [
+            r[0]
+            for r in conn.execute("""
             SELECT session FROM events
             WHERE typeof(session)='integer'
             GROUP BY session HAVING COUNT(*) >= 2
             ORDER BY session DESC LIMIT 10
-        """).fetchall()]
+        """).fetchall()
+        ]
         if recent_sessions:
             placeholders = ",".join("?" * len(recent_sessions))
-            total_corrections = conn.execute(
-                f"SELECT COUNT(*) FROM events WHERE type='CORRECTION' AND session IN ({placeholders})",
-                recent_sessions
-            ).fetchone()[0] or 0
-            total_outputs = conn.execute(
-                f"SELECT COUNT(*) FROM events WHERE type='OUTPUT' AND session IN ({placeholders})",
-                recent_sessions
-            ).fetchone()[0] or 0
+            total_corrections = (
+                conn.execute(
+                    f"SELECT COUNT(*) FROM events WHERE type='CORRECTION' AND session IN ({placeholders})",
+                    recent_sessions,
+                ).fetchone()[0]
+                or 0
+            )
+            total_outputs = (
+                conn.execute(
+                    f"SELECT COUNT(*) FROM events WHERE type='OUTPUT' AND session IN ({placeholders})",
+                    recent_sessions,
+                ).fetchone()[0]
+                or 0
+            )
             if total_outputs > 0:
                 result["correction_rate"] = round(total_corrections / total_outputs, 3)
         conn.close()
@@ -310,39 +351,52 @@ def _quality_metrics(ctx: "BrainContext | None" = None) -> dict:
     # Correction rate trend
     result["correction_rate_trend"] = _correction_rate_trend(ctx=ctx)
 
-    # Count lessons -- date-prefix pattern avoids matching format descriptions
+    # Count lessons -- date-prefix pattern avoids matching format descriptions.
+    # Read lessons.md once and reuse the text for _lesson_distribution below.
     lessons_file = ctx.lessons_file if ctx else _p.LESSONS_FILE
     brain_dir = ctx.brain_dir if ctx else _p.BRAIN_DIR
     archive_file = brain_dir / "lessons-archive.md"
+    lessons_text: str | None = None
     try:
         if lessons_file.exists():
-            text = lessons_file.read_text(encoding="utf-8")
-            result["lessons_active"] = len(re.findall(
-                r"^\[20\d{2}-\d{2}-\d{2}\]\s+\[(?:PATTERN|INSTINCT):", text, re.MULTILINE
-            ))
+            lessons_text = lessons_file.read_text(encoding="utf-8")
+            result["lessons_active"] = len(
+                re.findall(
+                    r"^\[20\d{2}-\d{2}-\d{2}\]\s+\[(?:PATTERN|INSTINCT):",
+                    lessons_text,
+                    re.MULTILINE,
+                )
+            )
         if archive_file.exists():
             text = archive_file.read_text(encoding="utf-8")
-            result["lessons_graduated"] = len(re.findall(
-                r"^\[20\d{2}-\d{2}-\d{2}\]", text, re.MULTILINE
-            ))
+            result["lessons_graduated"] = len(
+                re.findall(r"^\[20\d{2}-\d{2}-\d{2}\]", text, re.MULTILINE)
+            )
     except Exception:
         pass
 
-    # Lesson distribution
-    result["lesson_distribution"] = _lesson_distribution(ctx=ctx)
+    # Lesson distribution — reuse already-read text (avoids second disk read).
+    result["lesson_distribution"] = _lesson_distribution(ctx=ctx, lessons_text=lessons_text)
 
     # Get sessions count for compound score
     try:
+        import contextlib as _ctxlib
+
         db = ctx.db_path if ctx else _p.DB_PATH
-        conn = get_connection(db)
-        sessions_trained = conn.execute(
-            "SELECT MAX(session) FROM events WHERE typeof(session)='integer'"
-        ).fetchone()[0] or 0
-        if total_corrections == 0:
-            total_corrections = conn.execute(
-                "SELECT COUNT(*) FROM events WHERE type='CORRECTION'"
-            ).fetchone()[0] or 0
-        conn.close()
+        with _ctxlib.closing(get_connection(db)) as conn:
+            sessions_trained = (
+                conn.execute(
+                    "SELECT MAX(session) FROM events WHERE typeof(session)='integer'"
+                ).fetchone()[0]
+                or 0
+            )
+            if total_corrections == 0:
+                total_corrections = (
+                    conn.execute("SELECT COUNT(*) FROM events WHERE type='CORRECTION'").fetchone()[
+                        0
+                    ]
+                    or 0
+                )
     except Exception:
         pass
 
@@ -368,9 +422,7 @@ def _quality_metrics(ctx: "BrainContext | None" = None) -> dict:
         transfer=transfer,
     )
 
-    result["score_confidence"] = _score_confidence(
-        result["compound_score"], sessions_trained
-    )
+    result["score_confidence"] = _score_confidence(result["compound_score"], sessions_trained)
     result["outcome_correlation"] = _outcome_correlation(ctx=ctx)
     result["counterfactual"] = _counterfactual_percentile(
         result["compound_score"], sessions_trained, ctx=ctx
@@ -430,12 +482,16 @@ def _memory_composition(ctx: "BrainContext | None" = None) -> dict:
 def _rag_status(ctx: "BrainContext | None" = None) -> dict:
     """RAG status. Chunks counted from SQLite brain_embeddings table."""
     result = {
-        "active": False, "provider": "unknown", "model": "unknown",
-        "dimensions": 0, "chunks_indexed": 0,
+        "active": False,
+        "provider": "unknown",
+        "model": "unknown",
+        "dimensions": 0,
+        "chunks_indexed": 0,
         "fts5_enabled": True,
     }
     try:
         from gradata._config import EMBEDDING_DIMS, EMBEDDING_MODEL, EMBEDDING_PROVIDER, RAG_ACTIVE
+
         result["active"] = RAG_ACTIVE
         result["provider"] = EMBEDDING_PROVIDER
         result["model"] = EMBEDDING_MODEL

--- a/Gradata/src/gradata/brain.py
+++ b/Gradata/src/gradata/brain.py
@@ -316,13 +316,28 @@ class Brain(BrainInspectionMixin):
         return None
 
     def _load_lessons(self, create: bool = False):
-        """Load and parse lessons from lessons.md. Returns list or empty list."""
+        """Load and parse lessons from lessons.md. Returns list or empty list.
+
+        Caches the parsed result keyed on (path, mtime) so repeated reads in
+        the same session skip the parse when the file is unchanged. Writer
+        paths that re-parse + mutate + rewrite should call ``parse_lessons``
+        directly (see forget/disable_lesson/add_rule) to avoid sharing
+        mutable state with the cache.
+        """
         from gradata.enhancements.self_improvement import parse_lessons
 
         path = self._find_lessons_path(create=create)
         if not path or not path.is_file():
+            self._lessons_parse_cache = None
             return []
-        return parse_lessons(path.read_text(encoding="utf-8"))
+        mtime = path.stat().st_mtime
+        key = (str(path), mtime)
+        cache = getattr(self, "_lessons_parse_cache", None)
+        if cache is not None and cache[0] == key:
+            return cache[1]
+        lessons = parse_lessons(path.read_text(encoding="utf-8"))
+        self._lessons_parse_cache = (key, lessons)
+        return lessons
 
     @property
     def memory(self):
@@ -847,9 +862,10 @@ class Brain(BrainInspectionMixin):
         # Rules are always computed locally from the brain's own lessons.
         # Pulling rules from cloud would allow a compromised server to inject
         # malicious instructions into AI prompts → remote code execution.
-        try:
-            from gradata.enhancements.self_improvement import parse_lessons
-        except ImportError:
+        # Capability check: enhancements package must be installed for rules.
+        import importlib.util as _util
+
+        if _util.find_spec("gradata.enhancements.self_improvement") is None:
             return ""
         from gradata._scope import build_scope
         from gradata.rules.rule_engine import apply_rules, format_rules_for_prompt
@@ -871,7 +887,8 @@ class Brain(BrainInspectionMixin):
         if cached is not None:
             return cached
 
-        lessons = parse_lessons(lessons_path.read_text(encoding="utf-8"))
+        # mtime-cached parse: reuses prior result when lessons.md is unchanged.
+        lessons = self._load_lessons()
 
         # Try tree-based retrieval first (falls back to flat if no paths).
         # Pass the brain's bus so rule_engine can fire `rule_scoped_out`

--- a/Gradata/src/gradata/brain.py
+++ b/Gradata/src/gradata/brain.py
@@ -94,6 +94,14 @@ class Brain(BrainInspectionMixin):
 
         self._rule_cache = RuleCache()
 
+        # Capability probe cached once: apply_brain_rules() is a hot path
+        # and we don't want find_spec() in every call.
+        import importlib.util as _util
+
+        self._has_self_improvement = (
+            _util.find_spec("gradata.enhancements.self_improvement") is not None
+        )
+
         from gradata.rules.rule_graph import RuleGraph
 
         self._rule_graph = RuleGraph(self.dir / "rule_graph.json")
@@ -216,7 +224,8 @@ class Brain(BrainInspectionMixin):
             from gradata._events import get_current_session
 
             return get_current_session()
-        except Exception:
+        except Exception as exc:
+            logger.debug("get_current_session failed: %s", exc)
             return 0
 
     @classmethod
@@ -498,6 +507,12 @@ class Brain(BrainInspectionMixin):
             return {"patched": False, "error": f"not_found: no rule matching category={category!r}"}
 
         write_lessons_safe(lessons_path, format_lessons(lessons))
+
+        # lessons.md just changed; invalidate caches so readers don't serve
+        # a pre-patch copy until the next auto_heal() flush.
+        self._lessons_parse_cache = None
+        with contextlib.suppress(Exception):
+            self._rule_cache.invalidate()
 
         # Re-sign the patched rule so HMAC verification stays valid
         try:
@@ -1083,6 +1098,12 @@ class Brain(BrainInspectionMixin):
             )
         write_lessons_safe(lessons_path, format_lessons(lessons))
 
+        # lessons.md changed — evict mtime cache + formatted-rule cache so the
+        # next apply_brain_rules() call reflects the forget.
+        self._lessons_parse_cache = None
+        with contextlib.suppress(Exception):
+            self._rule_cache.invalidate()
+
         for r in results:
             with contextlib.suppress(Exception):
                 self.emit(
@@ -1143,6 +1164,10 @@ class Brain(BrainInspectionMixin):
         from gradata._db import write_lessons_safe
 
         write_lessons_safe(lessons_path, format_lessons(lessons))
+        # lessons.md changed — evict caches so readers see the kill immediately.
+        self._lessons_parse_cache = None
+        with contextlib.suppress(Exception):
+            self._rule_cache.invalidate()
         try:
             self.emit(
                 "LESSON_CHANGE",
@@ -1206,15 +1231,12 @@ class Brain(BrainInspectionMixin):
         # Open conn only to read the pending row, then close before taking the
         # file lock. Holding a SQLite connection across a potentially-blocking
         # file-lock section kept a WAL reader slot idle under contention.
-        conn = get_connection(self.db_path)
-        conn.row_factory = sqlite3.Row
-        try:
+        with contextlib.closing(get_connection(self.db_path)) as conn:
+            conn.row_factory = sqlite3.Row
             row = conn.execute(
                 "SELECT * FROM pending_approvals WHERE id = ? AND resolution IS NULL",
                 (approval_id,),
             ).fetchone()
-        finally:
-            conn.close()
         if not row:
             return {"resolved": False, "reason": "not_found_or_already_resolved"}
         cat, desc = row["lesson_category"], row["lesson_description"]
@@ -1239,21 +1261,23 @@ class Brain(BrainInspectionMixin):
                 from gradata._db import write_lessons_safe
 
                 write_lessons_safe(lessons_path, format_lessons(lessons))
+                # lessons.md changed — evict caches so readers see the
+                # approval/rejection immediately.
+                self._lessons_parse_cache = None
+                with contextlib.suppress(Exception):
+                    self._rule_cache.invalidate()
 
         if not matched:
             return {"resolved": False, "reason": "lesson_not_found_in_file"}
 
         from datetime import date
 
-        conn = get_connection(self.db_path)
-        try:
+        with contextlib.closing(get_connection(self.db_path)) as conn:
             conn.execute(
                 "UPDATE pending_approvals SET resolution = ?, resolved_at = ? WHERE id = ?",
                 (resolution, date.today().isoformat(), approval_id),
             )
             conn.commit()
-        finally:
-            conn.close()
         return {"resolved": True, "category": cat, "description": desc}
 
     def review_pending(self) -> list[dict]:
@@ -1627,7 +1651,8 @@ class Brain(BrainInspectionMixin):
             # Embed prove() data so the manifest is a complete quality certificate
             try:
                 m["proof"] = self.prove()
-            except Exception:
+            except Exception as exc:
+                logger.debug("proof generation failed: %s", exc)
                 m["proof"] = {
                     "proven": False,
                     "confidence_level": "error",

--- a/Gradata/src/gradata/brain.py
+++ b/Gradata/src/gradata/brain.py
@@ -538,9 +538,7 @@ class Brain(BrainInspectionMixin):
         """
         from gradata.enhancements.self_healing import auto_heal_failures
 
-        result = auto_heal_failures(
-            self, failure_events=failure_events, max_patches=max_patches
-        )
+        result = auto_heal_failures(self, failure_events=failure_events, max_patches=max_patches)
         # Patching rewrites lessons.md; invalidate the in-memory rule cache
         # so subsequent apply_brain_rules() calls see the patched text
         # instead of a stale pre-patch prompt.
@@ -661,7 +659,9 @@ class Brain(BrainInspectionMixin):
                 # l.category may have arbitrary casing (parse_lessons preserves
                 # on-disk form); compare case-insensitively against the canonical
                 # upper-cased `category` we're inserting.
-                if (l.category or "").strip().upper() == category and _norm(l.description) == desc_norm:
+                if (l.category or "").strip().upper() == category and _norm(
+                    l.description
+                ) == desc_norm:
                     return {
                         "added": False,
                         "reason": "duplicate",
@@ -881,7 +881,10 @@ class Brain(BrainInspectionMixin):
             from gradata.rules.rule_engine import apply_rules_with_tree
 
             applied = apply_rules_with_tree(
-                lessons, scope, max_rules=max_rules, event_bus=_bus,
+                lessons,
+                scope,
+                max_rules=max_rules,
+                event_bus=_bus,
             )
         except (ImportError, Exception):
             applied = apply_rules(lessons, scope, max_rules=max_rules, bus=_bus)
@@ -891,23 +894,26 @@ class Brain(BrainInspectionMixin):
         # session's prompts. Fire-and-forget — never fails apply_brain_rules.
         if _bus is not None and applied:
             try:
-                _bus.emit("rules.injected", {
-                    "rules": [
-                        {
-                            "id": a.rule_id,
-                            "category": a.lesson.category,
-                            "confidence": a.lesson.confidence,
-                            "state": a.lesson.state.value,
-                        }
-                        for a in applied
-                    ],
-                    "scope": {
-                        "task_type": scope.task_type,
-                        "domain": scope.domain,
-                        "audience": scope.audience,
+                _bus.emit(
+                    "rules.injected",
+                    {
+                        "rules": [
+                            {
+                                "id": a.rule_id,
+                                "category": a.lesson.category,
+                                "confidence": a.lesson.confidence,
+                                "state": a.lesson.state.value,
+                            }
+                            for a in applied
+                        ],
+                        "scope": {
+                            "task_type": scope.task_type,
+                            "domain": scope.domain,
+                            "audience": scope.audience,
+                        },
+                        "task": task,
                     },
-                    "task": task,
-                })
+                )
             except Exception as e:
                 logger.debug("rules.injected emit failed: %s", e)
 
@@ -1180,19 +1186,24 @@ class Brain(BrainInspectionMixin):
         from gradata._db import get_connection, lessons_lock
         from gradata.enhancements.self_improvement import format_lessons, parse_lessons
 
+        # Open conn only to read the pending row, then close before taking the
+        # file lock. Holding a SQLite connection across a potentially-blocking
+        # file-lock section kept a WAL reader slot idle under contention.
         conn = get_connection(self.db_path)
         conn.row_factory = sqlite3.Row
-        row = conn.execute(
-            "SELECT * FROM pending_approvals WHERE id = ? AND resolution IS NULL", (approval_id,)
-        ).fetchone()
-        if not row:
+        try:
+            row = conn.execute(
+                "SELECT * FROM pending_approvals WHERE id = ? AND resolution IS NULL",
+                (approval_id,),
+            ).fetchone()
+        finally:
             conn.close()
+        if not row:
             return {"resolved": False, "reason": "not_found_or_already_resolved"}
         cat, desc = row["lesson_category"], row["lesson_description"]
 
         lessons_path = self._find_lessons_path()
         if not lessons_path or not lessons_path.is_file():
-            conn.close()
             return {"resolved": False, "reason": "no_lessons_file"}
 
         with lessons_lock(lessons_path):
@@ -1213,17 +1224,19 @@ class Brain(BrainInspectionMixin):
                 write_lessons_safe(lessons_path, format_lessons(lessons))
 
         if not matched:
-            conn.close()
             return {"resolved": False, "reason": "lesson_not_found_in_file"}
 
         from datetime import date
 
-        conn.execute(
-            "UPDATE pending_approvals SET resolution = ?, resolved_at = ? WHERE id = ?",
-            (resolution, date.today().isoformat(), approval_id),
-        )
-        conn.commit()
-        conn.close()
+        conn = get_connection(self.db_path)
+        try:
+            conn.execute(
+                "UPDATE pending_approvals SET resolution = ?, resolved_at = ? WHERE id = ?",
+                (resolution, date.today().isoformat(), approval_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
         return {"resolved": True, "category": cat, "description": desc}
 
     def review_pending(self) -> list[dict]:

--- a/Gradata/src/gradata/brain.py
+++ b/Gradata/src/gradata/brain.py
@@ -35,6 +35,7 @@ per process, or use process-level locks for multi-worker deployments.
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import sys
 from pathlib import Path
@@ -1828,8 +1829,6 @@ class Brain(BrainInspectionMixin):
     def health(self) -> dict:
         """Generate brain health report."""
         try:
-            import dataclasses
-
             from gradata.enhancements.reporting import generate_health_report
 
             return dataclasses.asdict(generate_health_report(self.db_path))

--- a/Gradata/src/gradata/brain.py
+++ b/Gradata/src/gradata/brain.py
@@ -1201,8 +1201,10 @@ class Brain(BrainInspectionMixin):
             return []
         import sqlite3
 
+        from gradata._db import get_connection
+
         try:
-            with sqlite3.connect(str(self.db_path)) as conn:
+            with contextlib.closing(get_connection(self.db_path)) as conn:
                 conn.row_factory = sqlite3.Row
                 if category:
                     rows = conn.execute(

--- a/Gradata/src/gradata/brain.py
+++ b/Gradata/src/gradata/brain.py
@@ -422,8 +422,8 @@ class Brain(BrainInspectionMixin):
             # be defensive in case the schema changes.
             if not dry_run and result and result.get("graduated"):
                 _telemetry.send_once("first_graduation")
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("telemetry send_once failed: %s", e)
 
         return result
 
@@ -1244,16 +1244,17 @@ class Brain(BrainInspectionMixin):
         if not self.db_path.is_file():
             return []
         try:
+            import contextlib
             import sqlite3
 
             from gradata._db import get_connection
 
-            conn = get_connection(self.db_path)
-            conn.row_factory = sqlite3.Row
-            rows = conn.execute(
-                "SELECT * FROM pending_approvals WHERE resolution IS NULL ORDER BY created_at DESC"
-            ).fetchall()
-            conn.close()
+            with contextlib.closing(get_connection(self.db_path)) as conn:
+                conn.row_factory = sqlite3.Row
+                rows = conn.execute(
+                    "SELECT * FROM pending_approvals "
+                    "WHERE resolution IS NULL ORDER BY created_at DESC"
+                ).fetchall()
             return [dict(r) for r in rows]
         except Exception as e:
             logger.debug("review_pending query failed: %s", e)

--- a/Gradata/src/gradata/brain.py
+++ b/Gradata/src/gradata/brain.py
@@ -1276,11 +1276,20 @@ class Brain(BrainInspectionMixin):
         from datetime import date
 
         with contextlib.closing(get_connection(self.db_path)) as conn:
-            conn.execute(
-                "UPDATE pending_approvals SET resolution = ?, resolved_at = ? WHERE id = ?",
+            # Re-check resolution IS NULL to prevent lost-race overwrites when
+            # two workers resolve the same approval concurrently. rowcount == 0
+            # means another worker won the race.
+            cur = conn.execute(
+                "UPDATE pending_approvals SET resolution = ?, resolved_at = ? "
+                "WHERE id = ? AND resolution IS NULL",
                 (resolution, date.today().isoformat(), approval_id),
             )
             conn.commit()
+            if cur.rowcount == 0:
+                return {
+                    "resolved": False,
+                    "reason": "already_resolved_by_other_worker",
+                }
         return {"resolved": True, "category": cat, "description": desc}
 
     def review_pending(self) -> list[dict]:

--- a/Gradata/src/gradata/brain.py
+++ b/Gradata/src/gradata/brain.py
@@ -1561,24 +1561,31 @@ class Brain(BrainInspectionMixin):
             if not db or not db.exists():
                 return []
             results, terms = [], query.lower().split()
+            if not terms:
+                return []
+            # Push term filter into SQL so we don't scan 500 rows + filter
+            # Python-side. Each term becomes a `data_json LIKE ?` — lowercase
+            # both sides so the filter matches regardless of stored case.
+            where = " AND ".join(["LOWER(data_json) LIKE ?"] * len(terms))
+            params: list = [f"%{t}%" for t in terms]
+            params.append(top_k)
             with sqlite3.connect(str(db)) as conn:
                 rows = conn.execute(
-                    "SELECT id, ts, type, source, data_json FROM events ORDER BY id DESC LIMIT 500"
+                    f"SELECT id, ts, type, source, data_json FROM events "
+                    f"WHERE {where} ORDER BY id DESC LIMIT ?",
+                    params,
                 ).fetchall()
             for row_id, ts, etype, _, data_json in rows:
-                if any(t in (data_json or "").lower() for t in terms):
-                    results.append(
-                        {
-                            "source": f"event:{etype}:{row_id}",
-                            "file_type": "event",
-                            "text": (data_json or "")[:500],
-                            "score": 1.0,
-                            "confidence": "keyword_match",
-                            "modified": ts,
-                        }
-                    )
-                if len(results) >= top_k:
-                    break
+                results.append(
+                    {
+                        "source": f"event:{etype}:{row_id}",
+                        "file_type": "event",
+                        "text": (data_json or "")[:500],
+                        "score": 1.0,
+                        "confidence": "keyword_match",
+                        "modified": ts,
+                    }
+                )
             return results
 
     def embed(self, full: bool = False) -> int:
@@ -1946,8 +1953,3 @@ class Brain(BrainInspectionMixin):
             "results": results,
             "failures": failed,
         }
-
-
-# Re-export Pipeline type
-with contextlib.suppress(ImportError):
-    pass

--- a/Gradata/src/gradata/cloud/client.py
+++ b/Gradata/src/gradata/cloud/client.py
@@ -168,6 +168,11 @@ class CloudClient:
         if manifest_path.exists():
             try:
                 return json.loads(manifest_path.read_text(encoding="utf-8"))
-            except Exception:
+            except Exception as exc:
+                logger.warning(
+                    "Failed to parse %s: %s — sending empty manifest to cloud",
+                    manifest_path,
+                    exc,
+                )
                 return {}
         return {}

--- a/Gradata/src/gradata/cloud/sync.py
+++ b/Gradata/src/gradata/cloud/sync.py
@@ -33,6 +33,23 @@ _DEFAULT_API_BASE = os.environ.get("GRADATA_CLOUD_API_BASE", "https://api.gradat
 _CONFIG_FILE_NAME = "cloud-config.json"
 
 
+def _normalize_api_base(api_base: str) -> str:
+    """Upgrade legacy bases missing ``/api/v1`` to the versioned path.
+
+    Earlier releases wrote ``https://api.gradata.ai`` (no version segment)
+    to cloud-config.json. Request paths were rewritten to include
+    ``/api/v1`` in the base, so legacy configs would POST to unversioned
+    endpoints and silently break. Detect the gradata.ai host without a
+    path suffix and append ``/api/v1`` so legacy clients self-heal.
+    """
+    if not api_base:
+        return api_base
+    stripped = api_base.rstrip("/")
+    if stripped in ("https://api.gradata.ai", "http://api.gradata.ai"):
+        return stripped + "/api/v1"
+    return api_base
+
+
 @dataclass
 class CloudConfig:
     """Per-brain cloud sync configuration, persisted to brain_dir/cloud-config.json."""
@@ -58,7 +75,7 @@ def load_config(brain_dir: Path) -> CloudConfig:
         return CloudConfig(
             sync_enabled=bool(data.get("sync_enabled", False)),
             token=str(data.get("token", "")),
-            api_base=str(data.get("api_base", _DEFAULT_API_BASE)),
+            api_base=_normalize_api_base(str(data.get("api_base", _DEFAULT_API_BASE))),
             contribute_corpus=bool(data.get("contribute_corpus", False)),
             last_sync_at=str(data.get("last_sync_at", "")),
         )

--- a/Gradata/src/gradata/cloud/sync.py
+++ b/Gradata/src/gradata/cloud/sync.py
@@ -1,6 +1,6 @@
 """Cloud sync client — opt-in telemetry of metrics to Gradata Cloud dashboard.
 
-Wire protocol: POST https://api.gradata.ai/v1/telemetry/metrics
+Wire protocol: POST https://api.gradata.ai/api/v1/telemetry/metrics
 Auth: Bearer <GRADATA_API_TOKEN>
 Payload: aggregated metrics (NOT correction content)
 
@@ -13,6 +13,7 @@ Privacy model:
   - Separate opt-in for corpus contribution (anonymized corrections for
     cross-user meta-rule synthesis). See `CloudClient.contribute_corpus()`.
 """
+
 from __future__ import annotations
 
 import json
@@ -28,7 +29,7 @@ from gradata._http import require_https
 
 log = logging.getLogger(__name__)
 
-_DEFAULT_API_BASE = os.environ.get("GRADATA_CLOUD_API_BASE", "https://api.gradata.ai")
+_DEFAULT_API_BASE = os.environ.get("GRADATA_CLOUD_API_BASE", "https://api.gradata.ai/api/v1")
 _CONFIG_FILE_NAME = "cloud-config.json"
 
 
@@ -151,7 +152,7 @@ class CloudClient:
         """
         if not self.enabled:
             return False
-        result = self._post("/v1/telemetry/metrics", asdict(payload))
+        result = self._post("/telemetry/metrics", asdict(payload))
         if result is not None:
             self.config.last_sync_at = payload.sent_at
             save_config(self.brain_dir, self.config)
@@ -167,7 +168,7 @@ class CloudClient:
         """
         if not self.enabled or not self.config.contribute_corpus:
             return False
-        result = self._post("/v1/corpus/contribute", {"patterns": anonymized_patterns})
+        result = self._post("/corpus/contribute", {"patterns": anonymized_patterns})
         return result is not None
 
 

--- a/Gradata/src/gradata/contrib/enhancements/quality_gates.py
+++ b/Gradata/src/gradata/contrib/enhancements/quality_gates.py
@@ -52,9 +52,7 @@ class QualityRubric:
         if self.weight <= 0:
             raise ValueError(f"QualityRubric '{self.name}': weight must be > 0")
         if not (0.0 <= self.threshold <= 10.0):
-            raise ValueError(
-                f"QualityRubric '{self.name}': threshold must be in [0, 10]"
-            )
+            raise ValueError(f"QualityRubric '{self.name}': threshold must be in [0, 10]")
 
 
 @dataclass
@@ -250,16 +248,10 @@ class QualityGate:
             raw = scorer(output, rubric)
             dimension_scores[rubric.name] = round(min(10.0, max(0.0, float(raw))), 2)
 
-        overall = sum(
-            dimension_scores[r.name] * r.weight for r in self.rubrics
-        ) / total_weight
+        overall = sum(dimension_scores[r.name] * r.weight for r in self.rubrics) / total_weight
         overall = round(overall, 2)
 
-        failures = [
-            r.name
-            for r in self.rubrics
-            if dimension_scores[r.name] < r.threshold
-        ]
+        failures = [r.name for r in self.rubrics if dimension_scores[r.name] < r.threshold]
 
         passed = overall >= self.threshold and len(failures) == 0
 
@@ -325,6 +317,7 @@ class QualityGate:
 @dataclass
 class SuccessCondition:
     """A single success condition evaluation."""
+
     name: str
     met: bool = False
     value: float = 0.0
@@ -335,13 +328,16 @@ class SuccessCondition:
 @dataclass
 class SuccessConditionsReport:
     """Result of evaluating all 6 success conditions."""
+
     all_met: bool = False
     conditions: list[SuccessCondition] = field(default_factory=list)
     window_size: int = 20
     sessions_evaluated: int = 0
 
 
-def evaluate_success_conditions(db_path=None, window: int = 20, ctx=None) -> SuccessConditionsReport:
+def evaluate_success_conditions(
+    db_path=None, window: int = 20, ctx=None
+) -> SuccessConditionsReport:
     """Evaluate the 6 SPEC success conditions over a session window."""
     report = SuccessConditionsReport(window_size=window)
     conditions = [
@@ -353,16 +349,24 @@ def evaluate_success_conditions(db_path=None, window: int = 20, ctx=None) -> Suc
         SuccessCondition(name="not_bland", detail="Requires blandness < 0.70"),
     ]
     try:
+        import contextlib
         import sqlite3
         from pathlib import Path as _Path
+
         db = _Path(db_path) if db_path else (_Path(ctx.brain_dir) / "system.db" if ctx else None)
         if db and db.exists():
-            conn = sqlite3.connect(str(db))
-            max_session = conn.execute("SELECT MAX(session) FROM events WHERE typeof(session)='integer'").fetchone()[0] or 0
-            report.sessions_evaluated = max_session
-            conn.close()
-    except Exception:
-        pass
+            with contextlib.closing(sqlite3.connect(str(db))) as conn:
+                max_session = (
+                    conn.execute(
+                        "SELECT MAX(session) FROM events WHERE typeof(session)='integer'"
+                    ).fetchone()[0]
+                    or 0
+                )
+                report.sessions_evaluated = max_session
+    except Exception as exc:
+        import logging
+
+        logging.getLogger(__name__).debug("success report db read failed: %s", exc)
     report.conditions = conditions
     report.all_met = all(c.met for c in conditions)
     return report

--- a/Gradata/src/gradata/contrib/patterns/guardrails.py
+++ b/Gradata/src/gradata/contrib/patterns/guardrails.py
@@ -48,9 +48,9 @@ class GuardCheck:
     """
 
     name: str
-    result: str          # "pass" | "fail" | "override"
+    result: str  # "pass" | "fail" | "override"
     details: str
-    action_taken: str    # "blocked" | "redacted" | "passed" | "user_override"
+    action_taken: str  # "blocked" | "redacted" | "passed" | "user_override"
 
 
 @dataclass
@@ -200,9 +200,7 @@ def guarded(
 
         failing_input = [c for c in input_checks if c.result == "fail"]
         if failing_input:
-            block_reason = "; ".join(
-                f"{c.name}: {c.details}" for c in failing_input
-            )
+            block_reason = "; ".join(f"{c.name}: {c.details}" for c in failing_input)
             return GuardedResult(
                 input_checks=input_checks,
                 output_checks=[],
@@ -242,12 +240,8 @@ def guarded(
 # ---------------------------------------------------------------------------
 
 # Input patterns
-_RE_EMAIL = re.compile(
-    r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b"
-)
-_RE_PHONE = re.compile(
-    r"(?:\+\d[\s\-.]?)?(?:\(\d{3}\)|\d{3})[\s\-.]?\d{3}[\s\-.]?\d{4}\b"
-)
+_RE_EMAIL = re.compile(r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b")
+_RE_PHONE = re.compile(r"(?:\+\d[\s\-.]?)?(?:\(\d{3}\)|\d{3})[\s\-.]?\d{3}[\s\-.]?\d{4}\b")
 _RE_SSN = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
 _RE_API_KEY = re.compile(r"\b(?:sk-|key-)[A-Za-z0-9_\-]{8,}\b")
 
@@ -269,7 +263,6 @@ _RE_DESTRUCTIVE = re.compile(
 # Domain-specific brains can override this via configure_scope_guard().
 # Layer 0 patterns MUST NOT hardcode domain-specific competitor names.
 _RE_OUT_OF_SCOPE: re.Pattern | None = None
-
 
 
 # ---------------------------------------------------------------------------
@@ -329,7 +322,12 @@ def _check_injection(data: Any) -> GuardCheck:
 def _check_scope(data: Any) -> GuardCheck:
     """Validate that the request is in-scope (configurable, disabled by default)."""
     if _RE_OUT_OF_SCOPE is None:
-        return GuardCheck(name="scope_validator", result="pass", details="scope guard disabled", action_taken="passed")
+        return GuardCheck(
+            name="scope_validator",
+            result="pass",
+            details="scope guard disabled",
+            action_taken="passed",
+        )
     text = str(data)
     match = _RE_OUT_OF_SCOPE.search(text)
     if match:
@@ -455,7 +453,7 @@ def check_write_path(
         target = target[2:]
 
     # 1. Global deny list
-    for pattern in (global_deny or []):
+    for pattern in global_deny or []:
         if fnmatch(target, pattern) or fnmatch(target.split("/")[-1], pattern):
             return ManifestCheckResult(False, f"DENIED by global policy: matches '{pattern}'")
 
@@ -465,7 +463,7 @@ def check_write_path(
             return ManifestCheckResult(True, f"ALLOWED: matches agent write path '{pattern}'")
 
     # 3. Check tools_denied for write restrictions
-    for denial in (agent_tools_denied or []):
+    for denial in agent_tools_denied or []:
         if denial.startswith("Write "):
             deny_pattern = denial[6:]
             if fnmatch(target, deny_pattern):
@@ -493,7 +491,9 @@ def check_exec_command(
     cmd_lower = command.lower().strip()
     for pattern in deny_patterns:
         if pattern.lower() in cmd_lower:
-            return ManifestCheckResult(False, f"DENIED: command matches blocked pattern '{pattern}'")
+            return ManifestCheckResult(
+                False, f"DENIED: command matches blocked pattern '{pattern}'"
+            )
     return ManifestCheckResult(True, "ALLOWED: no deny patterns matched")
 
 
@@ -553,7 +553,9 @@ def validate_agent_spawn(
     if available >= max_tokens:
         return ManifestCheckResult(True, f"ALLOWED: budget {max_tokens} tokens", max_tokens)
 
-    usage_pct = int((max_tokens / parent_budget_remaining) * 100) if parent_budget_remaining > 0 else 100
+    usage_pct = (
+        int((max_tokens / parent_budget_remaining) * 100) if parent_budget_remaining > 0 else 100
+    )
 
     if usage_pct >= child_hard_limit_percent:
         return ManifestCheckResult(
@@ -630,12 +632,11 @@ def guards_from_graduated_rules() -> list[Guard]:
 
     guards = []
     for rule in rules:
-        rule.principle.lower()
 
         def _make_check(rule_text: str, rule_cat: str) -> Callable[[Any], GuardCheck]:
             """Create a check function that scans output for rule violations."""
+
             def check_fn(data: Any) -> GuardCheck:
-                str(data).lower() if data else ""
                 # Simple keyword check — does the output violate the rule?
                 # Rules are phrased as "never X" or "always Y"
                 # This is a heuristic; real guardrails need LLM-backed checks
@@ -645,10 +646,13 @@ def guards_from_graduated_rules() -> list[Guard]:
                     details=f"Rule: {rule_text[:80]}",
                     action_taken="passed",
                 )
+
             return check_fn
 
-        guards.append(Guard(
-            name=f"rule_{rule.category.lower()}_{len(guards)}",
-            check_fn=_make_check(rule.principle, rule.category),
-        ))
+        guards.append(
+            Guard(
+                name=f"rule_{rule.category.lower()}_{len(guards)}",
+                check_fn=_make_check(rule.principle, rule.category),
+            )
+        )
     return guards

--- a/Gradata/src/gradata/contrib/patterns/guardrails.py
+++ b/Gradata/src/gradata/contrib/patterns/guardrails.py
@@ -200,7 +200,11 @@ def guarded(
 
         failing_input = [c for c in input_checks if c.result == "fail"]
         if failing_input:
-            block_reason = "; ".join(f"{c.name}: {c.details}" for c in failing_input)
+            # Docstring contract: block_reason describes the FIRST blocking
+            # failure. Return only the first — joining all fails made callers
+            # see different text than promised.
+            first = failing_input[0]
+            block_reason = f"{first.name}: {first.details}"
             return GuardedResult(
                 input_checks=input_checks,
                 output_checks=[],

--- a/Gradata/src/gradata/contrib/patterns/loop_detection.py
+++ b/Gradata/src/gradata/contrib/patterns/loop_detection.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections import deque
+from collections import Counter, deque
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
@@ -51,9 +51,10 @@ __all__ = [
 
 class LoopAction(Enum):
     """Action to take based on loop detection."""
-    ALLOW = "allow"    # No loop detected, proceed normally
-    WARN = "warn"      # Loop pattern detected, log warning but continue
-    STOP = "stop"      # Hard loop detected, halt execution
+
+    ALLOW = "allow"  # No loop detected, proceed normally
+    WARN = "warn"  # Loop pattern detected, log warning but continue
+    STOP = "stop"  # Hard loop detected, halt execution
 
 
 @dataclass
@@ -66,6 +67,7 @@ class LoopEvent:
         action: The action determined by the detector.
         repeat_count: How many times this exact call has been seen in window.
     """
+
     tool_name: str
     call_hash: str
     action: LoopAction
@@ -81,6 +83,7 @@ class LoopDetectorConfig:
         warn_threshold: Number of identical calls before warning.
         stop_threshold: Number of identical calls before hard stop.
     """
+
     window_size: int = 20
     warn_threshold: int = 3
     stop_threshold: int = 5
@@ -100,6 +103,7 @@ class LoopDetector:
     def __init__(self, config: LoopDetectorConfig | None = None) -> None:
         self.config = config or LoopDetectorConfig()
         self._window: deque[str] = deque(maxlen=self.config.window_size)
+        self._counts: Counter[str] = Counter()
         self._events: list[LoopEvent] = []
 
     def record(
@@ -117,10 +121,16 @@ class LoopDetector:
             LoopAction indicating whether to proceed, warn, or stop.
         """
         call_hash = self._hash_call(tool_name, arguments)
+        # Maintain Counter alongside the deque so repeat detection is O(1)
+        # instead of O(window_size) per record() call.
+        if len(self._window) == self._window.maxlen:
+            evicted = self._window[0]
+            self._counts[evicted] -= 1
+            if self._counts[evicted] <= 0:
+                del self._counts[evicted]
         self._window.append(call_hash)
-
-        # Count occurrences of this hash in the window
-        repeat_count = sum(1 for h in self._window if h == call_hash)
+        self._counts[call_hash] += 1
+        repeat_count = self._counts[call_hash]
 
         # Determine action
         if repeat_count >= self.config.stop_threshold:
@@ -143,6 +153,7 @@ class LoopDetector:
     def reset(self) -> None:
         """Clear the sliding window and event history."""
         self._window.clear()
+        self._counts.clear()
         self._events.clear()
 
     @property
@@ -210,10 +221,7 @@ def _normalize_args(args: dict[str, Any]) -> dict[str, Any]:
         if isinstance(val, dict):
             result[key] = _normalize_args(val)
         elif isinstance(val, (list, tuple)):
-            result[key] = [
-                _normalize_args(v) if isinstance(v, dict) else v
-                for v in val
-            ]
+            result[key] = [_normalize_args(v) if isinstance(v, dict) else v for v in val]
         else:
             result[key] = val
     return result

--- a/Gradata/src/gradata/contrib/patterns/memory.py
+++ b/Gradata/src/gradata/contrib/patterns/memory.py
@@ -11,11 +11,13 @@ from typing import Protocol, runtime_checkable
 # Constants
 # ---------------------------------------------------------------------------
 
-VALID_TYPES: frozenset[str] = frozenset({
-    "episodic",     # What happened (interactions, outcomes)
-    "semantic",     # What is true (facts, knowledge)
-    "procedural",   # How to do things (workflows, patterns)
-})
+VALID_TYPES: frozenset[str] = frozenset(
+    {
+        "episodic",  # What happened (interactions, outcomes)
+        "semantic",  # What is true (facts, knowledge)
+        "procedural",  # How to do things (workflows, patterns)
+    }
+)
 
 
 # ---------------------------------------------------------------------------
@@ -55,8 +57,7 @@ class Memory:
     def __post_init__(self) -> None:
         if self.memory_type not in VALID_TYPES:
             raise ValueError(
-                f"Invalid memory_type {self.memory_type!r}. "
-                f"Must be one of: {sorted(VALID_TYPES)}"
+                f"Invalid memory_type {self.memory_type!r}. Must be one of: {sorted(VALID_TYPES)}"
             )
         if not self.content:
             raise ValueError("Memory content must not be empty.")
@@ -128,6 +129,8 @@ class InMemoryStore:
         allowed = set(types) if types is not None else VALID_TYPES
         now = _now_iso()
 
+        import heapq
+
         matches: list[Memory] = []
         for memory in self._data.values():
             if memory.memory_type not in allowed:
@@ -136,8 +139,11 @@ class InMemoryStore:
                 memory.last_accessed = now
                 matches.append(memory)
 
-        matches.sort(key=lambda m: m.last_accessed, reverse=True)
-        return matches[:limit]
+        # heapq.nlargest beats full sort when limit << len(matches).
+        if limit >= len(matches):
+            matches.sort(key=lambda m: m.last_accessed, reverse=True)
+            return matches
+        return heapq.nlargest(limit, matches, key=lambda m: m.last_accessed)
 
     def update(self, memory_id: str, content: str) -> None:
         """Replace content of an existing memory."""
@@ -217,10 +223,7 @@ class EpisodicMemory:
         for memory in list(self._store.all()):
             if memory.memory_type != self.memory_type:
                 continue
-            if (
-                memory.age_days() > max_age_days
-                and memory.reinforcement_count < min_reinforcements
-            ):
+            if memory.age_days() > max_age_days and memory.reinforcement_count < min_reinforcements:
                 self._store.delete(memory.id)
                 pruned.append(memory.id)
         return pruned
@@ -350,10 +353,7 @@ class ProceduralMemory:
         for memory in list(self._store.all()):
             if memory.memory_type != self.memory_type:
                 continue
-            if (
-                memory.age_days() > max_age_days
-                and memory.reinforcement_count < min_reinforcements
-            ):
+            if memory.age_days() > max_age_days and memory.reinforcement_count < min_reinforcements:
                 self._store.delete(memory.id)
                 pruned.append(memory.id)
         return pruned
@@ -390,10 +390,7 @@ class MemoryManager:
             return self.semantic.store(content, metadata)
         if memory_type == "procedural":
             return self.procedural.store(content, metadata)
-        raise ValueError(
-            f"Unknown memory_type {memory_type!r}. "
-            f"Valid types: {sorted(VALID_TYPES)}"
-        )
+        raise ValueError(f"Unknown memory_type {memory_type!r}. Valid types: {sorted(VALID_TYPES)}")
 
     def retrieve(
         self,
@@ -423,10 +420,7 @@ class MemoryManager:
             )
         pruned: list[str] = []
         for memory in list(self._store.all()):
-            if (
-                memory.age_days() > max_age_days
-                and memory.reinforcement_count < min_reinforcements
-            ):
+            if memory.age_days() > max_age_days and memory.reinforcement_count < min_reinforcements:
                 self._store.delete(memory.id)
                 pruned.append(memory.id)
         return pruned
@@ -452,9 +446,7 @@ class MemoryManager:
             by_type[m.memory_type] = by_type.get(m.memory_type, 0) + 1
 
         avg_reinforcements = (
-            round(sum(m.reinforcement_count for m in all_memories) / total, 2)
-            if total > 0
-            else 0.0
+            round(sum(m.reinforcement_count for m in all_memories) / total, 2) if total > 0 else 0.0
         )
 
         created_timestamps = [m.created for m in all_memories]
@@ -502,7 +494,6 @@ _SCOPE_PATH_RULES: list[tuple[str, str]] = [
     (r"^competitors/", "project"),
     (r"^icp-research", "project"),
     (r"^learnings/", "project"),
-
     # USER scope (personal, never shared)
     (r"^metrics/", "user"),
     (r"^loop-state\.md$", "user"),
@@ -510,7 +501,6 @@ _SCOPE_PATH_RULES: list[tuple[str, str]] = [
     (r"^self-model\.md$", "user"),
     (r"^audits/", "user"),
     (r"^evals/", "user"),
-
     # LOCAL scope (deployment-specific)
     (r"^prospects/", "local"),
     (r"^pipeline/", "local"),

--- a/Gradata/src/gradata/contrib/patterns/orchestrator.py
+++ b/Gradata/src/gradata/contrib/patterns/orchestrator.py
@@ -100,6 +100,7 @@ ALL_PATTERNS: frozenset[str] = frozenset(
 # Intent-to-pattern mapping
 # ---------------------------------------------------------------------------
 
+
 @dataclass(frozen=True)
 class IntentPattern:
     """Maps a named intent to its primary pattern and optional secondaries.
@@ -159,7 +160,6 @@ DEFAULT_INTENT_PATTERNS: list[IntentPattern] = [
         primary=PATTERN_PLANNING,
         secondary=[PATTERN_CHAIN_OF_THOUGHT, PATTERN_ORCHESTRATION],
     ),
-
     # ── Engineering / developer ──────────────────────────────────────────────
     IntentPattern(
         intent="code_review",
@@ -181,7 +181,6 @@ DEFAULT_INTENT_PATTERNS: list[IntentPattern] = [
         primary=PATTERN_TRANSFORMATION,
         secondary=[PATTERN_REFLECTION, PATTERN_VALIDATION],
     ),
-
     # ── Recruiting / talent ──────────────────────────────────────────────────
     IntentPattern(
         intent="interview_prep",
@@ -198,7 +197,6 @@ DEFAULT_INTENT_PATTERNS: list[IntentPattern] = [
         primary=PATTERN_GENERATION,
         secondary=[PATTERN_REFLECTION, PATTERN_VALIDATION],
     ),
-
     # ── Sales (preserved for backward compatibility) ─────────────────────────
     IntentPattern(
         intent="email_draft",
@@ -245,6 +243,10 @@ _DEFAULT_FALLBACK = IntentPattern(
 # ---------------------------------------------------------------------------
 
 _REGISTERED_INTENT_PATTERNS: list[IntentPattern] = list(DEFAULT_INTENT_PATTERNS)
+# O(1) lookup mirror of _REGISTERED_INTENT_PATTERNS; rebuilt on registration.
+_REGISTERED_INTENT_INDEX: dict[str, IntentPattern] = {
+    p.intent: p for p in _REGISTERED_INTENT_PATTERNS
+}
 
 
 def register_intent_pattern(
@@ -288,21 +290,15 @@ def register_intent_pattern(
         )
     """
     if pattern not in ALL_PATTERNS:
-        raise ValueError(
-            f"Unknown pattern {pattern!r}.  "
-            f"Must be one of: {sorted(ALL_PATTERNS)}"
-        )
+        raise ValueError(f"Unknown pattern {pattern!r}.  Must be one of: {sorted(ALL_PATTERNS)}")
     bad = [s for s in (secondary or []) if s not in ALL_PATTERNS]
     if bad:
         raise ValueError(
-            f"Unknown secondary pattern(s) {bad!r}.  "
-            f"Must be one of: {sorted(ALL_PATTERNS)}"
+            f"Unknown secondary pattern(s) {bad!r}.  Must be one of: {sorted(ALL_PATTERNS)}"
         )
 
     global _REGISTERED_INTENT_PATTERNS
-    _REGISTERED_INTENT_PATTERNS = [
-        p for p in _REGISTERED_INTENT_PATTERNS if p.intent != intent
-    ]
+    _REGISTERED_INTENT_PATTERNS = [p for p in _REGISTERED_INTENT_PATTERNS if p.intent != intent]
 
     entry = IntentPattern(
         intent=intent,
@@ -314,10 +310,14 @@ def register_intent_pattern(
     else:
         _REGISTERED_INTENT_PATTERNS.append(entry)
 
+    # Keep the dict index in sync for O(1) classify_request lookup.
+    _REGISTERED_INTENT_INDEX[entry.intent] = entry
+
 
 # ---------------------------------------------------------------------------
 # Classification result
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class RequestClassification:
@@ -346,6 +346,7 @@ class RequestClassification:
 # Public API
 # ---------------------------------------------------------------------------
 
+
 def classify_request(query: str) -> RequestClassification:
     """Classify a raw query and return the full routing decision.
 
@@ -370,15 +371,8 @@ def classify_request(query: str) -> RequestClassification:
     """
     intent_name, audience = classify_scope(query)
 
-    # Look up the registered mapping for this intent.
-    matched: IntentPattern | None = None
-    for entry in _REGISTERED_INTENT_PATTERNS:
-        if entry.intent == intent_name:
-            matched = entry
-            break
-
-    if matched is None:
-        matched = _DEFAULT_FALLBACK
+    # O(1) dict lookup (was an O(N) linear scan of _REGISTERED_INTENT_PATTERNS).
+    matched = _REGISTERED_INTENT_INDEX.get(intent_name, _DEFAULT_FALLBACK)
 
     # Confidence is 1.0 when we matched a specific intent, 0.5 for the
     # fallback.  The audience detection does not yet adjust this score.
@@ -400,6 +394,7 @@ def classify_request(query: str) -> RequestClassification:
 # This is a simpler, domain-agnostic routing mechanism that maps keyword
 # lists to agent names.  Domains register their own rules at startup;
 # ``route_by_keywords`` then matches an incoming task description.
+
 
 @dataclass
 class RouteRule:
@@ -514,9 +509,15 @@ def execute_orchestrated(
     if len(tasks) == 1:
         try:
             result = worker(tasks[0])  # type: ignore[operator]
-            return {"strategy": "direct", "results": [{"task": tasks[0], "status": "completed", "result": result}]}
+            return {
+                "strategy": "direct",
+                "results": [{"task": tasks[0], "status": "completed", "result": result}],
+            }
         except Exception as e:
-            return {"strategy": "direct", "results": [{"task": tasks[0], "status": "failed", "error": str(e)}]}
+            return {
+                "strategy": "direct",
+                "results": [{"task": tasks[0], "status": "failed", "error": str(e)}],
+            }
 
     # Multiple tasks — classify to check if they're independent
     classifications = [classify_request(t) for t in tasks]

--- a/Gradata/src/gradata/contrib/patterns/parallel.py
+++ b/Gradata/src/gradata/contrib/patterns/parallel.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import time
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -170,8 +170,7 @@ def _topological_waves(tasks: list[ParallelTask]) -> list[list[str]]:
         for dep_id in task.depends_on:
             if dep_id not in task_map:
                 raise ValueError(
-                    f"Task '{task.id}' declares dependency on unknown "
-                    f"task '{dep_id}'."
+                    f"Task '{task.id}' declares dependency on unknown task '{dep_id}'."
                 )
             in_degree[task.id] += 1
             dependents[dep_id].append(task.id)
@@ -193,9 +192,7 @@ def _topological_waves(tasks: list[ParallelTask]) -> list[list[str]]:
     scheduled = sum(len(w) for w in waves)
     if scheduled != len(tasks):
         unscheduled = [tid for tid in in_degree if in_degree[tid] > 0]
-        raise ValueError(
-            f"Dependency cycle detected. Tasks involved: {unscheduled}"
-        )
+        raise ValueError(f"Dependency cycle detected. Tasks involved: {unscheduled}")
 
     return waves
 
@@ -304,37 +301,34 @@ class DependencyGraph:
 
                 # Check whether any dependency failed; skip if so.
                 failed_deps = [
-                    dep for dep in task.depends_on
-                    if dep in results and not results[dep].success
+                    dep for dep in task.depends_on if dep in results and not results[dep].success
                 ]
                 if failed_deps:
                     results[tid] = TaskResult(
                         task_id=tid,
                         success=False,
                         output=None,
-                        error=(
-                            f"Skipped: upstream dependencies failed: "
-                            f"{failed_deps}"
-                        ),
+                        error=(f"Skipped: upstream dependencies failed: {failed_deps}"),
                     )
                     continue
 
-                # Forward upstream outputs into input_data.
+                # Forward upstream outputs into input_data. Use dataclasses.replace
+                # to avoid mutating the caller's ParallelTask — a second run of the
+                # same graph would otherwise see stale inputs from the prior run.
                 if task.depends_on:
-                    upstream_outputs = {
-                        dep: results[dep].output for dep in task.depends_on
-                    }
+                    upstream_outputs = {dep: results[dep].output for dep in task.depends_on}
                     if len(upstream_outputs) == 1:
                         # Single parent: pass the value directly for ergonomics.
-                        task.input_data = next(iter(upstream_outputs.values()))
+                        resolved_input = next(iter(upstream_outputs.values()))
                     else:
-                        task.input_data = upstream_outputs
+                        resolved_input = upstream_outputs
+                    task_to_run = replace(task, input_data=resolved_input)
+                else:
+                    task_to_run = task
 
-                results[tid] = _run_task(task)
+                results[tid] = _run_task(task_to_run)
 
-        total_duration_ms = round(
-            (time.monotonic() - graph_start) * 1000.0, 2
-        )
+        total_duration_ms = round((time.monotonic() - graph_start) * 1000.0, 2)
         all_succeeded = all(r.success for r in results.values())
 
         return ParallelResult(
@@ -388,8 +382,7 @@ def merge_results(
     valid_strategies = {"combine", "best_of", "synthesize"}
     if strategy not in valid_strategies:
         raise ValueError(
-            f"Unknown merge strategy '{strategy}'. "
-            f"Choose from: {sorted(valid_strategies)}"
+            f"Unknown merge strategy '{strategy}'. Choose from: {sorted(valid_strategies)}"
         )
 
     successful = [r for r in results if r.success]

--- a/Gradata/src/gradata/contrib/patterns/q_learning_router.py
+++ b/Gradata/src/gradata/contrib/patterns/q_learning_router.py
@@ -31,8 +31,12 @@ Usage::
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
+import logging
+import platform
 import random
+import time
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -63,10 +67,19 @@ class RouterConfig:
         feature_dim: Dimensionality of feature vectors.
         save_interval: Auto-save after this many updates.
     """
-    agents: list[str] = field(default_factory=lambda: [
-        "coder", "reviewer", "architect", "researcher",
-        "debugger", "writer", "optimizer", "tester",
-    ])
+
+    agents: list[str] = field(
+        default_factory=lambda: [
+            "coder",
+            "reviewer",
+            "architect",
+            "researcher",
+            "debugger",
+            "writer",
+            "optimizer",
+            "tester",
+        ]
+    )
     learning_rate: float = 0.1
     discount_factor: float = 0.95
     epsilon_start: float = 1.0
@@ -90,6 +103,7 @@ class RouteDecision:
         confidence: Confidence in the decision (max Q / sum Q).
         exploiting: True if decision was greedy, False if exploring.
     """
+
     agent: str
     state_hash: str = ""
     q_values: dict[str, float] = field(default_factory=dict)
@@ -107,6 +121,7 @@ class Experience:
         reward: Reward received.
         td_error: Temporal difference error magnitude (for prioritized replay).
     """
+
     state_hash: str
     action_idx: int
     reward: float
@@ -157,7 +172,7 @@ def _extract_features(text: str, dim: int = 32) -> list[float]:
     # N-gram hash features (remaining dimensions)
     for n in range(1, 4):  # unigrams, bigrams, trigrams
         for j in range(len(words) - n + 1):
-            ngram = " ".join(words[j:j + n])
+            ngram = " ".join(words[j : j + n])
             h = int(hashlib.md5(ngram.encode()).hexdigest(), 16)
             idx = 8 + (h % max(1, dim - 8))
             if idx < dim:
@@ -187,6 +202,7 @@ def _hash_state(features: list[float], quantize_bits: int = 4) -> str:
 # Q-Learning Router
 # ---------------------------------------------------------------------------
 
+
 class QLearningRouter:
     """Q-Learning based agent router with experience replay.
 
@@ -207,6 +223,8 @@ class QLearningRouter:
         self.q_table: dict[str, list[float]] = {}
         self.epsilon = self.config.epsilon_start
         self.update_count = 0
+        # O(1) agent->index lookup used by reward updates (avoids linear list.index()).
+        self._agent_index: dict[str, int] = {a: i for i, a in enumerate(self.config.agents)}
 
         # LRU cache: state_hash -> (agent, timestamp)
         self._cache: OrderedDict[str, tuple[str, float]] = OrderedDict()
@@ -236,8 +254,6 @@ class QLearningRouter:
         Returns:
             A RouteDecision with the selected agent and metadata.
         """
-        import time
-
         features = _extract_features(task_description, self.config.feature_dim)
         state_hash = _hash_state(features)
 
@@ -308,7 +324,7 @@ class QLearningRouter:
         """
         reward = max(0.0, min(1.0, reward))
         state_hash = decision.state_hash
-        action_idx = self.config.agents.index(decision.agent)
+        action_idx = self._agent_index[decision.agent]
 
         q_values = self._get_q_values(state_hash)
         old_q = q_values[action_idx]
@@ -369,13 +385,12 @@ class QLearningRouter:
 
     @staticmethod
     def _compute_hmac(data_bytes: bytes) -> str:
-        """Compute HMAC-SHA256 for integrity verification."""
-        import hmac as _hmac
+        """Compute HMAC-SHA256 for integrity verification.
 
-        # Key derived from machine identity (not secret, just tamper detection)
-        import platform
+        Key is derived from machine identity (not secret, just tamper detection).
+        """
         key = f"gradata-router-{platform.node()}".encode()
-        return _hmac.new(key, data_bytes, "sha256").hexdigest()
+        return hmac.new(key, data_bytes, "sha256").hexdigest()
 
     def save(self, filepath: str | Path) -> None:
         """Save router state to JSON file with HMAC integrity check.
@@ -426,7 +441,6 @@ class QLearningRouter:
             body = json.dumps(state, sort_keys=True, separators=(",", ":")).encode()
             expected = self._compute_hmac(body)
             if stored_hmac != expected:
-                import logging
                 logging.getLogger(__name__).warning(
                     "Q-table integrity check failed: %s may be tampered", filepath
                 )
@@ -485,9 +499,7 @@ class QLearningRouter:
         """Get or initialize Q-values for a state."""
         if state_hash not in self.q_table:
             # Initialize with small random values to break ties
-            self.q_table[state_hash] = [
-                random.uniform(0.0, 0.01) for _ in self.config.agents
-            ]
+            self.q_table[state_hash] = [random.uniform(0.0, 0.01) for _ in self.config.agents]
         return self.q_table[state_hash]
 
     def _compute_confidence(self, q_values: list[float]) -> float:

--- a/Gradata/src/gradata/contrib/patterns/rag.py
+++ b/Gradata/src/gradata/contrib/patterns/rag.py
@@ -424,7 +424,11 @@ def cascade_retrieve(
                     graduated = apply_graduation_scoring(merged, cfg)
                     return RetrievalResult(
                         chunks=graduated[:limit],
-                        query=expanded_query,
+                        # Preserve the original user query. Exposing
+                        # `expanded_query` leaked mined corpus terms into
+                        # downstream telemetry/logging that assume this
+                        # field is user input.
+                        query=query,
                         mode=f"two_pass (expanded: +{len(expansion_terms)} terms)",
                         total_candidates=total + pass2_total,
                     )

--- a/Gradata/src/gradata/contrib/patterns/rag.py
+++ b/Gradata/src/gradata/contrib/patterns/rag.py
@@ -15,8 +15,12 @@ backends are in _query.py and _embed.py (the existing modules).
 
 from __future__ import annotations
 
+import logging
+import zlib
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -121,7 +125,10 @@ def rrf_merge(
 
     for result_list in result_lists:
         for rank, chunk in enumerate(result_list):
-            cid = chunk.chunk_id or f"{chunk.source}:{hash(chunk.content) % 10000}"
+            cid = (
+                chunk.chunk_id
+                or f"{chunk.source}:{zlib.crc32(chunk.content.encode('utf-8')) & 0x7FFFFFFF}"
+            )
             scores[cid] = scores.get(cid, 0.0) + 1.0 / (k + rank + 1)
             if cid not in chunks_by_id:
                 chunks_by_id[cid] = chunk
@@ -401,15 +408,15 @@ def cascade_retrieve(
                         fts2 = fts_fn(expanded_query, limit * 2)
                         pass2_results.append(fts2)
                         pass2_total += len(fts2)
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        logger.debug("two-pass fts expansion failed: %s", exc)
                 if vector_fn is not None:
                     try:
                         vec2 = vector_fn(expanded_query, limit * 2)
                         pass2_results.append(vec2)
                         pass2_total += len(vec2)
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        logger.debug("two-pass vector expansion failed: %s", exc)
 
                 if pass2_results:
                     all_combined = all_results + pass2_results
@@ -462,15 +469,14 @@ def order_by_relevance_position(chunks: list[Chunk]) -> list[Chunk]:
         return chunks
 
     sorted_chunks = sorted(chunks, key=lambda c: -c.relevance_score)
-    result: list[Chunk] = []
-    left = True
-    for chunk in sorted_chunks:
-        if left:
-            result.insert(0, chunk)
-        else:
-            result.append(chunk)
-        left = not left
-    return result
+    # Split alternating items into head/tail without O(N) list.insert(0, ...)
+    # which was O(N^2) total. Reversing the head at the end restores order.
+    head: list[Chunk] = []
+    tail: list[Chunk] = []
+    for i, chunk in enumerate(sorted_chunks):
+        (head if i % 2 == 0 else tail).append(chunk)
+    head.reverse()
+    return head + tail
 
 
 # ---------------------------------------------------------------------------
@@ -524,5 +530,6 @@ class NaiveRAG:
             return RetrievalResult(
                 chunks=results, query=query, mode="naive", total_candidates=len(results)
             )
-        except Exception:
+        except Exception as exc:
+            logger.debug("NaiveRAG.retrieve fts_fn failed: %s", exc)
             return RetrievalResult(chunks=[], query=query, mode="naive", total_candidates=0)

--- a/Gradata/src/gradata/contrib/patterns/rag.py
+++ b/Gradata/src/gradata/contrib/patterns/rag.py
@@ -26,12 +26,13 @@ if TYPE_CHECKING:
 # Data types
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class Chunk:
     """A retrieved chunk of brain content."""
 
     content: str
-    source: str           # file/doc name
+    source: str  # file/doc name
     chunk_id: str = ""
     relevance_score: float = 0.0
     recency_weight: float = 1.0
@@ -45,7 +46,7 @@ class RetrievalResult:
 
     chunks: list[Chunk]
     query: str
-    mode: str              # "fts", "vector", "hybrid", "cascade"
+    mode: str  # "fts", "vector", "hybrid", "cascade"
     total_candidates: int = 0
     citations: dict[str, str] = field(default_factory=dict)  # claim -> source
 
@@ -54,23 +55,26 @@ class RetrievalResult:
 class CascadeConfig:
     """Configuration for the retrieval cascade."""
 
-    fts_threshold: float = 0.3      # min FTS score to stop cascade
-    vector_threshold: float = 0.5   # min vector score to stop cascade
-    hybrid_rrf_k: int = 60          # RRF constant
+    fts_threshold: float = 0.3  # min FTS score to stop cascade
+    vector_threshold: float = 0.5  # min vector score to stop cascade
+    hybrid_rrf_k: int = 60  # RRF constant
     max_results: int = 10
-    two_pass: bool = False          # Enable two-pass query expansion
-    two_pass_top_k: int = 3         # How many results to mine for expansion terms
-    graduation_boost: dict[str, float] = field(default_factory=lambda: {
-        "RULE": 1.2,
-        "PATTERN": 1.0,
-        "INSTINCT": 0.8,
-        "UNTESTABLE": 0.5,
-    })
+    two_pass: bool = False  # Enable two-pass query expansion
+    two_pass_top_k: int = 3  # How many results to mine for expansion terms
+    graduation_boost: dict[str, float] = field(
+        default_factory=lambda: {
+            "RULE": 1.2,
+            "PATTERN": 1.0,
+            "INSTINCT": 0.8,
+            "UNTESTABLE": 0.5,
+        }
+    )
 
 
 # ---------------------------------------------------------------------------
 # Graduation-aware scoring
 # ---------------------------------------------------------------------------
+
 
 def apply_graduation_scoring(
     chunks: list[Chunk],
@@ -102,6 +106,7 @@ def apply_graduation_scoring(
 # Reciprocal Rank Fusion (RRF)
 # ---------------------------------------------------------------------------
 
+
 def rrf_merge(
     *result_lists: list[Chunk],
     k: int = 60,
@@ -125,15 +130,17 @@ def rrf_merge(
     merged: list[Chunk] = []
     for cid, score in sorted(scores.items(), key=lambda x: -x[1]):
         chunk = chunks_by_id[cid]
-        merged.append(Chunk(
-            content=chunk.content,
-            source=chunk.source,
-            chunk_id=cid,
-            relevance_score=round(score, 6),
-            recency_weight=chunk.recency_weight,
-            memory_type=chunk.memory_type,
-            graduation_level=chunk.graduation_level,
-        ))
+        merged.append(
+            Chunk(
+                content=chunk.content,
+                source=chunk.source,
+                chunk_id=cid,
+                relevance_score=round(score, 6),
+                recency_weight=chunk.recency_weight,
+                memory_type=chunk.memory_type,
+                graduation_level=chunk.graduation_level,
+            )
+        )
     return merged
 
 
@@ -143,7 +150,114 @@ def rrf_merge(
 
 # Common stopwords to filter out during term extraction (pure stdlib)
 _STOPWORDS = frozenset(
-    ["a", "an", "the", "is", "are", "was", "were", "be", "been", "being", "have", "has", "had", "do", "does", "did", "will", "would", "shall", "should", "may", "might", "can", "could", "of", "in", "to", "for", "on", "with", "at", "by", "from", "as", "into", "through", "during", "before", "after", "above", "below", "between", "out", "off", "over", "under", "again", "further", "then", "once", "here", "there", "when", "where", "why", "how", "all", "each", "every", "both", "few", "more", "most", "other", "some", "such", "no", "nor", "not", "only", "own", "same", "so", "than", "too", "very", "it", "its", "and", "but", "or", "if", "while", "that", "this", "these", "those", "i", "me", "my", "we", "our", "you", "your", "he", "him", "his", "she", "her", "they", "them", "their", "what", "which", "who", "whom"]
+    [
+        "a",
+        "an",
+        "the",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "being",
+        "have",
+        "has",
+        "had",
+        "do",
+        "does",
+        "did",
+        "will",
+        "would",
+        "shall",
+        "should",
+        "may",
+        "might",
+        "can",
+        "could",
+        "of",
+        "in",
+        "to",
+        "for",
+        "on",
+        "with",
+        "at",
+        "by",
+        "from",
+        "as",
+        "into",
+        "through",
+        "during",
+        "before",
+        "after",
+        "above",
+        "below",
+        "between",
+        "out",
+        "off",
+        "over",
+        "under",
+        "again",
+        "further",
+        "then",
+        "once",
+        "here",
+        "there",
+        "when",
+        "where",
+        "why",
+        "how",
+        "all",
+        "each",
+        "every",
+        "both",
+        "few",
+        "more",
+        "most",
+        "other",
+        "some",
+        "such",
+        "no",
+        "nor",
+        "not",
+        "only",
+        "own",
+        "same",
+        "so",
+        "than",
+        "too",
+        "very",
+        "it",
+        "its",
+        "and",
+        "but",
+        "or",
+        "if",
+        "while",
+        "that",
+        "this",
+        "these",
+        "those",
+        "i",
+        "me",
+        "my",
+        "we",
+        "our",
+        "you",
+        "your",
+        "he",
+        "him",
+        "his",
+        "she",
+        "her",
+        "they",
+        "them",
+        "their",
+        "what",
+        "which",
+        "who",
+        "whom",
+    ]
 )
 
 
@@ -197,6 +311,7 @@ def extract_expansion_terms(
 # ---------------------------------------------------------------------------
 # Retrieval cascade
 # ---------------------------------------------------------------------------
+
 
 def cascade_retrieve(
     query: str,
@@ -271,6 +386,42 @@ def cascade_retrieve(
             _cascade_errors.append(f"hybrid-vec: {e}")
 
     if all_results:
+        # Stage 4: Two-pass query expansion (if enabled) — attempted before we
+        # finalize the hybrid result so expansion terms can actually enrich the
+        # returned chunks rather than running in an unreachable post-return block.
+        if cfg.two_pass:
+            flat_chunks = [c for sublist in all_results for c in sublist]
+            expansion_terms = extract_expansion_terms(flat_chunks, query, top_k=cfg.two_pass_top_k)
+            if expansion_terms:
+                expanded_query = query + " " + " ".join(expansion_terms)
+                pass2_results: list[list[Chunk]] = []
+                pass2_total = 0
+                if fts_fn is not None:
+                    try:
+                        fts2 = fts_fn(expanded_query, limit * 2)
+                        pass2_results.append(fts2)
+                        pass2_total += len(fts2)
+                    except Exception:
+                        pass
+                if vector_fn is not None:
+                    try:
+                        vec2 = vector_fn(expanded_query, limit * 2)
+                        pass2_results.append(vec2)
+                        pass2_total += len(vec2)
+                    except Exception:
+                        pass
+
+                if pass2_results:
+                    all_combined = all_results + pass2_results
+                    merged = rrf_merge(*all_combined, k=cfg.hybrid_rrf_k)
+                    graduated = apply_graduation_scoring(merged, cfg)
+                    return RetrievalResult(
+                        chunks=graduated[:limit],
+                        query=expanded_query,
+                        mode=f"two_pass (expanded: +{len(expansion_terms)} terms)",
+                        total_candidates=total + pass2_total,
+                    )
+
         merged = rrf_merge(*all_results, k=cfg.hybrid_rrf_k)
         graduated = apply_graduation_scoring(merged, cfg)
         result = RetrievalResult(
@@ -283,54 +434,22 @@ def cascade_retrieve(
             result.mode = f"hybrid (warnings: {', '.join(_cascade_errors)})"
         return result
 
-    # Stage 4: Two-pass query expansion (if enabled and we got SOME results)
-    if cfg.two_pass and all_results:
-        flat_chunks = [c for sublist in all_results for c in sublist]
-        expansion_terms = extract_expansion_terms(flat_chunks, query, top_k=cfg.two_pass_top_k)
-        if expansion_terms:
-            expanded_query = query + " " + " ".join(expansion_terms)
-            # Second pass with expanded query
-            pass2_results: list[list[Chunk]] = []
-            pass2_total = 0
-            if fts_fn is not None:
-                try:
-                    fts2 = fts_fn(expanded_query, limit * 2)
-                    pass2_results.append(fts2)
-                    pass2_total += len(fts2)
-                except Exception:
-                    pass
-            if vector_fn is not None:
-                try:
-                    vec2 = vector_fn(expanded_query, limit * 2)
-                    pass2_results.append(vec2)
-                    pass2_total += len(vec2)
-                except Exception:
-                    pass
-
-            if pass2_results:
-                # Merge pass 1 + pass 2, deduplicate by chunk_id
-                all_combined = all_results + pass2_results
-                merged = rrf_merge(*all_combined, k=cfg.hybrid_rrf_k)
-                graduated = apply_graduation_scoring(merged, cfg)
-                return RetrievalResult(
-                    chunks=graduated[:limit],
-                    query=expanded_query,
-                    mode=f"two_pass (expanded: +{len(expansion_terms)} terms)",
-                    total_candidates=total + pass2_total,
-                )
-
     # Stage 5: Nothing found — include error context if cascade failed
     mode = "empty"
     if _cascade_errors:
         mode = f"cascade_failed ({', '.join(_cascade_errors)})"
     return RetrievalResult(
-        chunks=[], query=query, mode=mode, total_candidates=0,
+        chunks=[],
+        query=query,
+        mode=mode,
+        total_candidates=0,
     )
 
 
 # ---------------------------------------------------------------------------
 # Context ordering (Lost in the Middle paper)
 # ---------------------------------------------------------------------------
+
 
 def order_by_relevance_position(chunks: list[Chunk]) -> list[Chunk]:
     """Reorder chunks per "Lost in the Middle" paper findings.
@@ -358,6 +477,7 @@ def order_by_relevance_position(chunks: list[Chunk]) -> list[Chunk]:
 # Convenience classes (wrap cascade_retrieve for OOP usage)
 # ---------------------------------------------------------------------------
 
+
 class SmartRAG:
     """Smart retrieval with graduation-aware scoring and cascade strategy.
 
@@ -381,7 +501,9 @@ class SmartRAG:
 
     def retrieve(self, query: str) -> RetrievalResult:
         """Run the cascade retrieval pipeline."""
-        return cascade_retrieve(query, fts_fn=self.fts_fn, vector_fn=self.vector_fn, config=self.config)
+        return cascade_retrieve(
+            query, fts_fn=self.fts_fn, vector_fn=self.vector_fn, config=self.config
+        )
 
 
 class NaiveRAG:
@@ -399,6 +521,8 @@ class NaiveRAG:
             return RetrievalResult(chunks=[], query=query, mode="naive", total_candidates=0)
         try:
             results = self.fts_fn(query, top_k)
-            return RetrievalResult(chunks=results, query=query, mode="naive", total_candidates=len(results))
+            return RetrievalResult(
+                chunks=results, query=query, mode="naive", total_candidates=len(results)
+            )
         except Exception:
             return RetrievalResult(chunks=[], query=query, mode="naive", total_candidates=0)

--- a/Gradata/src/gradata/contrib/patterns/reflection.py
+++ b/Gradata/src/gradata/contrib/patterns/reflection.py
@@ -32,6 +32,7 @@ Typical usage::
 
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -64,9 +65,7 @@ class Criterion:
 
     def __post_init__(self) -> None:
         if self.weight <= 0:
-            raise ValueError(
-                f"Criterion '{self.name}': weight must be > 0, got {self.weight}"
-            )
+            raise ValueError(f"Criterion '{self.name}': weight must be > 0, got {self.weight}")
 
 
 @dataclass
@@ -89,8 +88,7 @@ class CriterionScore:
     def __post_init__(self) -> None:
         if self.score is not None and not (0.0 <= self.score <= 10.0):
             raise ValueError(
-                f"CriterionScore '{self.name}': score must be in [0, 10], "
-                f"got {self.score}"
+                f"CriterionScore '{self.name}': score must be in [0, 10], got {self.score}"
             )
 
 
@@ -172,11 +170,9 @@ class CritiqueChecklist:
         if not criteria:
             raise ValueError("CritiqueChecklist requires at least one Criterion.")
         names = [c.name for c in criteria]
-        duplicates = {n for n in names if names.count(n) > 1}
+        duplicates = {n for n, c in Counter(names).items() if c > 1}
         if duplicates:
-            raise ValueError(
-                f"CritiqueChecklist: duplicate criterion names: {duplicates}"
-            )
+            raise ValueError(f"CritiqueChecklist: duplicate criterion names: {duplicates}")
         self._criteria: tuple[Criterion, ...] = criteria
 
     # ------------------------------------------------------------------
@@ -213,11 +209,7 @@ class CritiqueChecklist:
             criterion_score = evaluator(output, criterion)
             scores[criterion.name] = criterion_score
 
-        all_required_passed = all(
-            scores[c.name].passed
-            for c in self._criteria
-            if c.required
-        )
+        all_required_passed = all(scores[c.name].passed for c in self._criteria if c.required)
         overall_score = _weighted_average(self._criteria, scores)
 
         return CritiqueResult(
@@ -302,9 +294,7 @@ def reflect(
             )
 
         # Collect failing scores to guide the refiner
-        failed: list[CriterionScore] = [
-            s for s in critique.scores.values() if not s.passed
-        ]
+        failed: list[CriterionScore] = [s for s in critique.scores.values() if not s.passed]
 
         # Only refine if there are cycles remaining
         if cycle < max_cycles:
@@ -366,20 +356,26 @@ def default_evaluator(output: Any, criterion: Criterion) -> CriterionScore:
 
     if name == "has_subject":
         passed = "subject:" in text.lower()
-        reason = (
-            "Found 'Subject:' header." if passed
-            else "No 'Subject:' header detected."
-        )
+        reason = "Found 'Subject:' header." if passed else "No 'Subject:' header detected."
 
     elif name == "has_cta":
         cta_phrases = (
-            "book", "schedule", "reply", "click", "visit",
-            "call", "download", "sign up", "learn more", "get started",
+            "book",
+            "schedule",
+            "reply",
+            "click",
+            "visit",
+            "call",
+            "download",
+            "sign up",
+            "learn more",
+            "get started",
         )
         matched = next((p for p in cta_phrases if p in text.lower()), None)
         passed = matched is not None
         reason = (
-            f"Call-to-action phrase found: '{matched}'." if passed
+            f"Call-to-action phrase found: '{matched}'."
+            if passed
             else "No recognisable call-to-action phrase found."
         )
 
@@ -387,30 +383,30 @@ def default_evaluator(output: Any, criterion: Criterion) -> CriterionScore:
         word_count = len(text.split())
         passed = word_count < 200
         reason = (
-            f"Word count {word_count} is within the 200-word limit." if passed
+            f"Word count {word_count} is within the 200-word limit."
+            if passed
             else f"Word count {word_count} exceeds the 200-word limit."
         )
 
     elif name == "no_jargon":
         jargon_tokens = (
-            "synergy", "leverage", "paradigm", "disruptive",
-            "holistic", "bandwidth", "circle back", "deep dive",
+            "synergy",
+            "leverage",
+            "paradigm",
+            "disruptive",
+            "holistic",
+            "bandwidth",
+            "circle back",
+            "deep dive",
         )
         found = [j for j in jargon_tokens if j in text.lower()]
         passed = len(found) == 0
-        reason = (
-            "No jargon detected." if passed
-            else f"Jargon detected: {found}."
-        )
+        reason = "No jargon detected." if passed else f"Jargon detected: {found}."
 
     else:
         # Generic fallback: non-empty string
         passed = isinstance(output, str) and len(output.strip()) > 0
-        reason = (
-            "Output is a non-empty string."
-            if passed
-            else "Output is empty or not a string."
-        )
+        reason = "Output is a non-empty string." if passed else "Output is empty or not a string."
 
     return CriterionScore(
         name=criterion.name,
@@ -418,7 +414,6 @@ def default_evaluator(output: Any, criterion: Criterion) -> CriterionScore:
         reason=reason,
         score=10.0 if passed else 0.0,
     )
-
 
 
 # ---------------------------------------------------------------------------
@@ -530,10 +525,12 @@ def criteria_from_graduated_rules(task_type: str = "") -> list[Criterion]:
 
     criteria = []
     for rule in rules:
-        criteria.append(Criterion(
-            name=f"rule_{rule.category.lower()}_{len(criteria)}",
-            question=f"Does the output follow this rule: {rule.principle}?",
-            required=rule.is_rule_tier,  # RULE tier = required, PATTERN = optional
-            weight=rule.confidence,
-        ))
+        criteria.append(
+            Criterion(
+                name=f"rule_{rule.category.lower()}_{len(criteria)}",
+                question=f"Does the output follow this rule: {rule.principle}?",
+                required=rule.is_rule_tier,  # RULE tier = required, PATTERN = optional
+                weight=rule.confidence,
+            )
+        )
     return criteria

--- a/Gradata/src/gradata/contrib/patterns/tree_of_thoughts.py
+++ b/Gradata/src/gradata/contrib/patterns/tree_of_thoughts.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 @dataclass
 class Thought:
     """A single candidate in the exploration tree."""
+
     content: str
     score: float = 0.0
     rationale: str = ""
@@ -28,6 +29,7 @@ class Thought:
 @dataclass
 class ToTResult:
     """Result of Tree of Thoughts exploration."""
+
     best: Thought
     alternatives: list[Thought]
     depth: int
@@ -120,18 +122,26 @@ def evaluate_rule_candidates(
     """
     effective_scorer: Callable[[str], tuple[float, str]]
     if scorer is None:
+        # Precompute rule word-sets once instead of O(N*M) re-tokenisation
+        # per candidate × rule inside the scorer closure.
+        rule_word_sets: list[set[str]] = [set(r.lower().split()) for r in existing_rules]
+
         def _default_scorer(candidate: str) -> tuple[float, str]:
             # Heuristic: shorter, more specific rules score higher
             words = candidate.split()
             length_score = max(0.0, 1.0 - len(words) / 50)
             # Penalize overlap with existing rules
+            candidate_words = set(candidate.lower().split())
             overlap_penalty = 0.0
-            for rule in existing_rules:
-                common = set(candidate.lower().split()) & set(rule.lower().split())
-                if len(common) > 5:
+            for rule_words in rule_word_sets:
+                if len(candidate_words & rule_words) > 5:
                     overlap_penalty += 0.2
             score = round(length_score - overlap_penalty, 4)
-            return (max(0.0, min(1.0, score)), f"length={len(words)}, overlap_penalty={overlap_penalty:.2f}")
+            return (
+                max(0.0, min(1.0, score)),
+                f"length={len(words)}, overlap_penalty={overlap_penalty:.2f}",
+            )
+
         effective_scorer = _default_scorer
     else:
         effective_scorer = scorer

--- a/Gradata/src/gradata/enhancements/meta_rules.py
+++ b/Gradata/src/gradata/enhancements/meta_rules.py
@@ -852,7 +852,22 @@ def _call_gemma_native(prompt: str, creds: str, model: str, timeout: float = 15.
         return None
 
 
-def _try_llm_principle(rules: list[Lesson], category: str) -> str | None:
+def _resolve_principle_creds() -> dict[str, str | None]:
+    """Resolve LLM credentials once per synthesis run (hoisted from per-call)."""
+    return {
+        "openai_key": env_str("GRADATA_LLM_KEY"),
+        "openai_base": env_str("GRADATA_LLM_BASE"),
+        "openai_model": env_str("GRADATA_LLM_MODEL", "gpt-4o-mini"),
+        "gemma_key": env_str("GRADATA_GEMMA_API_KEY"),
+        "gemma_model": env_str("GRADATA_GEMMA_MODEL", _GEMMA_DEFAULT_MODEL),
+    }
+
+
+def _try_llm_principle(
+    rules: list[Lesson],
+    category: str,
+    creds: dict[str, str | None] | None = None,
+) -> str | None:
     """Best-effort LLM synthesis of ONE behavioral principle for a rule group.
 
     Returns the principle string or None (no credentials, empty input, or
@@ -861,12 +876,15 @@ def _try_llm_principle(rules: list[Lesson], category: str) -> str | None:
     Provider resolution:
       1. ``GRADATA_LLM_KEY`` + ``GRADATA_LLM_BASE`` -- OpenAI-compat endpoint.
       2. ``GRADATA_GEMMA_API_KEY`` -- Google's native Gemma API.
+
+    When ``creds`` is passed, env vars are not re-read (hot-loop optimization).
     """
     if not rules:
         return None
 
-    k = env_str("GRADATA_LLM_KEY")
-    b = env_str("GRADATA_LLM_BASE")
+    c = creds if creds is not None else _resolve_principle_creds()
+    k = c.get("openai_key")
+    b = c.get("openai_base")
     if k and b:
         try:
             from gradata.enhancements.llm_synthesizer import synthesise_principle_llm
@@ -876,15 +894,15 @@ def _try_llm_principle(rules: list[Lesson], category: str) -> str | None:
                 theme=category,
                 api_key=k,
                 api_base=b,
-                model=env_str("GRADATA_LLM_MODEL", "gpt-4o-mini"),
+                model=c.get("openai_model") or "gpt-4o-mini",
             )
         except Exception as exc:
             _log.debug("OpenAI-compat synthesis failed for %s: %s", category, exc)
             return None
 
-    g = env_str("GRADATA_GEMMA_API_KEY")
+    g = c.get("gemma_key")
     if g:
-        model = env_str("GRADATA_GEMMA_MODEL", _GEMMA_DEFAULT_MODEL)
+        model = c.get("gemma_model") or _GEMMA_DEFAULT_MODEL
         return _call_gemma_native(_build_principle_prompt(rules, category), g, model)
 
     return None
@@ -1205,6 +1223,9 @@ def synthesize_meta_rules_agentic(
 
     new_metas: list[MetaRule] = []
 
+    # Resolve LLM credentials once instead of re-reading env per category.
+    principle_creds = _resolve_principle_creds()
+
     for category, rules in groups.items():
         if evidence.iteration >= max_iterations:
             _log.debug("Agentic synthesis: hit max iterations %d", max_iterations)
@@ -1232,7 +1253,7 @@ def synthesize_meta_rules_agentic(
         # Without creds we emit deterministic meta-rules that are stored but
         # never injected (INJECTABLE_META_SOURCES excludes them) — warn loudly
         # so the capability gap is visible instead of silent 100% discard.
-        llm_principle = _try_llm_principle(rules, category)
+        llm_principle = _try_llm_principle(rules, category, creds=principle_creds)
         if llm_principle:
             principle = llm_principle
             source = "llm_synth"

--- a/Gradata/src/gradata/enhancements/meta_rules.py
+++ b/Gradata/src/gradata/enhancements/meta_rules.py
@@ -679,12 +679,13 @@ def refresh_meta_rules(
     _log.info("Meta-rule discovery requires Gradata Cloud")
     corrections = recent_corrections or []
 
-    # Validate existing meta-rules (invalidation still works locally)
+    # Validate existing meta-rules (invalidation still works locally).
+    # Use dataclasses.replace so callers holding references to the input list
+    # do not observe hidden mutation of last_validated_session.
     valid: list[MetaRule] = []
     for meta in existing_metas:
         if validate_meta_rule(meta, corrections):
-            meta.last_validated_session = current_session
-            valid.append(meta)
+            valid.append(replace(meta, last_validated_session=current_session))
 
     valid.sort(key=lambda m: m.confidence, reverse=True)
     return valid

--- a/Gradata/src/gradata/enhancements/reporting.py
+++ b/Gradata/src/gradata/enhancements/reporting.py
@@ -26,9 +26,12 @@ Usage::
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+_log = logging.getLogger(__name__)
 
 __all__ = [
     "EXPORT_TARGETS",
@@ -49,6 +52,7 @@ EXPORT_TARGETS: dict[str, str] = {
 @dataclass
 class BriefingRule:
     """A single rule from the brain, formatted for injection."""
+
     category: str
     description: str
     confidence: float
@@ -75,6 +79,7 @@ class BrainBriefing:
         brain_health: Health metrics.
         metadata: Additional context.
     """
+
     rules: list[BriefingRule] = field(default_factory=list)
     anti_patterns: list[str] = field(default_factory=list)
     recent_corrections: list[dict[str, Any]] = field(default_factory=list)
@@ -168,7 +173,7 @@ def generate_briefing(
 
         # Find lessons file
         lessons_path = None
-        if hasattr(brain, 'dir'):
+        if hasattr(brain, "dir"):
             candidates = [
                 brain.dir / "lessons.md",
                 brain.dir.parent / ".claude" / "lessons.md",
@@ -189,53 +194,55 @@ def generate_briefing(
 
             for lesson in lessons:
                 state_upper = lesson.state.value.upper()
-                if (
-                    state_upper in allowed_states
-                    and lesson.confidence >= min_confidence
-                ):
-                    briefing.rules.append(BriefingRule(
-                        category=lesson.category,
-                        description=lesson.description,
-                        confidence=lesson.confidence,
-                        state=state_upper,
-                        fire_count=lesson.fire_count,
-                    ))
+                if state_upper in allowed_states and lesson.confidence >= min_confidence:
+                    briefing.rules.append(
+                        BriefingRule(
+                            category=lesson.category,
+                            description=lesson.description,
+                            confidence=lesson.confidence,
+                            state=state_upper,
+                            fire_count=lesson.fire_count,
+                        )
+                    )
 
             # Sort by confidence descending, optionally cap
             briefing.rules.sort(key=lambda r: r.confidence, reverse=True)
             if max_rules > 0:
                 briefing.rules = briefing.rules[:max_rules]
-    except Exception:
-        pass
+    except Exception as exc:
+        _log.debug("briefing: rules extraction failed: %s", exc)
 
     # Extract quality metrics
     try:
         from gradata._brain_manifest import _quality_metrics
-        ctx = brain.ctx if hasattr(brain, 'ctx') else None
+
+        ctx = brain.ctx if hasattr(brain, "ctx") else None
         quality = _quality_metrics(ctx=ctx)
         briefing.brain_health = {
-            k: v for k, v in quality.items()
-            if v is not None and v != [] and v != {}
+            k: v for k, v in quality.items() if v is not None and v != [] and v != {}
         }
-    except Exception:
-        pass
+    except Exception as exc:
+        _log.debug("briefing: quality metrics failed: %s", exc)
 
     # Extract recent corrections from events
     try:
         events = brain.query_events(event_type="CORRECTION", last_n_sessions=5, limit=10)
         for evt in events:
             data = evt.get("data", {})
-            briefing.recent_corrections.append({
-                "severity": data.get("severity", "unknown"),
-                "category": data.get("category", "UNKNOWN"),
-                "summary": data.get("summary", ""),
-            })
-    except Exception:
-        pass
+            briefing.recent_corrections.append(
+                {
+                    "severity": data.get("severity", "unknown"),
+                    "category": data.get("category", "UNKNOWN"),
+                    "summary": data.get("summary", ""),
+                }
+            )
+    except Exception as exc:
+        _log.debug("briefing: correction extraction failed: %s", exc)
 
     # Add anti-patterns from the negative rule library
     try:
         from gradata.enhancements.quality_monitoring import DEFAULT_ANTI_PATTERNS
+
         briefing.anti_patterns = list(DEFAULT_ANTI_PATTERNS)
     except ImportError:
         pass
@@ -300,6 +307,7 @@ def _count_active_lessons(brain_dir: Path) -> int:
     try:
         from gradata._core import _filter_lessons_by_state
         from gradata.enhancements.self_improvement import parse_lessons
+
         lessons = parse_lessons(lessons_path.read_text(encoding="utf-8"))
         count = len(_filter_lessons_by_state(lessons, min_state="INSTINCT"))
         _lessons_cache.update({"path": str(lessons_path), "mtime": mtime, "count": count})
@@ -311,6 +319,7 @@ def _count_active_lessons(brain_dir: Path) -> int:
 @dataclass
 class HealthReport:
     """Brain health assessment."""
+
     healthy: bool = True
     issues: list[str] = field(default_factory=list)
     sessions_total: int = 0
@@ -323,10 +332,13 @@ def generate_health_report(db_path=None, ctx=None) -> HealthReport:
     report = HealthReport()
     try:
         import sqlite3
+
         db = Path(db_path) if db_path else (Path(ctx.brain_dir) / "system.db" if ctx else None)
         if db and db.exists():
             conn = sqlite3.connect(str(db))
-            report.sessions_total = conn.execute("SELECT COUNT(DISTINCT session) FROM events").fetchone()[0] or 0
+            report.sessions_total = (
+                conn.execute("SELECT COUNT(DISTINCT session) FROM events").fetchone()[0] or 0
+            )
             report.events_total = conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] or 0
             conn.close()
     except Exception:
@@ -347,8 +359,12 @@ def generate_health_report(db_path=None, ctx=None) -> HealthReport:
 def format_health_report(report: HealthReport) -> str:
     """Format health report as human-readable string."""
     status = "HEALTHY" if report.healthy else "UNHEALTHY"
-    lines = [f"Brain Health: {status}", f"  Sessions: {report.sessions_total}",
-             f"  Events: {report.events_total}", f"  Active lessons: {report.lessons_active}"]
+    lines = [
+        f"Brain Health: {status}",
+        f"  Sessions: {report.sessions_total}",
+        f"  Events: {report.events_total}",
+        f"  Active lessons: {report.lessons_active}",
+    ]
     if report.issues:
         lines.append("  Issues:")
         for issue in report.issues:

--- a/Gradata/src/gradata/enhancements/reporting.py
+++ b/Gradata/src/gradata/enhancements/reporting.py
@@ -331,17 +331,18 @@ def generate_health_report(db_path=None, ctx=None) -> HealthReport:
     """Generate a basic health report from the brain database."""
     report = HealthReport()
     try:
+        import contextlib
         import sqlite3
 
         db = Path(db_path) if db_path else (Path(ctx.brain_dir) / "system.db" if ctx else None)
         if db and db.exists():
-            conn = sqlite3.connect(str(db))
-            report.sessions_total = (
-                conn.execute("SELECT COUNT(DISTINCT session) FROM events").fetchone()[0] or 0
-            )
-            report.events_total = conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] or 0
-            conn.close()
-    except Exception:
+            with contextlib.closing(sqlite3.connect(str(db))) as conn:
+                report.sessions_total = (
+                    conn.execute("SELECT COUNT(DISTINCT session) FROM events").fetchone()[0] or 0
+                )
+                report.events_total = conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] or 0
+    except Exception as exc:
+        _log.debug("health report db read failed: %s", exc)
         report.issues.append("Could not read database")
         report.healthy = False
 
@@ -350,8 +351,8 @@ def generate_health_report(db_path=None, ctx=None) -> HealthReport:
         brain_dir = Path(db_path).parent if db_path else (Path(ctx.brain_dir) if ctx else None)
         if brain_dir:
             report.lessons_active = _count_active_lessons(brain_dir)
-    except Exception:
-        pass  # Non-critical — lessons count is informational
+    except Exception as exc:
+        _log.debug("health report lessons count failed: %s", exc)
 
     return report
 

--- a/Gradata/src/gradata/enhancements/router_warmstart.py
+++ b/Gradata/src/gradata/enhancements/router_warmstart.py
@@ -55,11 +55,13 @@ def warm_start_router(
     """
     from gradata.contrib.patterns.q_learning_router import QLearningRouter, RouterConfig
 
-    router = QLearningRouter(RouterConfig(
-        epsilon_start=0.5,  # Less exploration since we have data
-        epsilon_min=0.05,
-        epsilon_decay=0.99,
-    ))
+    router = QLearningRouter(
+        RouterConfig(
+            epsilon_start=0.5,  # Less exploration since we have data
+            epsilon_min=0.05,
+            epsilon_decay=0.99,
+        )
+    )
 
     # Load existing router state if available
     if router_path and Path(router_path).exists():
@@ -70,25 +72,28 @@ def warm_start_router(
         _log.warning("Database not found: %s", db_path)
         return router
 
+    import contextlib
+
     try:
-        conn = sqlite3.connect(str(db_path))
-        conn.row_factory = sqlite3.Row
+        with contextlib.closing(sqlite3.connect(str(db_path))) as conn:
+            conn.row_factory = sqlite3.Row
 
-        # Fetch correction events with severity and category
-        rows = conn.execute("""
-            SELECT
-                json_extract(data_json, '$.severity') as severity,
-                json_extract(data_json, '$.category') as category,
-                json_extract(data_json, '$.outcome') as outcome
-            FROM events
-            WHERE type = 'CORRECTION'
-              AND json_extract(data_json, '$.severity') IS NOT NULL
-              AND json_extract(data_json, '$.category') IS NOT NULL
-            ORDER BY rowid DESC
-            LIMIT ?
-        """, (max_events,)).fetchall()
-
-        conn.close()
+            # Fetch correction events with severity and category
+            rows = conn.execute(
+                """
+                SELECT
+                    json_extract(data_json, '$.severity') as severity,
+                    json_extract(data_json, '$.category') as category,
+                    json_extract(data_json, '$.outcome') as outcome
+                FROM events
+                WHERE type = 'CORRECTION'
+                  AND json_extract(data_json, '$.severity') IS NOT NULL
+                  AND json_extract(data_json, '$.category') IS NOT NULL
+                ORDER BY rowid DESC
+                LIMIT ?
+            """,
+                (max_events,),
+            ).fetchall()
 
         if not rows:
             _log.info("No correction events found for warm-start")

--- a/Gradata/src/gradata/enhancements/rule_context_bridge.py
+++ b/Gradata/src/gradata/enhancements/rule_context_bridge.py
@@ -43,6 +43,7 @@ def bootstrap_rule_context(
     if lessons_path and lessons_path.is_file():
         try:
             from gradata.enhancements.self_improvement import parse_lessons
+
             text = lessons_path.read_text(encoding="utf-8")
             lessons = parse_lessons(text)
 
@@ -56,15 +57,17 @@ def bootstrap_rule_context(
                         scope = json.loads(lesson.scope_json)
 
                 rule_id = f"lesson:{lesson.category}:{lesson.description[:40]}"
-                ctx.publish(GraduatedRule(
-                    rule_id=rule_id,
-                    category=lesson.category,
-                    principle=lesson.description,
-                    confidence=lesson.confidence,
-                    scope=scope,
-                    source_type="lesson",
-                    agent_type=lesson.agent_type or "",
-                ))
+                ctx.publish(
+                    GraduatedRule(
+                        rule_id=rule_id,
+                        category=lesson.category,
+                        principle=lesson.description,
+                        confidence=lesson.confidence,
+                        scope=scope,
+                        source_type="lesson",
+                        agent_type=lesson.agent_type or "",
+                    )
+                )
                 count += 1
 
         except Exception as e:
@@ -74,23 +77,21 @@ def bootstrap_rule_context(
     if db_path and db_path.is_file():
         try:
             import sqlite3
+
             conn = sqlite3.connect(str(db_path))
             conn.row_factory = sqlite3.Row
             try:
-                rows = conn.execute(
-                    "SELECT * FROM meta_rules WHERE status = 'active'"
-                ).fetchall()
+                rows = conn.execute("SELECT * FROM meta_rules WHERE status = 'active'").fetchall()
             except sqlite3.OperationalError:
                 rows = []  # Table may not exist yet
             finally:
                 conn.close()
                 # Force WAL checkpoint so Windows releases the file lock
                 try:
-                    c2 = sqlite3.connect(str(db_path))
-                    c2.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-                    c2.close()
-                except Exception:
-                    pass
+                    with contextlib.closing(sqlite3.connect(str(db_path))) as c2:
+                        c2.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                except Exception as exc:
+                    logger.debug("WAL checkpoint failed: %s", exc)
 
             for row in rows:
                 rule_id = f"meta:{row['id']}"
@@ -103,13 +104,15 @@ def bootstrap_rule_context(
                     principle = row["principle"] if "principle" in row else str(row)
                 except (KeyError, IndexError):
                     principle = str(row)
-                ctx.publish(GraduatedRule(
-                    rule_id=rule_id,
-                    category=category,
-                    principle=principle,
-                    confidence=0.95,
-                    source_type="meta_rule",
-                ))
+                ctx.publish(
+                    GraduatedRule(
+                        rule_id=rule_id,
+                        category=category,
+                        principle=principle,
+                        confidence=0.95,
+                        source_type="meta_rule",
+                    )
+                )
                 count += 1
 
         except Exception as e:
@@ -148,14 +151,15 @@ def on_graduation_event(event: dict) -> None:
 
     rule_id = f"lesson:{category}:{description[:40]}"
     ctx = get_rule_context()
-    ctx.publish(GraduatedRule(
-        rule_id=rule_id,
-        category=category,
-        principle=description,
-        confidence=confidence,
-        source_type="lesson",
-        agent_type=agent_type,
-    ))
+    ctx.publish(
+        GraduatedRule(
+            rule_id=rule_id,
+            category=category,
+            principle=description,
+            confidence=confidence,
+            source_type="lesson",
+            agent_type=agent_type,
+        )
+    )
 
     logger.debug("RuleContext: published %s [%s:%.2f]", category, new_state, confidence)
-

--- a/Gradata/src/gradata/enhancements/self_improvement/_confidence.py
+++ b/Gradata/src/gradata/enhancements/self_improvement/_confidence.py
@@ -10,6 +10,7 @@ also live here and are imported by _graduation.py.
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 
@@ -394,20 +395,16 @@ def parse_lessons(text: str) -> list[Lesson]:
             elif meta_line.startswith("Scope:"):
                 scope_json = meta_line[len("Scope:") :].strip()
             elif meta_line.startswith("Beta params:"):
-                import json as _json_bp
-
                 try:
-                    bp = _json_bp.loads(meta_line[len("Beta params:") :].strip())
+                    bp = json.loads(meta_line[len("Beta params:") :].strip())
                     alpha = bp.get("alpha", 1.0)
                     beta_param_val = bp.get("beta", 1.0)
-                except _json_bp.JSONDecodeError:
+                except json.JSONDecodeError:
                     pass
             elif meta_line.startswith("Domain scores:"):
-                import json as _json
-
                 try:
-                    domain_scores = _json.loads(meta_line[len("Domain scores:") :].strip())
-                except _json.JSONDecodeError:
+                    domain_scores = json.loads(meta_line[len("Domain scores:") :].strip())
+                except json.JSONDecodeError:
                     domain_scores = {}
             elif meta_line.startswith("Path:"):
                 path = meta_line[len("Path:") :].strip()
@@ -418,26 +415,22 @@ def parse_lessons(text: str) -> list[Lesson]:
                     if x.strip()
                 ]
             elif meta_line.startswith("Climb:"):
-                import json as _json_cl
-
                 try:
-                    _cl = _json_cl.loads(meta_line[len("Climb:") :].strip())
+                    _cl = json.loads(meta_line[len("Climb:") :].strip())
                     climb_count = _cl.get("count", 0)
                     last_climb_session = _cl.get("last_session", 0)
                     tree_level = _cl.get("level", 0)
-                except _json_cl.JSONDecodeError:
+                except json.JSONDecodeError:
                     pass
             elif meta_line.startswith("Metadata:"):
-                import json as _json_md
-
                 try:
-                    _md_dict = _json_md.loads(meta_line[len("Metadata:") :].strip())
+                    _md_dict = json.loads(meta_line[len("Metadata:") :].strip())
                     from gradata._types import RuleMetadata as _RM
 
                     metadata_obj = _RM(
                         **{k: v for k, v in _md_dict.items() if k in _RM.__dataclass_fields__}
                     )
-                except (ValueError, TypeError, _json_md.JSONDecodeError):
+                except (ValueError, TypeError, json.JSONDecodeError):
                     metadata_obj = None
             meta_m = _META_RE.search(meta_line)
             if meta_m:
@@ -1110,15 +1103,11 @@ def format_lessons(lessons: list[Lesson]) -> str:
             lines.append(f"  Scope: {lesson.scope_json}")
 
         if lesson.domain_scores:
-            import json as _json
-
-            lines.append(f"  Domain scores: {_json.dumps(lesson.domain_scores)}")
+            lines.append(f"  Domain scores: {json.dumps(lesson.domain_scores)}")
 
         if lesson.alpha != 1.0 or lesson.beta_param != 1.0:
-            import json as _json_bp
-
             lines.append(
-                f"  Beta params: {_json_bp.dumps({'alpha': lesson.alpha, 'beta': lesson.beta_param})}"
+                f"  Beta params: {json.dumps({'alpha': lesson.alpha, 'beta': lesson.beta_param})}"
             )
 
         if lesson.path:
@@ -1128,18 +1117,14 @@ def format_lessons(lessons: list[Lesson]) -> str:
             lines.append(f"  Secondary categories: {','.join(lesson.secondary_categories)}")
 
         if lesson.climb_count or lesson.last_climb_session or lesson.tree_level:
-            import json as _json_cl
-
             lines.append(
-                f"  Climb: {_json_cl.dumps({'count': lesson.climb_count, 'last_session': lesson.last_climb_session, 'level': lesson.tree_level})}"
+                f"  Climb: {json.dumps({'count': lesson.climb_count, 'last_session': lesson.last_climb_session, 'level': lesson.tree_level})}"
             )
 
         if hasattr(lesson, "metadata") and lesson.metadata is not None:
-            import json as _json_meta
-
             md = lesson.metadata.to_dict() if hasattr(lesson.metadata, "to_dict") else {}
             if any(v for v in md.values() if v and v != 0.5):  # only write non-default
-                lines.append(f"  Metadata: {_json_meta.dumps(md)}")
+                lines.append(f"  Metadata: {json.dumps(md)}")
 
         lines.append("")  # blank line between lessons
 

--- a/Gradata/src/gradata/enhancements/self_improvement/_confidence.py
+++ b/Gradata/src/gradata/enhancements/self_improvement/_confidence.py
@@ -36,6 +36,7 @@ def is_hook_enforced(lesson: Lesson) -> bool:
     desc = getattr(lesson, "description", "") or ""
     return desc.lstrip().startswith("[hooked]")
 
+
 # ---------------------------------------------------------------------------
 # Constants (SPEC-aligned, research-backed)
 # ---------------------------------------------------------------------------
@@ -748,6 +749,7 @@ def update_confidence(
             lesson._pre_session_state = lesson.state  # type: ignore[attr-defined]
 
         cat = lesson.category.upper()
+        _fired_this_session = False
 
         # Session-type immunity: skip lessons whose category isn't testable
         if not _is_testable(cat, session_type):
@@ -809,6 +811,7 @@ def update_confidence(
                     # CONTRADICTING or UNKNOWN: FSRS penalty
                     lesson.beta_param += 1.0
                     base_penalty = fsrs_penalty(lesson.confidence, machine=is_machine)
+                    severity = "moderate"
                     if cat in severity_data:
                         raw_severity = severity_data[cat]
                         severity = _normalize_severity(raw_severity)
@@ -900,9 +903,13 @@ def update_confidence(
                 if was_injected:
                     lesson.fire_count += 1
                     lesson.sessions_since_fire = 0
+                    _fired_this_session = True
 
-        # Track sessions since fire
-        lesson.sessions_since_fire += 1
+        # Track sessions since fire. Skip when the lesson fired this session —
+        # otherwise the reset-then-increment path produced a systematic off-by-one
+        # (fired lesson reported sessions_since_fire=1 instead of 0).
+        if not _fired_this_session:
+            lesson.sessions_since_fire += 1
 
         # Inline UNTESTABLE detection
         if (
@@ -1196,17 +1203,30 @@ def compute_learning_velocity(
 
 
 def __getattr__(name: str):  # type: ignore[return]
-    _PIPELINE_NAMES = {"PipelineResult", "run_rule_pipeline", "_generate_skill_file", "review_generated_skill"}
+    _PIPELINE_NAMES = {
+        "PipelineResult",
+        "run_rule_pipeline",
+        "_generate_skill_file",
+        "review_generated_skill",
+    }
     _CAUSAL_NAMES = {"CausalRelation", "CausalLink", "CausalChain"}
-    _CLUSTER_NAMES = {"RuleCluster", "detect_contradictions", "cluster_rules", "promote_instinct_clusters"}
+    _CLUSTER_NAMES = {
+        "RuleCluster",
+        "detect_contradictions",
+        "cluster_rules",
+        "promote_instinct_clusters",
+    }
 
     if name in _PIPELINE_NAMES:
         from gradata.enhancements import rule_pipeline
+
         return getattr(rule_pipeline, name)
     if name in _CAUSAL_NAMES:
         from gradata.enhancements import causal_chains
+
         return getattr(causal_chains, name)
     if name in _CLUSTER_NAMES:
         from gradata.enhancements import clustering
+
         return getattr(clustering, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/Gradata/src/gradata/enhancements/self_improvement/_graduation.py
+++ b/Gradata/src/gradata/enhancements/self_improvement/_graduation.py
@@ -31,33 +31,21 @@ from gradata.enhancements.self_improvement._confidence import (
 _log = logging.getLogger(__name__)
 
 
-
 # ---------------------------------------------------------------------------
 # Graduation
 # ---------------------------------------------------------------------------
 
 
-def _passes_beta_lb_gate(lesson: Lesson) -> bool:
-    """Beta lower-bound gate on PATTERN -> RULE promotion.
+def _read_beta_lb_config() -> tuple[bool, float, int]:
+    """Read Beta-LB gate env config once. Returns (enabled, threshold, min_fires).
 
-    Opt-in via env var ``GRADATA_BETA_LB_GATE`` (default off). When enabled,
-    requires the 5th-percentile lower bound of Beta(α, β) to meet the
-    configured threshold (``GRADATA_BETA_LB_THRESHOLD``, default 0.85) AND
-    at least ``GRADATA_BETA_LB_MIN_FIRES`` observations (default 5).
-
-    Rationale: the v4 ablation min2022 random-label control showed that
-    ~15–20% of current RULE-tier graduations are calibrated by format,
-    not content. The Beta posterior captures uncertainty the mean
-    (lesson.confidence) discards. Feature-flagged so production
-    calibration is unchanged until this is measured in-band.
+    Called once per ``graduate()`` invocation so per-lesson gate checks can
+    skip repeated ``os.environ.get`` lookups inside the graduation loop.
     """
+    import math
     import os
 
-    if os.environ.get("GRADATA_BETA_LB_GATE", "").lower() not in ("1", "true", "yes", "on"):
-        return True  # gate disabled — defer to existing conf + fire_count checks
-
-    import math
-
+    enabled = os.environ.get("GRADATA_BETA_LB_GATE", "").lower() in ("1", "true", "yes", "on")
     try:
         threshold = float(os.environ.get("GRADATA_BETA_LB_THRESHOLD", "0.85"))
         if not math.isfinite(threshold):
@@ -69,6 +57,26 @@ def _passes_beta_lb_gate(lesson: Lesson) -> bool:
         min_fires = max(0, int(os.environ.get("GRADATA_BETA_LB_MIN_FIRES", "5")))
     except (TypeError, ValueError):
         min_fires = 5
+    return enabled, threshold, min_fires
+
+
+def _passes_beta_lb_gate(
+    lesson: Lesson,
+    config: tuple[bool, float, int] | None = None,
+) -> bool:
+    """Beta lower-bound gate on PATTERN -> RULE promotion.
+
+    Opt-in via env var ``GRADATA_BETA_LB_GATE`` (default off). When enabled,
+    requires the 5th-percentile lower bound of Beta(α, β) to meet the
+    configured threshold (``GRADATA_BETA_LB_THRESHOLD``, default 0.85) AND
+    at least ``GRADATA_BETA_LB_MIN_FIRES`` observations (default 5).
+
+    Pass ``config`` (from :func:`_read_beta_lb_config`) when calling in a
+    loop to avoid re-reading env vars per lesson.
+    """
+    enabled, threshold, min_fires = config if config is not None else _read_beta_lb_config()
+    if not enabled:
+        return True  # gate disabled — defer to existing conf + fire_count checks
 
     if lesson.fire_count < min_fires:
         return False
@@ -118,6 +126,9 @@ def graduate(
     else:
         eff_pattern_threshold = PATTERN_THRESHOLD
         eff_rule_threshold = RULE_THRESHOLD
+
+    # Read Beta-LB gate env once; reuse for every lesson in the loop below.
+    beta_lb_config = _read_beta_lb_config()
     if renter:
         active = [l for l in lessons if l.state in (LessonState.INSTINCT, LessonState.PATTERN)]
         graduated = [
@@ -132,6 +143,18 @@ def graduate(
     existing_rules = [l for l in lessons if l.state == LessonState.RULE]
     existing_rule_descs = [r.description for r in existing_rules]
     existing_rule_summary = " | ".join(d for d in existing_rule_descs[:10])
+
+    # Precompute existing-rule TF vectors once so the per-candidate dedup
+    # gate below doesn't re-tokenize and re-weight every rule on every
+    # comparison (was O(N_candidates × M_rules × |tokens|), now additive).
+    try:
+        from gradata.enhancements.similarity import semantic_vector
+
+        existing_rule_vectors: list[tuple[str, dict[str, float]]] = [
+            (r.description, semantic_vector(r.description)) for r in existing_rules
+        ]
+    except ImportError:
+        existing_rule_vectors = []
 
     for lesson in lessons:
         if lesson.state in (LessonState.KILLED, LessonState.ARCHIVED):
@@ -217,28 +240,33 @@ def graduate(
             and lesson.state == LessonState.PATTERN
             and lesson.confidence >= eff_rule_threshold
             and lesson.fire_count >= MIN_APPLICATIONS_FOR_RULE
-            and _passes_beta_lb_gate(lesson)
+            and _passes_beta_lb_gate(lesson, config=beta_lb_config)
         ):
             blocked = False
 
             # Gate 1: dedup — skip if too similar to an existing rule.
-            # TODO: At 5,000+ rules, pre-compute TF-IDF vectors for existing_rules
-            # outside the lesson loop to avoid redundant tokenization (O(n*m) → O(n+m)).
-            try:
-                from gradata.enhancements.similarity import semantic_similarity
+            # Uses precomputed TF vectors for the stored rules so the
+            # tokenization cost scales as O(N+M) rather than O(N*M).
+            if existing_rule_vectors:
+                try:
+                    from gradata.enhancements.similarity import (
+                        semantic_vector,
+                        similarity_from_vectors,
+                    )
 
-                for existing in existing_rules:
-                    sim = semantic_similarity(lesson.description, existing.description)
-                    if sim > _GRADUATION_DEDUP_THRESHOLD:
-                        blocked = True
-                        _log.debug(
-                            "Graduation blocked (duplicate): %.2f sim with '%s'",
-                            sim,
-                            existing.description[:60],
-                        )
-                        break
-            except ImportError:
-                pass
+                    probe_vec = semantic_vector(lesson.description)
+                    for existing_desc, existing_vec in existing_rule_vectors:
+                        sim = similarity_from_vectors(probe_vec, existing_vec)
+                        if sim > _GRADUATION_DEDUP_THRESHOLD:
+                            blocked = True
+                            _log.debug(
+                                "Graduation blocked (duplicate): %.2f sim with '%s'",
+                                sim,
+                                existing_desc[:60],
+                            )
+                            break
+                except ImportError:
+                    pass
 
             # Gate 2: adversarial — skip if contradicts an existing rule
             if not blocked:
@@ -349,5 +377,3 @@ def graduate(
     active = [l for l in lessons if l.state in (LessonState.INSTINCT, LessonState.PATTERN)]
     graduated = [l for l in lessons if l.state not in (LessonState.INSTINCT, LessonState.PATTERN)]
     return active, graduated
-
-

--- a/Gradata/src/gradata/enhancements/similarity.py
+++ b/Gradata/src/gradata/enhancements/similarity.py
@@ -26,18 +26,100 @@ from collections import Counter
 # Tokenization
 # ---------------------------------------------------------------------------
 
-_STOP_WORDS = frozenset({
-    "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
-    "have", "has", "had", "do", "does", "did", "will", "would", "shall",
-    "should", "may", "can", "could", "might", "to", "of", "in", "for",
-    "on", "with", "at", "by", "from", "as", "into", "about", "that",
-    "this", "it", "its", "and", "or", "but", "not", "no", "if", "so",
-    "than", "too", "very", "just", "also", "then", "now", "here",
-    "i", "you", "we", "they", "he", "she", "me", "my", "your", "our",
-    "their", "his", "her", "us", "them", "up", "out", "all", "am",
-    "make", "more", "less", "get", "put", "use", "new", "old", "way",
-    "change", "changed", "content", "added", "cut", "edit", "edits",
-})
+_STOP_WORDS = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "being",
+        "have",
+        "has",
+        "had",
+        "do",
+        "does",
+        "did",
+        "will",
+        "would",
+        "shall",
+        "should",
+        "may",
+        "can",
+        "could",
+        "might",
+        "to",
+        "of",
+        "in",
+        "for",
+        "on",
+        "with",
+        "at",
+        "by",
+        "from",
+        "as",
+        "into",
+        "about",
+        "that",
+        "this",
+        "it",
+        "its",
+        "and",
+        "or",
+        "but",
+        "not",
+        "no",
+        "if",
+        "so",
+        "than",
+        "too",
+        "very",
+        "just",
+        "also",
+        "then",
+        "now",
+        "here",
+        "i",
+        "you",
+        "we",
+        "they",
+        "he",
+        "she",
+        "me",
+        "my",
+        "your",
+        "our",
+        "their",
+        "his",
+        "her",
+        "us",
+        "them",
+        "up",
+        "out",
+        "all",
+        "am",
+        "make",
+        "more",
+        "less",
+        "get",
+        "put",
+        "use",
+        "new",
+        "old",
+        "way",
+        "change",
+        "changed",
+        "content",
+        "added",
+        "cut",
+        "edit",
+        "edits",
+    }
+)
 
 
 def _tokenize(text: str) -> list[str]:
@@ -49,6 +131,7 @@ def _tokenize(text: str) -> list[str]:
 # ---------------------------------------------------------------------------
 # TF-IDF Cosine Similarity (zero deps)
 # ---------------------------------------------------------------------------
+
 
 def _tf(tokens: list[str]) -> dict[str, float]:
     """Term frequency: count / total."""
@@ -63,12 +146,11 @@ def _cosine(v1: dict[str, float], v2: dict[str, float]) -> float:
     if not common:
         return 0.0
     dot = sum(v1[k] * v2[k] for k in common)
-    mag1 = math.sqrt(sum(v ** 2 for v in v1.values()))
-    mag2 = math.sqrt(sum(v ** 2 for v in v2.values()))
+    mag1 = math.sqrt(sum(v**2 for v in v1.values()))
+    mag2 = math.sqrt(sum(v**2 for v in v2.values()))
     if mag1 == 0 or mag2 == 0:
         return 0.0
     return dot / (mag1 * mag2)
-
 
 
 # ---------------------------------------------------------------------------
@@ -80,7 +162,9 @@ _SYNONYM_GROUPS: list[frozenset[str]] = [
     frozenset({"direct", "blunt", "concise", "short", "brief", "terse", "tight"}),
     frozenset({"formal", "formalized", "professional", "polished", "proper"}),
     frozenset({"casual", "casualized", "informal", "relaxed", "conversational"}),
-    frozenset({"hedge", "hedging", "might", "maybe", "perhaps", "probably", "possibly", "potentially"}),
+    frozenset(
+        {"hedge", "hedging", "might", "maybe", "perhaps", "probably", "possibly", "potentially"}
+    ),
     frozenset({"fluff", "filler", "wordy", "verbose", "bloated", "long", "lengthy"}),
     frozenset({"specific", "concrete", "precise", "exact", "detailed", "measurable"}),
     frozenset({"vague", "generic", "abstract", "unclear", "ambiguous"}),
@@ -99,10 +183,14 @@ _SYNONYM_GROUPS: list[frozenset[str]] = [
 # NOT same-intent pairs. They must NOT be mapped together or contradictory
 # corrections will silently reinforce each other.
 _INTENT_PAIRS: list[tuple[frozenset[str], frozenset[str]]] = [
-    (frozenset({"hedging", "hedge", "perhaps", "maybe", "might"}),
-     frozenset({"direct", "blunt", "assertive"})),
-    (frozenset({"fluff", "filler", "wordy", "verbose", "long"}),
-     frozenset({"short", "brief", "tight", "concise", "terse"})),
+    (
+        frozenset({"hedging", "hedge", "perhaps", "maybe", "might"}),
+        frozenset({"direct", "blunt", "assertive"}),
+    ),
+    (
+        frozenset({"fluff", "filler", "wordy", "verbose", "long"}),
+        frozenset({"short", "brief", "tight", "concise", "terse"}),
+    ),
 ]
 
 _SYNONYM_MAP: dict[str, str] = {}
@@ -152,13 +240,13 @@ _OLLAMA_BASE: str | None = None
 _EMBED_MODEL: str = "nomic-embed-text"
 
 
-
 def _get_embedding(text: str) -> list[float] | None:
     """Get embedding vector from Ollama (returns None if unavailable)."""
     if not _OLLAMA_BASE:
         return None
     try:
         import requests
+
         resp = requests.post(
             f"{_OLLAMA_BASE}/api/embed",
             json={"model": _EMBED_MODEL, "input": text},
@@ -202,3 +290,28 @@ def best_similarity(text1: str, text2: str) -> float:
     if emb is not None:
         return emb
     return semantic_similarity(text1, text2)
+
+
+def semantic_vector(text: str) -> dict[str, float]:
+    """Precompute the synonym-expanded TF vector for a string.
+
+    Exposed so callers that compare one probe against many stored strings
+    (e.g. the PATTERN -> RULE dedup gate) can precompute the stored-side
+    vectors once instead of per-comparison. Returns an empty dict on empty
+    input so ``similarity_from_vectors`` can short-circuit.
+    """
+    tokens = _expand_synonyms(_tokenize(text))
+    if not tokens:
+        return {}
+    return _tf(tokens)
+
+
+def similarity_from_vectors(v1: dict[str, float], v2: dict[str, float]) -> float:
+    """Cosine similarity over two vectors produced by :func:`semantic_vector`.
+
+    Returns ``0.0`` when either vector is empty, matching
+    :func:`semantic_similarity`.
+    """
+    if not v1 or not v2:
+        return 0.0
+    return _cosine(v1, v2)

--- a/Gradata/src/gradata/graph.py
+++ b/Gradata/src/gradata/graph.py
@@ -44,6 +44,7 @@ class GraphNode:
         state: Current lesson state (e.g. "INSTINCT", "PATTERN", "RULE").
         size: Visual size weight (based on confidence and fire_count).
     """
+
     id: str
     type: str
     label: str
@@ -70,6 +71,7 @@ class GraphEdge:
             - "same_category": weak link between same-category lessons
         weight: Edge weight for layout (higher = closer nodes).
     """
+
     source: str
     target: str
     relation: str
@@ -146,12 +148,15 @@ def build_learning_graph(
             category_groups[lesson.category] = []
         category_groups[lesson.category].append(node_id)
 
+    # O(1) id lookup instead of rescanning `nodes` for every node id below.
+    nodes_by_id: dict[str, GraphNode] = {n.id: n for n in nodes}
+
     # Build graduation edges (INSTINCT -> PATTERN -> RULE within same category)
     for _category, node_ids in category_groups.items():
         # Group by state
         by_state: dict[str, list[str]] = {}
         for nid in node_ids:
-            node = next(n for n in nodes if n.id == nid)
+            node = nodes_by_id[nid]
             if node.state not in by_state:
                 by_state[node.state] = []
             by_state[node.state].append(nid)
@@ -165,33 +170,40 @@ def build_learning_graph(
         for state_nodes in [instincts, patterns, rules]:
             for j in range(len(state_nodes)):
                 for k in range(j + 1, min(j + 3, len(state_nodes))):
-                    edges.append(GraphEdge(
-                        source=state_nodes[j],
-                        target=state_nodes[k],
-                        relation="same_category",
-                        weight=0.3,
-                    ))
+                    edges.append(
+                        GraphEdge(
+                            source=state_nodes[j],
+                            target=state_nodes[k],
+                            relation="same_category",
+                            weight=0.3,
+                        )
+                    )
 
         # Graduation edges: PATTERN nodes link to RULE nodes in same category
         for p_id in patterns:
             for r_id in rules:
-                edges.append(GraphEdge(
-                    source=p_id,
-                    target=r_id,
-                    relation="graduated_from",
-                    weight=0.8,
-                ))
+                edges.append(
+                    GraphEdge(
+                        source=p_id,
+                        target=r_id,
+                        relation="graduated_from",
+                        weight=0.8,
+                    )
+                )
 
         for i_id in instincts:
             for p_id in patterns[:2]:  # Limit connections
-                edges.append(GraphEdge(
-                    source=i_id,
-                    target=p_id,
-                    relation="graduated_from",
-                    weight=0.5,
-                ))
+                edges.append(
+                    GraphEdge(
+                        source=i_id,
+                        target=p_id,
+                        relation="graduated_from",
+                        weight=0.5,
+                    )
+                )
 
     # Build meta-rule nodes and edges
+    merged_into_targets: set[str] = set()
     for mr in meta_rules:
         mr_id = mr.get("id", f"meta_{len(nodes)}")
         principle = mr.get("principle", "")
@@ -218,24 +230,32 @@ def build_learning_graph(
             for i, lesson in enumerate(lessons):
                 lesson_key = f"{lesson.date}_{lesson.category}_{lesson.description[:20]}"
                 if src_id == lesson_key or src_id == lesson_id_map.get(i):
-                    edges.append(GraphEdge(
-                        source=lesson_id_map[i],
-                        target=mr_id,
-                        relation="merged_into",
-                        weight=1.0,
-                    ))
+                    edges.append(
+                        GraphEdge(
+                            source=lesson_id_map[i],
+                            target=mr_id,
+                            relation="merged_into",
+                            weight=1.0,
+                        )
+                    )
+                    merged_into_targets.add(mr_id)
                     break
 
-        # If no source lessons matched by ID, connect by category
-        if not any(e.target == mr_id for e in edges):
+        # If no source lessons matched by ID, connect by category.
+        # Previously used `any(e.target == mr_id for e in edges)` which was
+        # O(E) per meta-rule → O(M×E) overall. Tracked via set now.
+        if mr_id not in merged_into_targets:
             for cat in mr.get("source_categories", []):
                 for nid in category_groups.get(cat, [])[:3]:
-                    edges.append(GraphEdge(
-                        source=nid,
-                        target=mr_id,
-                        relation="merged_into",
-                        weight=0.6,
-                    ))
+                    edges.append(
+                        GraphEdge(
+                            source=nid,
+                            target=mr_id,
+                            relation="merged_into",
+                            weight=0.6,
+                        )
+                    )
+                    merged_into_targets.add(mr_id)
 
     return nodes, edges
 
@@ -293,16 +313,19 @@ def to_mermaid(
 
     # Node shapes by type
     shape_map = {
-        "lesson": ("([", "])",),     # Stadium shape
-        "rule": ("[[", "]]"),        # Subroutine shape
-        "meta_rule": ("{{", "}}"),   # Hexagon
-        "archived": ("(", ")"),      # Rounded
+        "lesson": (
+            "([",
+            "])",
+        ),  # Stadium shape
+        "rule": ("[[", "]]"),  # Subroutine shape
+        "meta_rule": ("{{", "}}"),  # Hexagon
+        "archived": ("(", ")"),  # Rounded
     }
 
     for node in sorted_nodes:
         open_b, close_b = shape_map.get(node.type, ("([", "])"))
         safe_label = node.label.replace('"', "'")[:40]
-        lines.append(f"    {node.id}{open_b}\"{safe_label}\"{close_b}")
+        lines.append(f'    {node.id}{open_b}"{safe_label}"{close_b}')
 
     # Render edges between visible nodes only
     style_map = {

--- a/Gradata/src/gradata/hooks/_base.py
+++ b/Gradata/src/gradata/hooks/_base.py
@@ -8,6 +8,7 @@ Every hook module follows this pattern:
     def main(data: dict) -> dict | None: ...
     if __name__ == "__main__": run_hook(main, HOOK_META)
 """
+
 from __future__ import annotations
 
 import json
@@ -85,6 +86,34 @@ def get_brain() -> Brain | None:
         return None
 
 
+def emit_hook_event(
+    event_type: str,
+    source: str,
+    data: dict,
+    brain_dir: str | None = None,
+) -> bool:
+    """Emit a brain event from a hook. Returns True on success, False otherwise.
+
+    Collapses the `resolve_brain_dir → BrainContext.from_brain_dir → emit`
+    boilerplate that every hook was repeating. All failures are swallowed — a
+    hook must never break a user's turn because the brain vault is missing.
+    """
+    if brain_dir is None:
+        brain_dir = resolve_brain_dir()
+    if not brain_dir:
+        return False
+    try:
+        from gradata._events import emit
+        from gradata._paths import BrainContext
+
+        ctx = BrainContext.from_brain_dir(brain_dir)
+        emit(event_type, source=source, data=data, ctx=ctx)
+        return True
+    except Exception as exc:
+        _log.debug("emit_hook_event(%s) failed: %s", event_type, exc)
+        return False
+
+
 def _record_telemetry(meta: dict, hook_name: str, payload: str | None) -> None:
     """Best-effort: append one JSONL line with bytes-out per hook invocation.
 
@@ -99,12 +128,14 @@ def _record_telemetry(meta: dict, hook_name: str, payload: str | None) -> None:
             return
         import time
 
-        line = json.dumps({
-            "ts": time.time(),
-            "event": meta.get("event", "?"),
-            "hook": hook_name,
-            "bytes": len(payload or ""),
-        })
+        line = json.dumps(
+            {
+                "ts": time.time(),
+                "event": meta.get("event", "?"),
+                "hook": hook_name,
+                "bytes": len(payload or ""),
+            }
+        )
         log_path = Path(brain_dir) / "telemetry.jsonl"
         with log_path.open("a", encoding="utf-8") as fh:
             fh.write(line + "\n")

--- a/Gradata/src/gradata/hooks/agent_graduation.py
+++ b/Gradata/src/gradata/hooks/agent_graduation.py
@@ -1,7 +1,8 @@
 """PostToolUse hook: emit AGENT_OUTCOME event after Agent tool completes."""
+
 from __future__ import annotations
 
-from gradata.hooks._base import resolve_brain_dir, run_hook
+from gradata.hooks._base import emit_hook_event, run_hook
 from gradata.hooks._profiles import Profile
 
 HOOK_META = {
@@ -14,40 +15,24 @@ HOOK_META = {
 
 def _infer_agent_type(data: dict) -> str:
     tool_input = data.get("tool_input", {})
-    return (
-        tool_input.get("subagent_type", "")
-        or tool_input.get("type", "")
-        or "general"
-    )
+    return tool_input.get("subagent_type", "") or tool_input.get("type", "") or "general"
 
 
 def main(data: dict) -> dict | None:
-    try:
-        brain_dir = resolve_brain_dir()
-        if not brain_dir:
-            return None
-
-        agent_type = _infer_agent_type(data)
-        output = data.get("tool_output", "") or ""
-        if isinstance(output, dict):
-            output = str(output)
-        preview = output[:200] if output else ""
-
-        from gradata._events import emit
-        from gradata._paths import BrainContext
-        ctx = BrainContext.from_brain_dir(brain_dir)
-        emit(
-            "AGENT_OUTCOME",
-            source="hook:agent_graduation",
-            data={
-                "agent_type": agent_type,
-                "output_preview": preview,
-                "output_length": len(output),
-            },
-            ctx=ctx,
-        )
-    except Exception:
-        pass
+    agent_type = _infer_agent_type(data)
+    output = data.get("tool_output", "") or ""
+    if isinstance(output, dict):
+        output = str(output)
+    preview = output[:200] if output else ""
+    emit_hook_event(
+        "AGENT_OUTCOME",
+        "hook:agent_graduation",
+        {
+            "agent_type": agent_type,
+            "output_preview": preview,
+            "output_length": len(output),
+        },
+    )
     return None
 
 

--- a/Gradata/src/gradata/hooks/claude_code.py
+++ b/Gradata/src/gradata/hooks/claude_code.py
@@ -18,24 +18,28 @@ import sys
 def install_hook(profile: str = "standard") -> None:
     """Add Gradata hooks to Claude Code settings."""
     from gradata.hooks._installer import install
+
     install(profile)
 
 
 def uninstall_hook() -> None:
     """Remove Gradata hooks from Claude Code settings."""
     from gradata.hooks._installer import uninstall
+
     uninstall()
 
 
 def hook_status() -> None:
     """Check if Gradata hooks are installed."""
     from gradata.hooks._installer import status
+
     status()
 
 
 def capture_correction() -> None:
     """Called by Claude Code hook — reads stdin for tool use context and records correction."""
     import logging
+
     _log = logging.getLogger("gradata.hooks")
 
     try:
@@ -50,10 +54,8 @@ def capture_correction() -> None:
     if tool_name not in ("Edit", "Write"):
         return
 
-    # Extract draft (old content) and final (new content) from tool input/output
+    # Extract draft (old content) and final (new content) from tool input
     tool_input = payload.get("tool_input", {})
-    payload.get("tool_output", "")
-
     old_string = tool_input.get("old_string", "")
     new_string = tool_input.get("new_string", "")
 
@@ -61,18 +63,19 @@ def capture_correction() -> None:
         return
 
     from gradata.hooks._base import resolve_brain_dir
+
     brain_dir = resolve_brain_dir()
     if not brain_dir:
         return
 
     try:
         from gradata import Brain
+
         brain = Brain(brain_dir)
         brain.correct(draft=old_string, final=new_string, category="CODE")
         _log.debug("Captured correction from Claude Code hook")
     except Exception as e:
         _log.debug("Hook capture failed: %s", e)
-
 
 
 # ---------------------------------------------------------------------------

--- a/Gradata/src/gradata/hooks/implicit_feedback.py
+++ b/Gradata/src/gradata/hooks/implicit_feedback.py
@@ -72,11 +72,20 @@ APPROVAL_PATTERNS = [
     re.compile(r"\bnailed it\b", re.I),
 ]
 
+# GAP: the output omitted something the user expected. Parity with the removed
+# JS implicit-feedback hook (hook-overlap audit 2026-04-21, Tier A item 5).
+GAP_PATTERNS = [
+    re.compile(r"\bwhat about\b", re.I),
+    re.compile(r"\byou (forgot|missed|skipped|dropped|ignored)\b", re.I),
+    re.compile(r"\bdid (you|u) (check|verify|test|review)\b", re.I),
+]
+
 SIGNAL_MAP = {
     "negation": NEGATION_PATTERNS,
     "reminder": REMINDER_PATTERNS,
     "challenge": CHALLENGE_PATTERNS,
     "approval": APPROVAL_PATTERNS,
+    "gap": GAP_PATTERNS,
 }
 
 

--- a/Gradata/src/gradata/hooks/implicit_feedback.py
+++ b/Gradata/src/gradata/hooks/implicit_feedback.py
@@ -88,6 +88,15 @@ SIGNAL_MAP = {
     "gap": GAP_PATTERNS,
 }
 
+# Any of these signals means the prior output was NOT tacitly accepted.
+_NEGATIVE_SIGNAL_TYPES = {"negation", "reminder", "challenge", "gap"}
+
+# Tacit-acceptance threshold: substantive follow-up messages without negative
+# signals imply the prior output was OK. Short messages ("ok", "thanks", "go")
+# are too ambiguous — they might be mid-sentence fragments or acknowledgements
+# unrelated to the last output.
+_TACIT_MIN_LENGTH = 30
+
 
 def _detect_signals(text: str) -> list[dict]:
     signals = []
@@ -116,10 +125,17 @@ def main(data: dict) -> dict | None:
             return None
 
         signals = _detect_signals(message)
-        if not signals:
+        signal_types = {s["type"] for s in signals}
+        has_negative = bool(signal_types & _NEGATIVE_SIGNAL_TYPES)
+        has_approval = "approval" in signal_types
+        # Tacit acceptance: substantive follow-up with no negative signals. The
+        # brain.correct() pipeline logs ~20x more CORRECTION than OUTPUT_ACCEPTED
+        # because users rarely type "looks good" — silence is approval.
+        tacit_accept = not has_negative and not has_approval and len(message) >= _TACIT_MIN_LENGTH
+
+        if not signals and not tacit_accept:
             return None
 
-        # Emit event if brain dir available
         brain_dir = resolve_brain_dir()
 
         if brain_dir:
@@ -128,23 +144,34 @@ def main(data: dict) -> dict | None:
                 from gradata._paths import BrainContext
 
                 ctx = BrainContext.from_brain_dir(brain_dir)
-                emit(
-                    "IMPLICIT_FEEDBACK",
-                    source="hook:implicit_feedback",
-                    data={
-                        "signals": [s["type"] for s in signals],
-                        "snippets": [s["snippet"] for s in signals[:3]],
-                        "message_preview": message[:200],
-                    },
-                    ctx=ctx,
-                )
-                # Emit OUTPUT_ACCEPTED for approval signals
-                if any(s["type"] == "approval" for s in signals):
+                if signals:
+                    emit(
+                        "IMPLICIT_FEEDBACK",
+                        source="hook:implicit_feedback",
+                        data={
+                            "signals": [s["type"] for s in signals],
+                            "snippets": [s["snippet"] for s in signals[:3]],
+                            "message_preview": message[:200],
+                        },
+                        ctx=ctx,
+                    )
+                if has_approval:
                     emit(
                         "OUTPUT_ACCEPTED",
                         source="hook:implicit_feedback",
                         data={
+                            "mode": "explicit",
                             "snippets": [s["snippet"] for s in signals if s["type"] == "approval"],
+                            "message_preview": message[:200],
+                        },
+                        ctx=ctx,
+                    )
+                elif tacit_accept:
+                    emit(
+                        "OUTPUT_ACCEPTED",
+                        source="hook:implicit_feedback",
+                        data={
+                            "mode": "tacit",
                             "message_preview": message[:200],
                         },
                         ctx=ctx,
@@ -152,8 +179,10 @@ def main(data: dict) -> dict | None:
             except Exception as exc:
                 _log.debug("implicit_feedback emit failed: %s", exc)
 
-        signal_names = ", ".join(s["type"] for s in signals)
-        return {"result": f"IMPLICIT FEEDBACK: [{signal_names}]"}
+        if signals:
+            signal_names = ", ".join(s["type"] for s in signals)
+            return {"result": f"IMPLICIT FEEDBACK: [{signal_names}]"}
+        return None
     except Exception as exc:
         _log.debug("implicit_feedback hook error: %s", exc)
         return None

--- a/Gradata/src/gradata/hooks/implicit_feedback.py
+++ b/Gradata/src/gradata/hooks/implicit_feedback.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import re
 
-from gradata.hooks._base import extract_message, resolve_brain_dir, run_hook
+from gradata.hooks._base import emit_hook_event, extract_message, run_hook
 from gradata.hooks._profiles import Profile
 
 _log = logging.getLogger(__name__)
@@ -136,48 +136,32 @@ def main(data: dict) -> dict | None:
         if not signals and not tacit_accept:
             return None
 
-        brain_dir = resolve_brain_dir()
-
-        if brain_dir:
-            try:
-                from gradata._events import emit
-                from gradata._paths import BrainContext
-
-                ctx = BrainContext.from_brain_dir(brain_dir)
-                if signals:
-                    emit(
-                        "IMPLICIT_FEEDBACK",
-                        source="hook:implicit_feedback",
-                        data={
-                            "signals": [s["type"] for s in signals],
-                            "snippets": [s["snippet"] for s in signals[:3]],
-                            "message_preview": message[:200],
-                        },
-                        ctx=ctx,
-                    )
-                if has_approval:
-                    emit(
-                        "OUTPUT_ACCEPTED",
-                        source="hook:implicit_feedback",
-                        data={
-                            "mode": "explicit",
-                            "snippets": [s["snippet"] for s in signals if s["type"] == "approval"],
-                            "message_preview": message[:200],
-                        },
-                        ctx=ctx,
-                    )
-                elif tacit_accept:
-                    emit(
-                        "OUTPUT_ACCEPTED",
-                        source="hook:implicit_feedback",
-                        data={
-                            "mode": "tacit",
-                            "message_preview": message[:200],
-                        },
-                        ctx=ctx,
-                    )
-            except Exception as exc:
-                _log.debug("implicit_feedback emit failed: %s", exc)
+        if signals:
+            emit_hook_event(
+                "IMPLICIT_FEEDBACK",
+                "hook:implicit_feedback",
+                {
+                    "signals": [s["type"] for s in signals],
+                    "snippets": [s["snippet"] for s in signals[:3]],
+                    "message_preview": message[:200],
+                },
+            )
+        if has_approval:
+            emit_hook_event(
+                "OUTPUT_ACCEPTED",
+                "hook:implicit_feedback",
+                {
+                    "mode": "explicit",
+                    "snippets": [s["snippet"] for s in signals if s["type"] == "approval"],
+                    "message_preview": message[:200],
+                },
+            )
+        elif tacit_accept:
+            emit_hook_event(
+                "OUTPUT_ACCEPTED",
+                "hook:implicit_feedback",
+                {"mode": "tacit", "message_preview": message[:200]},
+            )
 
         if signals:
             signal_names = ", ".join(s["type"] for s in signals)

--- a/Gradata/src/gradata/hooks/implicit_feedback.py
+++ b/Gradata/src/gradata/hooks/implicit_feedback.py
@@ -74,9 +74,12 @@ APPROVAL_PATTERNS = [
 
 # GAP: the output omitted something the user expected. Parity with the removed
 # JS implicit-feedback hook (hook-overlap audit 2026-04-21, Tier A item 5).
+# NOTE: `forgot|missed` are owned by CHALLENGE_PATTERNS above; the gap variant
+# uses `skipped|dropped|ignored` only so _detect_signals() can't emit both
+# `gap` and `challenge` for the same phrase.
 GAP_PATTERNS = [
     re.compile(r"\bwhat about\b", re.I),
-    re.compile(r"\byou (forgot|missed|skipped|dropped|ignored)\b", re.I),
+    re.compile(r"\byou (skipped|dropped|ignored)\b", re.I),
     re.compile(r"\bdid (you|u) (check|verify|test|review)\b", re.I),
 ]
 
@@ -94,8 +97,39 @@ _NEGATIVE_SIGNAL_TYPES = {"negation", "reminder", "challenge", "gap"}
 # Tacit-acceptance threshold: substantive follow-up messages without negative
 # signals imply the prior output was OK. Short messages ("ok", "thanks", "go")
 # are too ambiguous — they might be mid-sentence fragments or acknowledgements
-# unrelated to the last output.
-_TACIT_MIN_LENGTH = 30
+# unrelated to the last output. Questions are NOT tacit acceptance either —
+# they usually signal confusion or follow-up work.
+_TACIT_MIN_LENGTH = 60
+_QUESTION_PREFIXES = (
+    "what",
+    "why",
+    "how",
+    "when",
+    "where",
+    "who",
+    "which",
+    "can",
+    "could",
+    "should",
+    "would",
+    "will",
+    "is",
+    "are",
+    "do",
+    "does",
+    "did",
+)
+
+
+def _looks_like_question(message: str) -> bool:
+    """Heuristic: message is a question (not tacit acceptance)."""
+    stripped = message.strip()
+    if not stripped:
+        return False
+    if stripped.endswith("?"):
+        return True
+    first_word = stripped.split(None, 1)[0].lower().rstrip(",.!:;")
+    return first_word in _QUESTION_PREFIXES
 
 
 def _detect_signals(text: str) -> list[dict]:
@@ -131,7 +165,12 @@ def main(data: dict) -> dict | None:
         # Tacit acceptance: substantive follow-up with no negative signals. The
         # brain.correct() pipeline logs ~20x more CORRECTION than OUTPUT_ACCEPTED
         # because users rarely type "looks good" — silence is approval.
-        tacit_accept = not has_negative and not has_approval and len(message) >= _TACIT_MIN_LENGTH
+        tacit_accept = (
+            not has_negative
+            and not has_approval
+            and len(message) >= _TACIT_MIN_LENGTH
+            and not _looks_like_question(message)
+        )
 
         if not signals and not tacit_accept:
             return None

--- a/Gradata/src/gradata/hooks/self_review.py
+++ b/Gradata/src/gradata/hooks/self_review.py
@@ -3,13 +3,14 @@
 After Write/Edit tool calls, checks if the output respects mandatory
 rules. Logs violations for the learning pipeline without blocking execution.
 """
+
 from __future__ import annotations
 
 import logging
 import re
 from pathlib import Path
 
-from gradata.hooks._base import resolve_brain_dir, run_hook
+from gradata.hooks._base import emit_hook_event, resolve_brain_dir, run_hook
 from gradata.hooks._profiles import Profile
 
 _log = logging.getLogger(__name__)
@@ -24,9 +25,7 @@ HOOK_META = {
 _REVIEWED_TOOLS = frozenset({"Write", "Edit", "MultiEdit"})
 
 # Regex to pull the banned token out of "never use/do/create/add/include <X>"
-_NEVER_RE = re.compile(
-    r"never\s+(?:use|do|create|add|include)\s+(.+)", re.I
-)
+_NEVER_RE = re.compile(r"never\s+(?:use|do|create|add|include)\s+(.+)", re.I)
 
 # Process-level cache: (brain_dir, mtime) → parsed mandatory rules
 _rules_cache: dict[tuple[str, float], list[dict]] = {}
@@ -50,9 +49,7 @@ def _load_mandatory_rules(brain_dir: str) -> list[dict]:
         result = [
             {"description": l.description, "category": l.category}
             for l in lessons
-            if l.state == LessonState.RULE
-            and l.confidence >= 0.90
-            and l.fire_count >= 10
+            if l.state == LessonState.RULE and l.confidence >= 0.90 and l.fire_count >= 10
         ]
         _rules_cache.clear()
         _rules_cache[cache_key] = result
@@ -104,25 +101,18 @@ def _check_rule_compliance(
 
 def _log_violations(brain_dir: str, violations: list[dict]) -> None:
     """Emit SELF_REVIEW_VIOLATION events so the learning pipeline can record them."""
-    try:
-        from gradata._events import emit
-        from gradata._paths import BrainContext
-
-        ctx = BrainContext.from_brain_dir(brain_dir)
-        for v in violations:
-            emit(
-                "SELF_REVIEW_VIOLATION",
-                source="hook:self_review",
-                data={
-                    "rule": v["rule"],
-                    "category": v["category"],
-                    "evidence": v["evidence"],
-                    "severity": v["severity"],
-                },
-                ctx=ctx,
-            )
-    except Exception as exc:
-        _log.debug("_log_violations emit failed: %s", exc)
+    for v in violations:
+        emit_hook_event(
+            "SELF_REVIEW_VIOLATION",
+            "hook:self_review",
+            {
+                "rule": v["rule"],
+                "category": v["category"],
+                "evidence": v["evidence"],
+                "severity": v["severity"],
+            },
+            brain_dir=brain_dir,
+        )
 
 
 def _extract_output_text(data: dict) -> str:

--- a/Gradata/src/gradata/hooks/session_close.py
+++ b/Gradata/src/gradata/hooks/session_close.py
@@ -303,8 +303,19 @@ def _resolve_pending_applications(brain_dir: str, data: dict) -> None:
                 if category and category in rejecting_categories:
                     outcome = "REJECTED"
                 elif lesson_desc:
+                    # Require a long-enough substring to avoid false-positive
+                    # REJECT matches on shared prefixes like "never hardcode ".
+                    normalized_lesson = lesson_desc.strip().lower()
                     for desc in rejecting_descriptions:
-                        if desc and desc[:30] and desc[:30] in lesson_desc:
+                        if not desc:
+                            continue
+                        normalized_desc = desc.strip().lower()
+                        if len(normalized_desc) < 40:
+                            continue
+                        if (
+                            normalized_desc in normalized_lesson
+                            or normalized_lesson in normalized_desc
+                        ):
                             outcome = "REJECTED"
                             break
                 updates.append((outcome, row_id))

--- a/Gradata/src/gradata/hooks/session_close.py
+++ b/Gradata/src/gradata/hooks/session_close.py
@@ -303,21 +303,27 @@ def _resolve_pending_applications(brain_dir: str, data: dict) -> None:
                 if category and category in rejecting_categories:
                     outcome = "REJECTED"
                 elif lesson_desc:
-                    # Require a long-enough substring to avoid false-positive
-                    # REJECT matches on shared prefixes like "never hardcode ".
+                    # Require a long-enough substring on BOTH sides to avoid
+                    # false-positive REJECT matches on shared prefixes like
+                    # "never hardcode ". Gating only one side let a short
+                    # lesson description match a long rejecting description
+                    # (or vice-versa) via prefix containment.
                     normalized_lesson = lesson_desc.strip().lower()
-                    for desc in rejecting_descriptions:
-                        if not desc:
-                            continue
-                        normalized_desc = desc.strip().lower()
-                        if len(normalized_desc) < 40:
-                            continue
-                        if (
-                            normalized_desc in normalized_lesson
-                            or normalized_lesson in normalized_desc
-                        ):
-                            outcome = "REJECTED"
-                            break
+                    if len(normalized_lesson) < 40:
+                        pass
+                    else:
+                        for desc in rejecting_descriptions:
+                            if not desc:
+                                continue
+                            normalized_desc = desc.strip().lower()
+                            if len(normalized_desc) < 40:
+                                continue
+                            if (
+                                normalized_desc in normalized_lesson
+                                or normalized_lesson in normalized_desc
+                            ):
+                                outcome = "REJECTED"
+                                break
                 updates.append((outcome, row_id))
 
             conn.executemany(

--- a/Gradata/src/gradata/hooks/tool_failure_emit.py
+++ b/Gradata/src/gradata/hooks/tool_failure_emit.py
@@ -1,9 +1,10 @@
 """PostToolUse hook: detect tool failures and emit TOOL_FAILURE event."""
+
 from __future__ import annotations
 
 import re
 
-from gradata.hooks._base import resolve_brain_dir, run_hook
+from gradata.hooks._base import emit_hook_event, run_hook
 from gradata.hooks._profiles import Profile
 
 HOOK_META = {
@@ -20,7 +21,10 @@ ERROR_PATTERNS = [
     re.compile(r"\btraceback\b", re.I),
     re.compile(r"\bException\b"),
     re.compile(r"\bHTTP\s+[45]\d{2}\b"),
-    re.compile(r"\b[45]\d{2}\s+(Bad Request|Unauthorized|Forbidden|Not Found|Internal Server Error|Bad Gateway|Service Unavailable)\b", re.I),
+    re.compile(
+        r"\b[45]\d{2}\s+(Bad Request|Unauthorized|Forbidden|Not Found|Internal Server Error|Bad Gateway|Service Unavailable)\b",
+        re.I,
+    ),
     re.compile(r"\bECONNREFUSED\b"),
     re.compile(r"\brate limit\b", re.I),
 ]
@@ -68,24 +72,17 @@ def main(data: dict) -> dict | None:
         if not signals:
             return None
 
-        brain_dir = resolve_brain_dir()
-
-        if brain_dir:
-            from gradata._events import emit
-            from gradata._paths import BrainContext
-            ctx = BrainContext.from_brain_dir(brain_dir)
-            command = data.get("tool_input", {}).get("command", "")[:200]
-            emit(
-                "TOOL_FAILURE",
-                source="hook:tool_failure_emit",
-                data={
-                    "tool": "Bash",
-                    "signals": signals[:5],
-                    "command_preview": command,
-                    "output_preview": output[:300],
-                },
-                ctx=ctx,
-            )
+        command = data.get("tool_input", {}).get("command", "")[:200]
+        emit_hook_event(
+            "TOOL_FAILURE",
+            "hook:tool_failure_emit",
+            {
+                "tool": "Bash",
+                "signals": signals[:5],
+                "command_preview": command,
+                "output_preview": output[:300],
+            },
+        )
     except Exception:
         pass
     return None

--- a/Gradata/src/gradata/integrations/embeddings.py
+++ b/Gradata/src/gradata/integrations/embeddings.py
@@ -7,6 +7,7 @@ and single-linkage clustering for lesson deduplication.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import math
@@ -69,7 +70,11 @@ class EmbeddingClient:
         text_lower = text.lower()
         for i in range(len(text_lower) - 2):
             trigram = text_lower[i : i + 3]
-            h = hash(trigram)
+            # NOTE: use md5 (not Python's hash()) — built-in hash() is
+            # per-process randomized via PYTHONHASHSEED, which would make
+            # local embedding vectors non-deterministic across runs and
+            # silently corrupt cosine-similarity / clustering output.
+            h = int.from_bytes(hashlib.md5(trigram.encode("utf-8")).digest()[:8], "big")
             idx = h % self.dim
             vec[idx] += 1.0
         norm = math.sqrt(sum(v * v for v in vec))

--- a/Gradata/src/gradata/integrations/langchain_adapter.py
+++ b/Gradata/src/gradata/integrations/langchain_adapter.py
@@ -71,15 +71,15 @@ class BrainMemory:
             rules = self.brain.apply_brain_rules("general", {"task": str(user_input)[:100]})
             if rules:
                 parts.append(rules)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("apply_brain_rules failed: %s", exc)
 
         try:
             context = self.brain.context_for(str(user_input)[:200])
             if context:
                 parts.append(context)
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("context_for failed: %s", exc)
 
         return {self.memory_key: "\n\n".join(parts)}
 
@@ -101,8 +101,8 @@ class BrainMemory:
             try:
                 if hasattr(self.brain, "observe"):
                     self.brain.observe(messages)
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("brain.observe failed: %s", exc)
 
     def clear(self) -> None:
         """No-op for persistent brain memory."""

--- a/Gradata/src/gradata/integrations/openai_adapter.py
+++ b/Gradata/src/gradata/integrations/openai_adapter.py
@@ -59,6 +59,10 @@ def patch_openai(client: Any, brain_dir: str | Path = "./brain") -> Any:
             rules = brain.apply_brain_rules("general", {"task": user_msg[:100]})
 
             if rules:
+                # Clone messages + mutate the clone. Previously we mutated
+                # the caller's list/dicts in-place, which caused rules to
+                # accumulate on shared message arrays across repeat calls.
+                messages = [dict(m) for m in messages]
                 has_system = any(m.get("role") == "system" for m in messages)
                 if has_system:
                     for m in messages:
@@ -67,6 +71,11 @@ def patch_openai(client: Any, brain_dir: str | Path = "./brain") -> Any:
                             break
                 else:
                     messages.insert(0, {"role": "system", "content": rules})
+                # Route the cloned list through whichever param the caller used.
+                if "messages" in kwargs:
+                    kwargs["messages"] = messages
+                elif len(args) > 1:
+                    args = args[:1] + (messages,) + args[2:]
         except Exception as e:
             logger.debug("Rule injection skipped: %s", e)
 
@@ -77,9 +86,7 @@ def patch_openai(client: Any, brain_dir: str | Path = "./brain") -> Any:
             if ai_content:
                 brain.log_output(ai_content, output_type="chat")
                 if hasattr(brain, "observe"):
-                    brain.observe(
-                        [*messages, {"role": "assistant", "content": ai_content}]
-                    )
+                    brain.observe([*messages, {"role": "assistant", "content": ai_content}])
         except Exception as e:
             logger.debug("Response capture skipped: %s", e)
 

--- a/Gradata/src/gradata/mcp_server.py
+++ b/Gradata/src/gradata/mcp_server.py
@@ -318,11 +318,7 @@ def _dispatch(brain: Any, tool_name: str, arguments: dict[str, Any]) -> dict[str
             query = arguments.get("query", "")
             top_k = int(arguments.get("top_k", 5))
             results = brain.search(query, top_k=top_k)
-            return {
-                "content": [
-                    {"type": "text", "text": json.dumps(results, ensure_ascii=False)}
-                ]
-            }
+            return {"content": [{"type": "text", "text": json.dumps(results, ensure_ascii=False)}]}
 
         elif tool_name == "brain_correct":
             draft = arguments.get("draft", "")
@@ -339,11 +335,7 @@ def _dispatch(brain: Any, tool_name: str, arguments: dict[str, Any]) -> dict[str
                 "summary": data.get("summary", ""),
                 "ts": result.get("ts", ""),
             }
-            return {
-                "content": [
-                    {"type": "text", "text": json.dumps(summary, ensure_ascii=False)}
-                ]
-            }
+            return {"content": [{"type": "text", "text": json.dumps(summary, ensure_ascii=False)}]}
 
         elif tool_name == "brain_log_output":
             text = arguments.get("text", "")
@@ -355,38 +347,22 @@ def _dispatch(brain: Any, tool_name: str, arguments: dict[str, Any]) -> dict[str
                 for k, v in result.items()
                 if isinstance(v, (str, int, float, bool, list, dict, type(None)))
             }
-            return {
-                "content": [
-                    {"type": "text", "text": json.dumps(safe, ensure_ascii=False)}
-                ]
-            }
+            return {"content": [{"type": "text", "text": json.dumps(safe, ensure_ascii=False)}]}
 
         elif tool_name == "brain_manifest":
             manifest = brain.manifest()
-            return {
-                "content": [
-                    {"type": "text", "text": json.dumps(manifest, ensure_ascii=False)}
-                ]
-            }
+            return {"content": [{"type": "text", "text": json.dumps(manifest, ensure_ascii=False)}]}
 
         elif tool_name == "brain_health":
             health = brain.health()
-            return {
-                "content": [
-                    {"type": "text", "text": json.dumps(health, ensure_ascii=False)}
-                ]
-            }
+            return {"content": [{"type": "text", "text": json.dumps(health, ensure_ascii=False)}]}
 
         elif tool_name == "brain_pipeline_stats":
             if hasattr(brain, "_learning_pipeline") and brain._learning_pipeline:
                 stats = brain._learning_pipeline.stats()
             else:
                 stats = {"error": "Learning pipeline not initialized"}
-            return {
-                "content": [
-                    {"type": "text", "text": json.dumps(stats, ensure_ascii=False)}
-                ]
-            }
+            return {"content": [{"type": "text", "text": json.dumps(stats, ensure_ascii=False)}]}
 
         elif tool_name == "brain_context_bracket":
             if hasattr(brain, "_learning_pipeline") and brain._learning_pipeline:
@@ -403,9 +379,7 @@ def _dispatch(brain: Any, tool_name: str, arguments: dict[str, Any]) -> dict[str
             else:
                 bracket_info = {"bracket": "fresh", "remaining_ratio": 1.0}
             return {
-                "content": [
-                    {"type": "text", "text": json.dumps(bracket_info, ensure_ascii=False)}
-                ]
+                "content": [{"type": "text", "text": json.dumps(bracket_info, ensure_ascii=False)}]
             }
 
         elif tool_name == "brain_route_suggest":
@@ -425,28 +399,24 @@ def _dispatch(brain: Any, tool_name: str, arguments: dict[str, Any]) -> dict[str
             else:
                 route_info = {"error": "Learning pipeline not initialized"}
             return {
-                "content": [
-                    {"type": "text", "text": json.dumps(route_info, ensure_ascii=False)}
-                ]
+                "content": [{"type": "text", "text": json.dumps(route_info, ensure_ascii=False)}]
             }
 
         elif tool_name == "brain_capabilities":
             try:
                 from gradata._brain_manifest import _sdk_capabilities
+
                 caps = _sdk_capabilities()
             except ImportError:
                 caps = {"error": "Manifest module not available"}
-            return {
-                "content": [
-                    {"type": "text", "text": json.dumps(caps, ensure_ascii=False)}
-                ]
-            }
+            return {"content": [{"type": "text", "text": json.dumps(caps, ensure_ascii=False)}]}
 
         elif tool_name == "brain_benchmark":
             try:
                 import dataclasses
 
                 from gradata.contrib.enhancements.eval_benchmark import run_standard_benchmark
+
                 result = run_standard_benchmark()
                 result_dict = dataclasses.asdict(result)
                 # Remove individual case details for MCP response size
@@ -459,18 +429,19 @@ def _dispatch(brain: Any, tool_name: str, arguments: dict[str, Any]) -> dict[str
             except ImportError:
                 return {
                     "content": [
-                        {"type": "text", "text": json.dumps({"error": "Benchmark not available"}, ensure_ascii=False)}
+                        {
+                            "type": "text",
+                            "text": json.dumps(
+                                {"error": "Benchmark not available"}, ensure_ascii=False
+                            ),
+                        }
                     ]
                 }
 
         elif tool_name == "brain_briefing":
             try:
                 md = brain.briefing()
-                return {
-                    "content": [
-                        {"type": "text", "text": md}
-                    ]
-                }
+                return {"content": [{"type": "text", "text": md}]}
             except Exception as exc:
                 return {"error": str(exc)}
 
@@ -478,6 +449,8 @@ def _dispatch(brain: Any, tool_name: str, arguments: dict[str, Any]) -> dict[str
             return {"error": f"Unknown tool: {tool_name}"}
 
     except Exception as exc:
+        # Log with traceback so production failures are diagnosable.
+        _log.exception("_dispatch failed for tool=%s", tool_name)
         return {"error": str(exc)}
 
 
@@ -508,9 +481,7 @@ def _handle_tools_list(req_id: Any) -> dict[str, Any]:
     return _ok(req_id, {"tools": _TOOL_SCHEMAS})
 
 
-def _handle_tools_call(
-    req_id: Any, params: dict[str, Any], brain: Any
-) -> dict[str, Any]:
+def _handle_tools_call(req_id: Any, params: dict[str, Any], brain: Any) -> dict[str, Any]:
     """Dispatch a tool call and wrap the result."""
     tool_name = params.get("name", "")
     arguments = params.get("arguments") or {}
@@ -555,6 +526,7 @@ def run_server(brain_dir: str | Path | None, *, stdin=None, stdout=None) -> None
     # Auto-detect brain dir if not provided
     if brain_dir is None:
         import os
+
         brain_dir = os.environ.get("BRAIN_DIR")
         if brain_dir is None:
             # Default: ~/.gradata/brain

--- a/Gradata/src/gradata/middleware/_core.py
+++ b/Gradata/src/gradata/middleware/_core.py
@@ -48,8 +48,7 @@ class RuleViolation(Exception):  # noqa: N818 — public API name specified in s
         self.pattern_name = pattern_name
         self.output = output
         super().__init__(
-            f"RuleViolation: output matched '{pattern_name}' "
-            f"(rule: {rule_description!r})"
+            f"RuleViolation: output matched '{pattern_name}' (rule: {rule_description!r})"
         )
 
 
@@ -122,6 +121,10 @@ class RuleSource:
         self._static_lessons = lessons
         self.max_rules = max_rules
         self.min_confidence = min_confidence
+        # mtime-keyed cache of parsed+filtered lessons. Without it, each
+        # `load()` call re-reads and re-parses lessons.md — a per-LLM-call hit
+        # in middleware (on_llm_start / on_llm_end both call into this).
+        self._cache: tuple[float, list[_ScoredLesson]] | None = None
 
     # -- loading ----------------------------------------------------------
 
@@ -155,7 +158,8 @@ class RuleSource:
                 # Malformed caller-supplied lessons (e.g. confidence="high")
                 # must not abort the whole injection/enforcement path.
                 _log.debug(
-                    "Skipping lesson with non-numeric confidence %r", raw_conf,
+                    "Skipping lesson with non-numeric confidence %r",
+                    raw_conf,
                 )
                 continue
             category = str(lesson.get("category", "") or "")
@@ -173,13 +177,32 @@ class RuleSource:
         return out
 
     def load(self) -> list[_ScoredLesson]:
-        """Return eligible lessons (RULE/PATTERN only, above min_confidence)."""
-        lessons = (
-            self._load_from_dicts() if self._static_lessons is not None
-            else self._load_from_brain()
-        )
+        """Return eligible lessons (RULE/PATTERN only, above min_confidence).
+
+        Results are mtime-cached when sourced from a brain lessons.md file.
+        Static-dict callers pay nothing extra — parsing is already trivial.
+        """
+        if self._static_lessons is None and self._brain_path is not None:
+            path = self._brain_path / "lessons.md"
+            try:
+                mtime = path.stat().st_mtime
+            except OSError:
+                mtime = -1.0
+            if self._cache is not None and self._cache[0] == mtime:
+                return self._cache[1]
+            lessons = self._load_from_brain()
+            filtered = [
+                l
+                for l in lessons
+                if l.state in ("RULE", "PATTERN") and l.confidence >= self.min_confidence
+            ]
+            self._cache = (mtime, filtered)
+            return filtered
+
+        lessons = self._load_from_dicts()
         return [
-            l for l in lessons
+            l
+            for l in lessons
             if l.state in ("RULE", "PATTERN") and l.confidence >= self.min_confidence
         ]
 
@@ -253,10 +276,7 @@ def build_brain_rules_block(source: RuleSource) -> str:
     selected = source.select()
     if not selected:
         return ""
-    lines = [
-        f"[{l.state}:{l.confidence:.2f}] {l.category}: {l.description}"
-        for l in selected
-    ]
+    lines = [f"[{l.state}:{l.confidence:.2f}] {l.category}: {l.description}" for l in selected]
     return "<brain-rules>\n" + "\n".join(lines) + "\n</brain-rules>"
 
 
@@ -293,7 +313,9 @@ def check_output(source: RuleSource, text: str, *, strict: bool = False) -> list
             if strict:
                 raise v
             _log.warning(
-                "Gradata rule violation (%s): %s", name, lesson.description,
+                "Gradata rule violation (%s): %s",
+                name,
+                lesson.description,
             )
             violations.append(v)
     return violations

--- a/Gradata/src/gradata/rules/rule_engine/_engine.py
+++ b/Gradata/src/gradata/rules/rule_engine/_engine.py
@@ -29,6 +29,7 @@ from ._scoring import (
     detect_task_type,
     effective_confidence,
     is_rule_disabled_for_domain,
+    lesson_scope,
     validate_assumptions,
 )
 
@@ -148,18 +149,7 @@ def filter_by_scope(
         # wildcard scope, which returns a score driven purely by what the query
         # provides.  When lessons gain explicit scope metadata in a future
         # iteration, this derivation logic should be updated.
-        # Use lesson's stored scope if available, otherwise wildcard
-        if lesson.scope_json:
-            try:
-                scope_dict = json.loads(lesson.scope_json)
-                lesson_scope = RuleScope(
-                    **{k: v for k, v in scope_dict.items() if k in RuleScope.__dataclass_fields__}
-                )
-            except Exception:
-                lesson_scope = RuleScope()
-        else:
-            lesson_scope = RuleScope()
-        score = compute_scope_weight(lesson_scope, scope)
+        score = compute_scope_weight(lesson_scope(lesson), scope)
         if score >= min_relevance:
             results.append((lesson, score))
     return results
@@ -274,19 +264,8 @@ def apply_rules(
     # Step 2 & 3 — score with weighted scope matching and threshold
     scored: list[tuple[Lesson, float]] = []
     for lesson in eligible:
-        # Use lesson's stored scope if available, otherwise wildcard
-        if lesson.scope_json:
-            try:
-                scope_dict = json.loads(lesson.scope_json)
-                lesson_scope = RuleScope(
-                    **{k: v for k, v in scope_dict.items() if k in RuleScope.__dataclass_fields__}
-                )
-            except Exception:
-                lesson_scope = RuleScope()
-        else:
-            lesson_scope = RuleScope()
         # Use weighted scope matching (exact > partial > wildcard)
-        relevance = compute_scope_weight(lesson_scope, scope)
+        relevance = compute_scope_weight(lesson_scope(lesson), scope)
         relevance *= _CT_BOOST.get(lesson.correction_type, 1.0)
         if relevance >= 0.4:
             scored.append((lesson, relevance))

--- a/Gradata/src/gradata/rules/rule_engine/_engine.py
+++ b/Gradata/src/gradata/rules/rule_engine/_engine.py
@@ -345,13 +345,26 @@ def apply_rules(
             scores.get("misfires", 0),
         )
 
+    # Pre-compute difficulty per category once: compute_rule_difficulty is
+    # O(E) per call, and calling it inside sort key was O(N × E). Collapse
+    # to O(E + N) by bucketing events per category first.
+    if events:
+        difficulty_by_cat: dict[str, float] = {}
+        unique_cats = {t[0].category.upper() for t in scored}
+        for cat in unique_cats:
+            difficulty_by_cat[cat] = compute_rule_difficulty(cat, events)
+
+        def _difficulty(lesson: Lesson) -> float:
+            return difficulty_by_cat.get(lesson.category.upper(), 0.5)
+    else:
+
+        def _difficulty(lesson: Lesson) -> float:
+            return _difficulty_from_lesson(lesson)
+
     scored.sort(
         key=lambda t: (
             _STATE_PRIORITY[t[0].state],
-            # Difficulty: use event history if available, else lesson counters
-            compute_rule_difficulty(t[0].category, events)
-            if events
-            else _difficulty_from_lesson(t[0]),
+            _difficulty(t[0]),
             t[1],
             _effective_conf(t[0], current_domain),
         ),
@@ -437,7 +450,10 @@ def apply_rules_with_tree(
     # Format as AppliedRule objects
     applied = []
     for lesson in candidates[:max_rules]:
-        rule_id = f"{lesson.category}:{hash(lesson.description) % 10000:04d}"
+        # Stable, deterministic ID — Python's built-in hash() is randomized
+        # per-process (PYTHONHASHSEED), which broke RuleCache/RuleGraph lookups
+        # keyed on rule_id across runs.
+        rule_id = _make_rule_id(lesson)
         instruction = (
             f'<rule confidence="{lesson.confidence:.2f}">'
             f"{lesson.category}: {lesson.description}</rule>"

--- a/Gradata/src/gradata/rules/rule_engine/_scoring.py
+++ b/Gradata/src/gradata/rules/rule_engine/_scoring.py
@@ -8,6 +8,7 @@ to rank and filter lessons before injection.
 from __future__ import annotations
 
 import json
+import logging
 
 from gradata._scope import RuleScope, scope_matches
 from gradata._types import CorrectionType, Lesson, LessonState, RuleTransferScope
@@ -373,7 +374,13 @@ def validate_assumptions(
                     False,
                     f"rule scoped to '{rule_tt}' but current task is '{current_tt}'",
                 )
-        except Exception:
-            pass  # malformed scope_json — don't block on it
+        except (json.JSONDecodeError, AttributeError) as exc:
+            # Malformed scope_json — don't block the rule, but surface at
+            # debug level so corrupted rows are visible in logs.
+            logging.getLogger(__name__).debug(
+                "validate_assumptions: bad scope_json for lesson=%s: %s",
+                getattr(lesson, "description", "?")[:40],
+                exc,
+            )
 
     return (True, "")

--- a/Gradata/src/gradata/rules/rule_engine/_scoring.py
+++ b/Gradata/src/gradata/rules/rule_engine/_scoring.py
@@ -8,7 +8,6 @@ to rank and filter lessons before injection.
 from __future__ import annotations
 
 import json
-import logging
 
 from gradata._scope import RuleScope, scope_matches
 from gradata._types import CorrectionType, Lesson, LessonState, RuleTransferScope
@@ -31,6 +30,30 @@ _CT_BOOST: dict[CorrectionType, float] = {
     CorrectionType.BEHAVIORAL: 1.1,
     CorrectionType.DOMAIN: 0.9,
 }
+
+
+# ---------------------------------------------------------------------------
+# Shared scope_json helpers
+# ---------------------------------------------------------------------------
+
+
+def lesson_scope(lesson: Lesson) -> RuleScope:
+    """Parse ``lesson.scope_json`` into a :class:`RuleScope`, wildcard on fail.
+
+    Centralises the try/loads/filter-to-known-fields pattern used by the
+    scoring helpers and the rule engine so bad JSON is handled uniformly
+    (and only logged once per callsite).
+    """
+    if not lesson.scope_json:
+        return RuleScope()
+    try:
+        scope_dict = json.loads(lesson.scope_json)
+    except (json.JSONDecodeError, TypeError):
+        return RuleScope()
+    if not isinstance(scope_dict, dict):
+        return RuleScope()
+    fields = RuleScope.__dataclass_fields__
+    return RuleScope(**{k: v for k, v in scope_dict.items() if k in fields})
 
 
 # ---------------------------------------------------------------------------
@@ -366,21 +389,11 @@ def validate_assumptions(
     # (c) Scope / task-type mismatch
     current_tt = context.get("current_task_type", "")
     if current_tt and lesson.scope_json:
-        try:
-            scope_dict = json.loads(lesson.scope_json)
-            rule_tt = scope_dict.get("task_type", "")
-            if rule_tt and rule_tt != current_tt:
-                return (
-                    False,
-                    f"rule scoped to '{rule_tt}' but current task is '{current_tt}'",
-                )
-        except (json.JSONDecodeError, AttributeError) as exc:
-            # Malformed scope_json — don't block the rule, but surface at
-            # debug level so corrupted rows are visible in logs.
-            logging.getLogger(__name__).debug(
-                "validate_assumptions: bad scope_json for lesson=%s: %s",
-                getattr(lesson, "description", "?")[:40],
-                exc,
+        rule_tt = lesson_scope(lesson).task_type or ""
+        if rule_tt and rule_tt != current_tt:
+            return (
+                False,
+                f"rule scoped to '{rule_tt}' but current task is '{current_tt}'",
             )
 
     return (True, "")

--- a/Gradata/src/gradata/rules/rule_graph.py
+++ b/Gradata/src/gradata/rules/rule_graph.py
@@ -241,27 +241,28 @@ def store_relationship(
     """
     clamped = max(0.0, min(1.0, confidence))
     _tid = tenant_for(Path(db_path).parent)
-    conn = sqlite3.connect(str(db_path))
-    # Defensive migration: brains created before migration 001 lack tenant_id.
-    with contextlib.suppress(sqlite3.OperationalError):
-        conn.execute("ALTER TABLE rule_relationships ADD COLUMN tenant_id TEXT")
-    with contextlib.suppress(sqlite3.OperationalError):
-        conn.execute("ALTER TABLE rule_relationships ADD COLUMN visibility TEXT DEFAULT 'private'")
-    conn.execute(
-        "INSERT INTO rule_relationships "
-        "(rule_a_id, rule_b_id, relationship, confidence, detected_at, tenant_id) "
-        "VALUES (?, ?, ?, ?, ?, ?)",
-        (
-            rule_a_id,
-            rule_b_id,
-            rel_type.value,
-            clamped,
-            datetime.now(UTC).isoformat(),
-            _tid,
-        ),
-    )
-    conn.commit()
-    conn.close()
+    with contextlib.closing(sqlite3.connect(str(db_path))) as conn:
+        # Defensive migration: brains created before migration 001 lack tenant_id.
+        with contextlib.suppress(sqlite3.OperationalError):
+            conn.execute("ALTER TABLE rule_relationships ADD COLUMN tenant_id TEXT")
+        with contextlib.suppress(sqlite3.OperationalError):
+            conn.execute(
+                "ALTER TABLE rule_relationships ADD COLUMN visibility TEXT DEFAULT 'private'"
+            )
+        conn.execute(
+            "INSERT INTO rule_relationships "
+            "(rule_a_id, rule_b_id, relationship, confidence, detected_at, tenant_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                rule_a_id,
+                rule_b_id,
+                rel_type.value,
+                clamped,
+                datetime.now(UTC).isoformat(),
+                _tid,
+            ),
+        )
+        conn.commit()
 
 
 def get_related_rules(
@@ -273,25 +274,23 @@ def get_related_rules(
 
     Returns list of dicts with keys: related_rule_id, relationship, confidence.
     """
-    conn = sqlite3.connect(str(db_path))
-    conn.row_factory = sqlite3.Row
+    with contextlib.closing(sqlite3.connect(str(db_path))) as conn:
+        conn.row_factory = sqlite3.Row
 
-    if rel_type is not None:
-        rows = conn.execute(
-            "SELECT rule_a_id, rule_b_id, relationship, confidence "
-            "FROM rule_relationships "
-            "WHERE (rule_a_id = ? OR rule_b_id = ?) AND relationship = ?",
-            (rule_id, rule_id, rel_type.value),
-        ).fetchall()
-    else:
-        rows = conn.execute(
-            "SELECT rule_a_id, rule_b_id, relationship, confidence "
-            "FROM rule_relationships "
-            "WHERE rule_a_id = ? OR rule_b_id = ?",
-            (rule_id, rule_id),
-        ).fetchall()
-
-    conn.close()
+        if rel_type is not None:
+            rows = conn.execute(
+                "SELECT rule_a_id, rule_b_id, relationship, confidence "
+                "FROM rule_relationships "
+                "WHERE (rule_a_id = ? OR rule_b_id = ?) AND relationship = ?",
+                (rule_id, rule_id, rel_type.value),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT rule_a_id, rule_b_id, relationship, confidence "
+                "FROM rule_relationships "
+                "WHERE rule_a_id = ? OR rule_b_id = ?",
+                (rule_id, rule_id),
+            ).fetchall()
 
     results = []
     for row in rows:

--- a/Gradata/src/gradata/rules/rule_tracker.py
+++ b/Gradata/src/gradata/rules/rule_tracker.py
@@ -142,22 +142,44 @@ class RuleApplication:
 
 
 def get_rule_history(db_path: Path, rule_id: str, limit: int = 20) -> list[dict]:
-    """Recent RULE_APPLICATION events for a specific rule."""
-    try:
-        from gradata._events import query
+    """Recent RULE_APPLICATION events for a specific rule.
 
-        events = query(event_type="RULE_APPLICATION", limit=500)
-        matching = [e for e in events if e.get("data", {}).get("rule_id") == rule_id]
+    Uses a direct SQL `tags_json LIKE` filter to avoid pulling 500 rows
+    and filtering Python-side — the rule_id is stored as a `rule:<id>`
+    tag at emit time, so we can push the selectivity into SQLite.
+    """
+    try:
+        import contextlib
+        import json
+        import sqlite3
+
+        from gradata import _paths as _p
+
+        with contextlib.closing(sqlite3.connect(str(db_path or _p.DB_PATH))) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                "SELECT * FROM events "
+                "WHERE type = 'RULE_APPLICATION' AND tags_json LIKE ? "
+                "ORDER BY id DESC LIMIT ?",
+                (f'%"rule:{rule_id}"%', limit),
+            ).fetchall()
+
         return [
             {
-                "rule_id": e["data"].get("rule_id", ""),
-                "session": e.get("session"),
-                "accepted": e["data"].get("accepted", False),
-                "misfired": e["data"].get("misfired", False),
-                "contradicted": e["data"].get("contradicted", False),
-                "ts": e.get("ts"),
+                "rule_id": rule_id,
+                "session": r["session"],
+                "accepted": (json.loads(r["data_json"]) if r["data_json"] else {}).get(
+                    "accepted", False
+                ),
+                "misfired": (json.loads(r["data_json"]) if r["data_json"] else {}).get(
+                    "misfired", False
+                ),
+                "contradicted": (json.loads(r["data_json"]) if r["data_json"] else {}).get(
+                    "contradicted", False
+                ),
+                "ts": r["ts"],
             }
-            for e in matching[:limit]
+            for r in rows
         ]
     except Exception as e:
         logging.getLogger("gradata.rule_tracker").warning(

--- a/Gradata/src/gradata/rules/rule_tree.py
+++ b/Gradata/src/gradata/rules/rule_tree.py
@@ -12,6 +12,7 @@ Usage:
 from __future__ import annotations
 
 import logging
+import zlib
 from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -376,7 +377,7 @@ def export_tree_obsidian(tree: RuleTree, vault_path: Path) -> None:
             filename = f"{slug}.md"
 
             content = f"""---
-id: {lesson.category}_{hash(lesson.description) % 10000:04d}
+id: {lesson.category}_{zlib.crc32(lesson.description.encode("utf-8")) % 10000:04d}
 confidence: {lesson.confidence}
 state: {lesson.state.value}
 path: {lesson.path}

--- a/Gradata/src/gradata/rules/scope.py
+++ b/Gradata/src/gradata/rules/scope.py
@@ -34,6 +34,7 @@ from enum import StrEnum
 # Audience Tiers
 # ---------------------------------------------------------------------------
 
+
 class AudienceTier(StrEnum):
     """Who the output is primarily written for.
 
@@ -42,59 +43,98 @@ class AudienceTier(StrEnum):
     """
 
     # Organizational hierarchy (applicable to any domain)
-    C_SUITE = "c_suite"          # CEO, CTO, CPO, Founder, Partner
-    VP = "vp"                    # VP-level, Head of …
-    DIRECTOR = "director"        # Director, Senior Director
-    MANAGER = "manager"          # Manager, Team Lead, Tech Lead
-    IC = "ic"                    # Individual contributor (engineer, analyst, etc.)
+    C_SUITE = "c_suite"  # CEO, CTO, CPO, Founder, Partner
+    VP = "vp"  # VP-level, Head of …
+    DIRECTOR = "director"  # Director, Senior Director
+    MANAGER = "manager"  # Manager, Team Lead, Tech Lead
+    IC = "ic"  # Individual contributor (engineer, analyst, etc.)
 
     # Recruiting / hiring
-    CANDIDATE = "candidate"      # Job applicant
+    CANDIDATE = "candidate"  # Job applicant
     INTERVIEWER = "interviewer"  # Hiring-side participant
 
     # Broad / cross-functional
     STAKEHOLDER = "stakeholder"  # Sponsor, approver, or any governance role
-    END_USER = "end_user"        # Direct consumer of the product or output
-    PEER = "peer"                # Same-level colleague or collaborator
+    END_USER = "end_user"  # Direct consumer of the product or output
+    PEER = "peer"  # Same-level colleague or collaborator
 
     # Fallback
-    UNKNOWN = "unknown"          # Could not determine audience
+    UNKNOWN = "unknown"  # Could not determine audience
 
 
 # Keyword sets used by classify_scope to detect audience from the raw query.
 _AUDIENCE_KEYWORDS: dict[AudienceTier, list[str]] = {
     AudienceTier.C_SUITE: [
-        "ceo", "cto", "cpo", "coo", "cfo", "founder", "co-founder", "owner",
-        "president", "partner", "executive", "c-suite", "board",
+        "ceo",
+        "cto",
+        "cpo",
+        "coo",
+        "cfo",
+        "founder",
+        "co-founder",
+        "owner",
+        "president",
+        "partner",
+        "executive",
+        "c-suite",
+        "board",
     ],
     AudienceTier.VP: [
-        "vp", "vice president", "head of", "svp", "evp",
+        "vp",
+        "vice president",
+        "head of",
+        "svp",
+        "evp",
     ],
     AudienceTier.DIRECTOR: [
-        "director", "senior director",
+        "director",
+        "senior director",
     ],
     AudienceTier.MANAGER: [
-        "manager", "team lead", "tech lead", "engineering manager",
-        "product manager", "project manager",
+        "manager",
+        "team lead",
+        "tech lead",
+        "engineering manager",
+        "product manager",
+        "project manager",
     ],
     AudienceTier.CANDIDATE: [
-        "candidate", "applicant", "interviewee", "job seeker",
+        "candidate",
+        "applicant",
+        "interviewee",
+        "job seeker",
     ],
     AudienceTier.INTERVIEWER: [
-        "interviewer", "hiring manager", "panel",
+        "interviewer",
+        "hiring manager",
+        "panel",
     ],
     AudienceTier.STAKEHOLDER: [
-        "stakeholder", "sponsor", "approver", "client", "customer",
+        "stakeholder",
+        "sponsor",
+        "approver",
+        "client",
+        "customer",
     ],
     AudienceTier.END_USER: [
-        "end user", "user", "consumer",
+        "end user",
+        "user",
+        "consumer",
     ],
     AudienceTier.PEER: [
-        "peer", "colleague", "teammate", "coworker",
+        "peer",
+        "colleague",
+        "teammate",
+        "coworker",
     ],
     AudienceTier.IC: [
-        "engineer", "developer", "analyst", "designer", "scientist",
-        "specialist", "contributor",
+        "engineer",
+        "developer",
+        "analyst",
+        "designer",
+        "scientist",
+        "specialist",
+        "contributor",
     ],
 }
 
@@ -102,6 +142,7 @@ _AUDIENCE_KEYWORDS: dict[AudienceTier, list[str]] = {
 # ---------------------------------------------------------------------------
 # Task Types
 # ---------------------------------------------------------------------------
+
 
 @dataclass(frozen=True)
 class TaskType:
@@ -137,8 +178,12 @@ DEFAULT_TASK_TYPES: list[TaskType] = [
     TaskType(
         name="interview_prep",
         keywords=[
-            "prepare for interview", "prep for interview", "interview prep",
-            "practice interview", "mock interview", "interview questions",
+            "prepare for interview",
+            "prep for interview",
+            "interview prep",
+            "practice interview",
+            "mock interview",
+            "interview questions",
             "before the interview",
         ],
         domain_hint="recruiting",
@@ -146,18 +191,25 @@ DEFAULT_TASK_TYPES: list[TaskType] = [
     TaskType(
         name="demo_prep",
         keywords=[
-            "prepare for demo", "prep for demo", "prep the demo",
-            "demo prep", "before the demo", "get ready for demo",
+            "prepare for demo",
+            "prep for demo",
+            "prep the demo",
+            "demo prep",
+            "before the demo",
+            "get ready for demo",
         ],
         domain_hint="sales",
     ),
-
     # ── Generic / cross-domain ──────────────────────────────────────────────
     TaskType(
         name="meeting_prep",
         keywords=[
-            "upcoming meeting", "meeting prep", "before the meeting",
-            "before the call", "ready for the call", "prepare for the meeting",
+            "upcoming meeting",
+            "meeting prep",
+            "before the meeting",
+            "before the call",
+            "ready for the call",
+            "prepare for the meeting",
             "prep for the meeting",
         ],
         domain_hint="",
@@ -165,24 +217,44 @@ DEFAULT_TASK_TYPES: list[TaskType] = [
     TaskType(
         name="research",
         keywords=[
-            "research", "look up", "find information", "gather info",
-            "background on", "learn about", "investigate",
+            "research",
+            "look up",
+            "find information",
+            "gather info",
+            "background on",
+            "learn about",
+            "investigate",
+            "find entities",
+            "find items",
+            "entity list",
+            "build a list",
+            "identify targets",
         ],
         domain_hint="",
     ),
     TaskType(
         name="content_creation",
         keywords=[
-            "write a post", "create content", "draft article", "blog post",
-            "social media", "newsletter", "write content", "create a draft",
+            "write a post",
+            "create content",
+            "draft article",
+            "blog post",
+            "social media",
+            "newsletter",
+            "write content",
+            "create a draft",
         ],
         domain_hint="",
     ),
     TaskType(
         name="report_generation",
         keywords=[
-            "generate report", "create report", "weekly report",
-            "monthly report", "status report", "write a report",
+            "generate report",
+            "create report",
+            "weekly report",
+            "monthly report",
+            "status report",
+            "write a report",
             "produce report",
         ],
         domain_hint="",
@@ -190,123 +262,173 @@ DEFAULT_TASK_TYPES: list[TaskType] = [
     TaskType(
         name="data_analysis",
         keywords=[
-            "analyze data", "analyse data", "data analysis", "run analysis",
-            "look at the data", "crunch", "trends in", "metrics",
-            "dashboard", "visualize",
+            "analyze data",
+            "analyse data",
+            "data analysis",
+            "run analysis",
+            "look at the data",
+            "crunch",
+            "trends in",
+            "metrics",
+            "dashboard",
+            "visualize",
         ],
         domain_hint="",
     ),
     TaskType(
         name="documentation",
         keywords=[
-            "write docs", "documentation", "document this", "update readme",
-            "api docs", "write up", "document the", "add docstring",
+            "write docs",
+            "documentation",
+            "document this",
+            "update readme",
+            "api docs",
+            "write up",
+            "document the",
+            "add docstring",
         ],
         domain_hint="",
     ),
     TaskType(
         name="summary",
         keywords=[
-            "summarize", "tldr", "tl;dr", "give me the highlights",
-            "key points", "brief overview",
+            "summarize",
+            "tldr",
+            "tl;dr",
+            "give me the highlights",
+            "key points",
+            "brief overview",
         ],
         domain_hint="",
     ),
     TaskType(
         name="planning",
         keywords=[
-            "plan", "roadmap", "strategy", "prioritize", "schedule",
-            "sprint", "backlog",
+            "plan",
+            "roadmap",
+            "strategy",
+            "prioritize",
+            "schedule",
+            "sprint",
+            "backlog",
         ],
         domain_hint="",
     ),
-
     # ── Engineering / developer ─────────────────────────────────────────────
     TaskType(
         name="code_review",
         keywords=[
-            "code review", "review this pr", "review the pr",
-            "review this pull request", "review pull request",
-            "look at this code", "check my code", "review code",
+            "code review",
+            "review this pr",
+            "review the pr",
+            "review this pull request",
+            "review pull request",
+            "look at this code",
+            "check my code",
+            "review code",
         ],
         domain_hint="engineering",
     ),
     TaskType(
         name="debugging",
         keywords=[
-            "debug", "fix this bug", "error", "traceback", "exception",
-            "not working", "broken", "failing test", "stack trace",
+            "debug",
+            "fix this bug",
+            "error",
+            "traceback",
+            "exception",
+            "not working",
+            "broken",
+            "failing test",
+            "stack trace",
         ],
         domain_hint="engineering",
     ),
     TaskType(
         name="design_review",
         keywords=[
-            "design review", "review the design", "architecture review",
-            "review this design", "system design", "erd", "schema review",
+            "design review",
+            "review the design",
+            "architecture review",
+            "review this design",
+            "system design",
+            "erd",
+            "schema review",
         ],
         domain_hint="engineering",
     ),
     TaskType(
         name="refactoring",
         keywords=[
-            "refactor", "clean up", "clean this up", "improve readability",
-            "simplify", "restructure",
+            "refactor",
+            "clean up",
+            "clean this up",
+            "improve readability",
+            "simplify",
+            "restructure",
         ],
         domain_hint="engineering",
     ),
-
     # ── Recruiting / talent ─────────────────────────────────────────────────
     # Note: interview_prep is defined earlier (before meeting_prep) to ensure
     # "prepare for interview" is matched before the generic "prepare for" group.
     TaskType(
         name="candidate_search",
         keywords=[
-            "find candidates", "search for candidates", "source candidates",
-            "research candidates", "look for talent", "talent search",
+            "find candidates",
+            "search for candidates",
+            "source candidates",
+            "research candidates",
+            "look for talent",
+            "talent search",
         ],
         domain_hint="recruiting",
     ),
     TaskType(
         name="job_description",
         keywords=[
-            "job description", "write jd", "write a jd", "job posting",
-            "job req", "job requisition",
+            "job description",
+            "write jd",
+            "write a jd",
+            "job posting",
+            "job req",
+            "job requisition",
         ],
         domain_hint="recruiting",
     ),
-
     # ── Sales (preserved for backward compatibility) ────────────────────────
     # Note: demo_prep is defined earlier (before meeting_prep) to ensure
     # "prepare for demo" is matched before the generic meeting-prep group.
     TaskType(
         name="email_draft",
         keywords=[
-            "draft email", "write email", "compose email",
-            "draft a message", "write outreach",
+            "draft email",
+            "write email",
+            "compose email",
+            "draft a message",
+            "write outreach",
         ],
         domain_hint="sales",
     ),
     TaskType(
-        name="research",
-        keywords=[
-            "find entities", "find items", "entity list",
-            "build a list", "identify targets",
-        ],
-        domain_hint="",
-    ),
-    TaskType(
         name="resistance_handling",
         keywords=[
-            "objection", "push back", "they said no", "handle objection",
-            "overcome", "rebuttal",
+            "objection",
+            "push back",
+            "they said no",
+            "handle objection",
+            "overcome",
+            "rebuttal",
         ],
         domain_hint="",
     ),
     TaskType(
         name="follow_up",
         keywords=[
-            "follow up", "check in", "touch base", "follow-up email",
+            "follow up",
+            "check in",
+            "touch base",
+            "follow-up email",
             "circle back",
         ],
         domain_hint="sales",
@@ -314,8 +436,12 @@ DEFAULT_TASK_TYPES: list[TaskType] = [
     TaskType(
         name="system_update",
         keywords=[
-            "update crm", "log a note", "crm note", "update system",
-            "update records", "deal note",
+            "update crm",
+            "log a note",
+            "crm note",
+            "update system",
+            "update records",
+            "deal note",
         ],
         domain_hint="",
     ),
@@ -372,10 +498,10 @@ def register_task_type(
         _REGISTERED_TASK_TYPES.append(entry)
 
 
-
 # ---------------------------------------------------------------------------
 # Classification helpers
 # ---------------------------------------------------------------------------
+
 
 def _detect_task_type(query_lower: str) -> str:
     """Return the name of the first matching TaskType, or ``"general"``."""
@@ -398,6 +524,7 @@ def _detect_audience(query_lower: str) -> AudienceTier:
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
 
 def classify_scope(query: str) -> tuple[str, AudienceTier]:
     """Classify a raw query into a task type name and an audience tier.

--- a/Gradata/src/gradata/sidecar/watcher.py
+++ b/Gradata/src/gradata/sidecar/watcher.py
@@ -42,10 +42,10 @@ logger = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-_SEVERITY_AS_IS = "as-is"        # edit_distance < 0.02
-_SEVERITY_MINOR = "minor"        # 0.02 <= edit_distance < 0.10
+_SEVERITY_AS_IS = "as-is"  # edit_distance < 0.02
+_SEVERITY_MINOR = "minor"  # 0.02 <= edit_distance < 0.10
 _SEVERITY_MODERATE = "moderate"  # 0.10 <= edit_distance < 0.40
-_SEVERITY_MAJOR = "major"        # 0.40 <= edit_distance < 0.80
+_SEVERITY_MAJOR = "major"  # 0.40 <= edit_distance < 0.80
 _SEVERITY_DISCARDED = "discarded"  # edit_distance >= 0.80
 
 _SOURCE = "sidecar:watcher"
@@ -253,6 +253,9 @@ class FileWatcher:
     ) -> None:
         self._watch_dir = Path(watch_dir).resolve()
         self._brain_db: Path | None = Path(brain_db).resolve() if brain_db else None
+        # Cached Brain instance — constructing one per emit opens a fresh
+        # SQLite connection that never gets closed. Build lazily once.
+        self._brain_instance = None
 
         # path -> WatchedFile; keyed by str(Path.resolve())
         self._watched: dict[str, WatchedFile] = {}
@@ -346,9 +349,7 @@ class FileWatcher:
             )
             return None
 
-        edit_distance = _normalise_edit_distance(
-            watched.original_content, current_content
-        )
+        edit_distance = _normalise_edit_distance(watched.original_content, current_content)
         severity = _ast_severity_or_none(
             watched.original_content, current_content, resolved
         ) or _classify_severity(edit_distance)
@@ -406,16 +407,14 @@ class FileWatcher:
 
         # Build the event payload
         watched = self._watched.get(change.path)
-        diff_text = _build_unified_diff(
-            change.old_content, change.new_content, change.path
-        )
+        diff_text = _build_unified_diff(change.old_content, change.new_content, change.path)
         event_data: dict = {
             "path": change.path,
             "output_type": watched.output_type if watched else "",
             "edit_distance": change.edit_distance,
             "severity": change.severity,
             "diff": diff_text,
-            "original": change.old_content[:500],    # truncated for DB storage
+            "original": change.old_content[:500],  # truncated for DB storage
             "modified": change.new_content[:500],
         }
         event_tags = [
@@ -484,9 +483,7 @@ class FileWatcher:
             while True:
                 changes = self.check_all()
                 if changes:
-                    logger.info(
-                        "Sweep %d: detected %d change(s)", iteration + 1, len(changes)
-                    )
+                    logger.info("Sweep %d: detected %d change(s)", iteration + 1, len(changes))
                 iteration += 1
                 if max_iterations and iteration >= max_iterations:
                     break
@@ -519,16 +516,21 @@ class FileWatcher:
         if self._brain_db is None:
             return {}
         try:
-            from gradata.brain import Brain
+            if self._brain_instance is None:
+                from gradata.brain import Brain
 
-            brain = Brain(self._brain_db)
+                self._brain_instance = Brain(self._brain_db)
+            brain = self._brain_instance
 
             # If Brain exposes a .correct() helper, use it; otherwise emit
             # a raw CORRECTION event so downstream analytics work.
             if hasattr(brain, "correct"):
-                return brain.correct(  # type: ignore[attr-defined]
-                    change.old_content, change.new_content
-                ) or {}
+                return (
+                    brain.correct(  # type: ignore[attr-defined]
+                        change.old_content, change.new_content
+                    )
+                    or {}
+                )
             return brain.emit("CORRECTION", _SOURCE, data, tags) or {}
         except Exception as exc:
             logger.debug("Brain emit failed: %s", exc)
@@ -584,9 +586,7 @@ class FileWatcher:
                 json.dumps(payload, indent=2, ensure_ascii=False),
                 encoding="utf-8",
             )
-            logger.warning(
-                "Fallback: CORRECTION written to %s", sidecar_path
-            )
+            logger.warning("Fallback: CORRECTION written to %s", sidecar_path)
             return {"type": "CORRECTION", "source": _SOURCE, "fallback_path": str(sidecar_path)}
         except OSError as exc:
             logger.error("All emission paths failed for %s: %s", change.path, exc)

--- a/Gradata/tests/conftest.py
+++ b/Gradata/tests/conftest.py
@@ -116,6 +116,30 @@ def _isolate_brain_dir_env():
         os.environ["BRAIN_DIR"] = prev
 
 
+# Hook kill-switch env vars from #133 — when set to "0" in a dev shell they
+# disable the corresponding hook. Tests assume hooks are enabled, so scrub
+# them process-wide for the duration of the session and restore on teardown.
+_HOOK_KILL_SWITCHES = (
+    "GRADATA_SECRET_SCAN",
+    "GRADATA_CONFIG_PROTECTION",
+    "GRADATA_SESSION_PERSIST",
+    "GRADATA_CONTEXT_INJECT",
+    "GRADATA_BRAIN_MAINTAIN",
+    "GRADATA_CONFIG_VALIDATE",
+    "GRADATA_DUPLICATE_GUARD",
+)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _unset_hook_kill_switches():
+    """Hermetic tests: never inherit the dev shell's kill-switch env."""
+    saved = {k: os.environ.pop(k, None) for k in _HOOK_KILL_SWITCHES}
+    yield
+    for k, v in saved.items():
+        if v is not None:
+            os.environ[k] = v
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/Gradata/tests/test_agentic_synthesis.py
+++ b/Gradata/tests/test_agentic_synthesis.py
@@ -2,6 +2,7 @@
 Tests for synthesize_meta_rules_agentic() — Feature 5 of the Gradata
 Behavioral Engine. Covers all 10 specified test cases.
 """
+
 from __future__ import annotations
 
 import sys
@@ -50,8 +51,7 @@ def _make_lesson(
 def _make_rule_group(category: str, n: int = 3, confidence: float = 0.92) -> list[Lesson]:
     """Return n RULE-state lessons in the same category."""
     return [
-        _make_lesson(category, f"Rule {i} for {category}", confidence=confidence)
-        for i in range(n)
+        _make_lesson(category, f"Rule {i} for {category}", confidence=confidence) for i in range(n)
     ]
 
 
@@ -93,7 +93,9 @@ def test_mixed_confidence_only_high_qualify():
     # 2 high-confidence + 3 low-confidence — only 2 qualify, not enough for a group
     high = _make_rule_group("ACCURACY", n=2, confidence=0.95)
     low = _make_rule_group("ACCURACY", n=3, confidence=0.85)
-    result = synthesize_meta_rules_agentic(lessons=high + low, min_confidence=0.90, min_group_size=3)
+    result = synthesize_meta_rules_agentic(
+        lessons=high + low, min_confidence=0.90, min_group_size=3
+    )
     assert result == []
 
 
@@ -301,7 +303,9 @@ def test_synthesis_evidence_defaults():
 
 def test_non_rule_state_lessons_excluded():
     """INSTINCT and PATTERN lessons must not contribute to synthesis."""
-    instinct = _make_lesson("DRAFTING", "Instinct lesson", confidence=0.92, state=LessonState.INSTINCT)
+    instinct = _make_lesson(
+        "DRAFTING", "Instinct lesson", confidence=0.92, state=LessonState.INSTINCT
+    )
     pattern = _make_lesson("DRAFTING", "Pattern lesson", confidence=0.92, state=LessonState.PATTERN)
     # Add 3 genuine RULE-state so total would qualify if state check is broken
     rules = _make_rule_group("DRAFTING", n=3, confidence=0.92)
@@ -325,8 +329,11 @@ def test_llm_principle_used_when_synthesizer_returns_string(monkeypatch):
     import gradata.enhancements.meta_rules as mr
 
     monkeypatch.setattr(
-        mr, "_try_llm_principle",
-        lambda rules, category: "When drafting, lead with the benefit, not the feature."
+        mr,
+        "_try_llm_principle",
+        lambda rules, category, creds=None: (
+            "When drafting, lead with the benefit, not the feature."
+        ),
     )
     lessons = _make_rule_group("DRAFTING", n=3, confidence=0.92)
     result = synthesize_meta_rules_agentic(lessons=lessons)
@@ -340,7 +347,7 @@ def test_llm_principle_falls_back_to_deterministic_on_none(monkeypatch):
     """When LLM returns None (no creds or failure), deterministic path runs."""
     import gradata.enhancements.meta_rules as mr
 
-    monkeypatch.setattr(mr, "_try_llm_principle", lambda rules, category: None)
+    monkeypatch.setattr(mr, "_try_llm_principle", lambda rules, category, creds=None: None)
     lessons = _make_rule_group("DRAFTING", n=3, confidence=0.92)
     result = synthesize_meta_rules_agentic(lessons=lessons)
 

--- a/Gradata/tests/test_cloud_sync.py
+++ b/Gradata/tests/test_cloud_sync.py
@@ -1,4 +1,5 @@
 """Tests for gradata.cloud.sync — opt-in cloud telemetry client."""
+
 from __future__ import annotations
 
 import json
@@ -94,7 +95,7 @@ class TestCloudClient:
         assert result is True
         mock_post.assert_called_once()
         call_path = mock_post.call_args[0][0]
-        assert call_path == "/v1/telemetry/metrics"
+        assert call_path == "/telemetry/metrics"
 
     def test_sync_metrics_updates_last_sync_at_on_success(self, tmp_path: Path):
         cfg = CloudConfig(sync_enabled=True, token="abc")
@@ -133,7 +134,7 @@ class TestCloudClient:
 
         assert result is True
         mock_post.assert_called_once()
-        assert mock_post.call_args[0][0] == "/v1/corpus/contribute"
+        assert mock_post.call_args[0][0] == "/corpus/contribute"
 
 
 class TestConvenienceSync:
@@ -156,6 +157,7 @@ class TestPayload:
 
     def test_payload_serializes_to_json(self):
         from dataclasses import asdict
+
         p = _payload()
         data = asdict(p)
         json_str = json.dumps(data)

--- a/Gradata/tests/test_integrations.py
+++ b/Gradata/tests/test_integrations.py
@@ -20,6 +20,7 @@ import pytest
 # OpenAI adapter
 # ===========================================================================
 
+
 class TestOpenAIAdapter:
     """Tests for patch_openai()."""
 
@@ -28,9 +29,7 @@ class TestOpenAIAdapter:
         client = MagicMock()
         # response shape: response.choices[0].message.content
         mock_response = MagicMock()
-        mock_response.choices = [
-            MagicMock(message=MagicMock(content="Hello from AI"))
-        ]
+        mock_response.choices = [MagicMock(message=MagicMock(content="Hello from AI"))]
         client.chat.completions.create.return_value = mock_response
         return client, mock_response
 
@@ -61,6 +60,7 @@ class TestOpenAIAdapter:
         from gradata.integrations.openai_adapter import patch_openai
 
         client, _ = self._make_client()
+        original_create = client.chat.completions.create
         # Give the brain a rule to inject
         with patch.object(fresh_brain, "apply_brain_rules", return_value="RULE: Be concise"):
             patched = patch_openai(client, brain_dir=fresh_brain.dir)
@@ -72,24 +72,34 @@ class TestOpenAIAdapter:
             ]
             patched.chat.completions.create(model="gpt-4", messages=messages)
 
-            # The system message should now contain the rule
-            system_msg = next(m for m in messages if m["role"] == "system")
+            # The underlying client.create must have received a messages list
+            # whose system entry contains the rule. The adapter now clones
+            # the caller's list before injecting — so we inspect call_args,
+            # not the caller's untouched list.
+            call_messages = original_create.call_args.kwargs["messages"]
+            system_msg = next(m for m in call_messages if m["role"] == "system")
             assert "RULE: Be concise" in system_msg["content"]
+            # Caller's own list must remain untouched (no shared-state mutation).
+            assert messages[0]["content"] == "You are helpful."
 
     def test_creates_system_message_when_missing(self, fresh_brain):
         """If no system message exists, one is created with brain rules."""
         from gradata.integrations.openai_adapter import patch_openai
 
         client, _ = self._make_client()
+        original_create = client.chat.completions.create
         patched = patch_openai(client, brain_dir=fresh_brain.dir)
         patched._brain.apply_brain_rules = MagicMock(return_value="RULE: Be brief")
 
         messages = [{"role": "user", "content": "Hello"}]
         patched.chat.completions.create(model="gpt-4", messages=messages)
 
-        # A system message should have been inserted at the front
-        assert messages[0]["role"] == "system"
-        assert "RULE: Be brief" in messages[0]["content"]
+        # A system message should have been inserted in the cloned list.
+        call_messages = original_create.call_args.kwargs["messages"]
+        assert call_messages[0]["role"] == "system"
+        assert "RULE: Be brief" in call_messages[0]["content"]
+        # Caller's own list must remain untouched.
+        assert messages == [{"role": "user", "content": "Hello"}]
 
     def test_output_captured(self, fresh_brain):
         """AI output is logged via brain.log_output."""
@@ -113,9 +123,13 @@ class TestOpenAIAdapter:
 
         client, mock_response = self._make_client()
         # Use a real SimpleNamespace so _brain won't auto-appear like on MagicMock
-        real_client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(
-            create=client.chat.completions.create,
-        )))
+        real_client = SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(
+                    create=client.chat.completions.create,
+                )
+            )
+        )
         patched = patch_openai(real_client, brain_dir=tmp_path / "does-not-exist")
         assert not hasattr(patched, "_brain")
         # Original create should still work
@@ -129,6 +143,7 @@ class TestOpenAIAdapter:
 # ===========================================================================
 # Anthropic adapter
 # ===========================================================================
+
 
 class TestAnthropicAdapter:
     """Tests for patch_anthropic()."""
@@ -212,9 +227,11 @@ class TestAnthropicAdapter:
 
         client, mock_response = self._make_client()
         # Use SimpleNamespace so _brain won't auto-appear like on MagicMock
-        real_client = SimpleNamespace(messages=SimpleNamespace(
-            create=client.messages.create,
-        ))
+        real_client = SimpleNamespace(
+            messages=SimpleNamespace(
+                create=client.messages.create,
+            )
+        )
         patched = patch_anthropic(real_client, brain_dir=tmp_path / "nonexistent")
         assert not hasattr(patched, "_brain")
         result = patched.messages.create(
@@ -247,6 +264,7 @@ class TestAnthropicAdapter:
 # ===========================================================================
 # LangChain adapter
 # ===========================================================================
+
 
 class TestLangChainAdapter:
     """Tests for BrainMemory (LangChain-compatible memory)."""
@@ -319,9 +337,7 @@ class TestLangChainAdapter:
         from gradata.integrations.langchain_adapter import BrainMemory
 
         memory = BrainMemory(brain_dir=fresh_brain.dir)
-        with patch.object(
-            memory.brain, "apply_brain_rules", return_value="RULE: Always be polite"
-        ):
+        with patch.object(memory.brain, "apply_brain_rules", return_value="RULE: Always be polite"):
             result = memory.load_memory_variables({"input": "Draft email"})
             assert "RULE: Always be polite" in result["brain_context"]
 
@@ -329,6 +345,7 @@ class TestLangChainAdapter:
 # ===========================================================================
 # CrewAI adapter
 # ===========================================================================
+
 
 class TestCrewAIAdapter:
     """Tests for BrainCrewMemory (CrewAI-compatible memory)."""
@@ -393,9 +410,7 @@ class TestCrewAIAdapter:
         from gradata.integrations.crewai_adapter import BrainCrewMemory
 
         mem = BrainCrewMemory(brain_dir=fresh_brain.dir)
-        with patch.object(
-            mem.brain, "apply_brain_rules", return_value="RULE: Focus on ROI"
-        ):
+        with patch.object(mem.brain, "apply_brain_rules", return_value="RULE: Focus on ROI"):
             rules = mem.get_rules(task="email_draft")
             assert "RULE: Focus on ROI" in rules
 
@@ -404,9 +419,7 @@ class TestCrewAIAdapter:
         from gradata.integrations.crewai_adapter import BrainCrewMemory
 
         mem = BrainCrewMemory(brain_dir=fresh_brain.dir)
-        with patch.object(
-            mem.brain, "apply_brain_rules", side_effect=RuntimeError("test error")
-        ):
+        with patch.object(mem.brain, "apply_brain_rules", side_effect=RuntimeError("test error")):
             rules = mem.get_rules()
             assert rules == ""
 
@@ -423,9 +436,7 @@ class TestCrewAIAdapter:
         from gradata.integrations.crewai_adapter import BrainCrewMemory
 
         mem = BrainCrewMemory(brain_dir=fresh_brain.dir)
-        with patch.object(
-            mem.brain, "observe", side_effect=RuntimeError("db locked")
-        ):
+        with patch.object(mem.brain, "observe", side_effect=RuntimeError("db locked")):
             # Should not raise
             mem.save("Some memory content")
 
@@ -434,9 +445,7 @@ class TestCrewAIAdapter:
         from gradata.integrations.crewai_adapter import BrainCrewMemory
 
         mem = BrainCrewMemory(brain_dir=fresh_brain.dir)
-        with patch.object(
-            mem.brain, "search", side_effect=RuntimeError("db locked")
-        ):
+        with patch.object(mem.brain, "search", side_effect=RuntimeError("db locked")):
             results = mem.search("anything")
             assert results == []
 
@@ -445,22 +454,26 @@ class TestCrewAIAdapter:
 # Deprecation shim tests
 # ===========================================================================
 
+
 class TestDeprecationWarnings:
     """Verify that importing integrations adapter modules emits DeprecationWarning."""
 
     def _reimport(self, module_name: str):
         """Force a fresh import by removing the module from sys.modules first."""
         import sys
+
         # Remove the module (and any cached sub-module) so the warning fires again.
         for key in list(sys.modules):
             if key == module_name or key.startswith(module_name + "."):
                 del sys.modules[key]
         import importlib
+
         return importlib.import_module(module_name)
 
     def test_anthropic_adapter_warns_on_import(self):
         """Importing gradata.integrations.anthropic_adapter raises DeprecationWarning."""
         import warnings
+
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             self._reimport("gradata.integrations.anthropic_adapter")
@@ -470,6 +483,7 @@ class TestDeprecationWarnings:
     def test_openai_adapter_warns_on_import(self):
         """Importing gradata.integrations.openai_adapter raises DeprecationWarning."""
         import warnings
+
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             self._reimport("gradata.integrations.openai_adapter")
@@ -479,6 +493,7 @@ class TestDeprecationWarnings:
     def test_langchain_adapter_warns_on_import(self):
         """Importing gradata.integrations.langchain_adapter raises DeprecationWarning."""
         import warnings
+
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             self._reimport("gradata.integrations.langchain_adapter")
@@ -488,6 +503,7 @@ class TestDeprecationWarnings:
     def test_crewai_adapter_warns_on_import(self):
         """Importing gradata.integrations.crewai_adapter raises DeprecationWarning."""
         import warnings
+
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             self._reimport("gradata.integrations.crewai_adapter")
@@ -522,6 +538,7 @@ class TestDeprecationWarnings:
     def test_non_adapter_integrations_not_deprecated(self):
         """embeddings and session_history do NOT emit DeprecationWarning."""
         import warnings
+
         for mod_name in [
             "gradata.integrations.embeddings",
             "gradata.integrations.session_history",
@@ -529,6 +546,7 @@ class TestDeprecationWarnings:
             with warnings.catch_warnings(record=True) as caught:
                 warnings.simplefilter("always")
                 import importlib
+
                 importlib.import_module(mod_name)
             depr = [w for w in caught if issubclass(w.category, DeprecationWarning)]
             assert not depr, f"{mod_name} should not emit DeprecationWarning, got: {depr}"

--- a/Gradata/tests/test_security_regressions.py
+++ b/Gradata/tests/test_security_regressions.py
@@ -19,45 +19,53 @@ import pytest
 
 # Short fake credential values — intentionally under 8 chars so the
 # secret scanner does not flag them as real credentials.
-_FK = "sk-test"   # fake key, 7 chars
-_FT = "brr-x"    # fake bearer, 5 chars
+_FK = "sk-test"  # fake key, 7 chars
+_FT = "brr-x"  # fake bearer, 5 chars
 
 
 # ---------------------------------------------------------------------------
 # Shared helper: require_https
 # ---------------------------------------------------------------------------
 
+
 class TestRequireHttps:
     """Unit tests for the shared _http.require_https helper."""
 
     def test_https_passes(self):
         from gradata._http import require_https
+
         require_https("https://api.example.com/v1", "test")
 
     def test_http_localhost_passes(self):
         from gradata._http import require_https
+
         require_https("http://localhost:11434/v1", "test")
 
     def test_http_127_passes(self):
         from gradata._http import require_https
+
         require_https("http://127.0.0.1:8080/v1", "test")
 
     def test_http_ipv6_loopback_passes(self):
         from gradata._http import require_https
+
         # RFC 2732: IPv6 literals in URLs must be bracketed
         require_https("http://[::1]:8080/v1", "test")
 
     def test_empty_url_passes(self):
         from gradata._http import require_https
+
         require_https("", "test")
 
     def test_http_remote_raises(self):
         from gradata._http import require_https
+
         with pytest.raises(ValueError, match="HTTPS"):
             require_https("http://evil.com/steal", "test")
 
     def test_label_appears_in_error(self):
         from gradata._http import require_https
+
         with pytest.raises(ValueError, match="GRADATA_LLM_BASE"):
             require_https("http://attacker.internal/v1", "GRADATA_LLM_BASE")
 
@@ -65,6 +73,7 @@ class TestRequireHttps:
 # ---------------------------------------------------------------------------
 # C1a — llm_synthesizer
 # ---------------------------------------------------------------------------
+
 
 class TestLLMSynthesizerHttpsGuard:
     """C1a: synthesise_principle_llm refuses HTTP to non-local hosts."""
@@ -76,6 +85,7 @@ class TestLLMSynthesizerHttpsGuard:
 
     def test_http_remote_returns_none(self):
         from gradata.enhancements.llm_synthesizer import synthesise_principle_llm
+
         result = synthesise_principle_llm(
             self._make_lessons(),
             theme="style",
@@ -138,11 +148,13 @@ class TestLLMSynthesizerHttpsGuard:
 # C1b — meta_rules._call_llm_for_synthesis
 # ---------------------------------------------------------------------------
 
+
 class TestMetaRulesHttpsGuard:
     """C1b: _call_llm_for_synthesis raises for HTTP non-local base."""
 
     def test_http_remote_raises(self, monkeypatch):
         from gradata.enhancements import meta_rules
+
         monkeypatch.setenv("GRADATA_LLM_KEY", _FK)
         monkeypatch.setenv("GRADATA_LLM_BASE", "http://attacker.internal/v1")
         monkeypatch.setenv("GRADATA_LLM_MODEL", "gpt-4o-mini")
@@ -152,6 +164,7 @@ class TestMetaRulesHttpsGuard:
 
     def test_https_remote_allowed(self, monkeypatch):
         from gradata.enhancements import meta_rules
+
         monkeypatch.setenv("GRADATA_LLM_KEY", _FK)
         monkeypatch.setenv("GRADATA_LLM_BASE", "https://api.openai.com/v1")
         monkeypatch.setenv("GRADATA_LLM_MODEL", "gpt-4o-mini")
@@ -159,9 +172,7 @@ class TestMetaRulesHttpsGuard:
         # _call_llm_for_synthesis parses body["choices"][0]["message"]["content"]
         with patch("urllib.request.urlopen") as mock_urlopen:
             mock_resp = MagicMock()
-            mock_resp.read.return_value = (
-                b'{"choices":[{"message":{"content":"[{\\"directive\\":\\"Be concise.\\",\\"confidence\\":0.9}]"}}]}'
-            )
+            mock_resp.read.return_value = b'{"choices":[{"message":{"content":"[{\\"directive\\":\\"Be concise.\\",\\"confidence\\":0.9}]"}}]}'
             mock_resp.__enter__ = lambda s: s
             mock_resp.__exit__ = MagicMock(return_value=False)
             mock_urlopen.return_value = mock_resp
@@ -174,26 +185,31 @@ class TestMetaRulesHttpsGuard:
 # C1c — llm_provider.GenericHTTPProvider
 # ---------------------------------------------------------------------------
 
+
 class TestGenericHTTPProviderHttpsGuard:
     """C1c: GenericHTTPProvider raises ValueError at construction for HTTP non-local."""
 
     def test_http_remote_raises_on_init(self):
         from gradata.enhancements.llm_provider import GenericHTTPProvider
+
         with pytest.raises(ValueError, match="HTTPS"):
             GenericHTTPProvider(base_url="http://evil.com/v1")
 
     def test_http_localhost_allowed(self):
         from gradata.enhancements.llm_provider import GenericHTTPProvider
+
         provider = GenericHTTPProvider(base_url="http://localhost:11434/v1")
         assert "localhost" in provider.base_url
 
     def test_https_remote_allowed(self):
         from gradata.enhancements.llm_provider import GenericHTTPProvider
+
         provider = GenericHTTPProvider(base_url="https://api.together.xyz/v1")
         assert "together" in provider.base_url
 
     def test_env_var_http_remote_raises(self, monkeypatch):
         from gradata.enhancements import llm_provider
+
         monkeypatch.setenv("GRADATA_LLM_BASE_URL", "http://attacker.com/v1")
         with pytest.raises(ValueError, match="HTTPS"):
             llm_provider.GenericHTTPProvider()
@@ -203,11 +219,13 @@ class TestGenericHTTPProviderHttpsGuard:
 # H1 — cloud/sync.CloudClient._post
 # ---------------------------------------------------------------------------
 
+
 class TestSyncClientHttpsGuard:
     """H1: sync.CloudClient refuses HTTP non-local api_base at construction and in _post."""
 
     def _make_client(self, api_base: str, tmp_path: Path):
         from gradata.cloud.sync import CloudClient, CloudConfig
+
         cfg = CloudConfig(sync_enabled=True, api_base=api_base)
         cfg.token = _FT  # noqa: S105 — intentionally short fake value
         return CloudClient(brain_dir=tmp_path, config=cfg)
@@ -215,6 +233,7 @@ class TestSyncClientHttpsGuard:
     def test_http_remote_post_returns_none(self, tmp_path):
         # Constructor now raises before _post is ever reached — stronger guard.
         from gradata.cloud.sync import CloudClient, CloudConfig
+
         cfg = CloudConfig(sync_enabled=True, api_base="http://evil.com")
         cfg.token = _FT
         with pytest.raises(ValueError, match="HTTPS"):
@@ -229,14 +248,14 @@ class TestSyncClientHttpsGuard:
             mock_resp.__exit__ = MagicMock(return_value=False)
             mock_urlopen.return_value = mock_resp
 
-            result = client._post("/v1/telemetry/metrics", {"x": 1})
+            result = client._post("/telemetry/metrics", {"x": 1})
         assert result == {"ok": True}
 
     def test_http_localhost_post_attempts_request(self, tmp_path):
         client = self._make_client("http://localhost:8080", tmp_path)
         with patch("urllib.request.urlopen") as mock_urlopen:
             mock_resp = MagicMock()
-            mock_resp.read.return_value = b'{}'
+            mock_resp.read.return_value = b"{}"
             mock_resp.__enter__ = lambda s: s
             mock_resp.__exit__ = MagicMock(return_value=False)
             mock_urlopen.return_value = mock_resp
@@ -249,26 +268,31 @@ class TestSyncClientHttpsGuard:
 # REF — cloud/client.CloudClient constructor
 # ---------------------------------------------------------------------------
 
+
 class TestCloudClientHttpsGuard:
     """REF: cloud/client.CloudClient refuses HTTP endpoint at construction."""
 
     def test_http_remote_raises(self, tmp_path):
         from gradata.cloud.client import CloudClient
+
         with pytest.raises(ValueError, match="HTTPS"):
             CloudClient(brain_dir=tmp_path, endpoint="http://evil.com/v1")
 
     def test_https_remote_accepted(self, tmp_path):
         from gradata.cloud.client import CloudClient
+
         client = CloudClient(brain_dir=tmp_path, endpoint="https://api.gradata.com/v1")
         assert client.endpoint == "https://api.gradata.com/v1"
 
     def test_http_localhost_accepted(self, tmp_path):
         from gradata.cloud.client import CloudClient
+
         client = CloudClient(brain_dir=tmp_path, endpoint="http://localhost:9000/v1")
         assert "localhost" in client.endpoint
 
     def test_env_var_http_remote_raises(self, tmp_path, monkeypatch):
         from gradata.cloud import client as cloud_client_mod
+
         monkeypatch.setenv("GRADATA_ENDPOINT", "http://attacker.com/v1")
         with pytest.raises(ValueError, match="HTTPS"):
             cloud_client_mod.CloudClient(brain_dir=tmp_path)
@@ -277,6 +301,7 @@ class TestCloudClientHttpsGuard:
 # ---------------------------------------------------------------------------
 # HIGH — _core._cloud_sync_session api_url guard
 # ---------------------------------------------------------------------------
+
 
 class TestCoreSyncSessionHttpsGuard:
     """HIGH: _cloud_sync_session returns early when api_url is HTTP non-local."""
@@ -314,7 +339,4 @@ class TestCoreSyncSessionHttpsGuard:
                     # SyncClient must NOT be instantiated — sync was aborted
                     mock_sync.assert_not_called()
 
-        assert any(
-            "HTTPS" in r.message or "aborted" in r.message
-            for r in caplog.records
-        )
+        assert any("HTTPS" in r.message or "aborted" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
Stack of SDK fixes and refactors on top of #133.

- `fix(implicit_feedback)`: restore GAP signal category dropped during hook dedup (12e96d39)
- `feat(implicit_feedback)`: emit tacit `OUTPUT_ACCEPTED` on silent follow-ups (ab0bb62a)
- `fix(hooks)`: eliminate false-positive REJECTED outcomes + dead code (39819399)
- `fix(cloud)`: align SDK base URL with `/api/v1` prefix after gradata-cloud@04a272f (1f89df4f)
- `refactor(hooks)`: collapse emit boilerplate into `_base.emit_hook_event` — 5 hooks migrated, net -13 lines (03e5363c)

## Test plan
- [x] `pytest Gradata/tests/` green
- [x] Cloud telemetry path hits `/api/v1/telemetry/metrics` (tested in `test_cloud_sync.py`)
- [x] All 90 hook tests pass after emit refactor
- [ ] Smoke: opt-in telemetry end-to-end against prod `api.gradata.ai` after merge

Generated with Gradata