### PR TITLE
feat(rules): slot-grouped brain injection + graduation-time classifier

### DIFF
--- a/Gradata/src/gradata/_types.py
+++ b/Gradata/src/gradata/_types.py
@@ -176,12 +176,18 @@ class Lesson:
     tree_level: int = 0  # Current depth: 0=leaf, 1=branch, 2=trunk
     # Transient runtime state (not persisted to lessons.md) — self_improvement
     # / rule_evolution decay confidence once this crosses a threshold.
-    _contradiction_streak: int = 0  # Consecutive contradictions; triggers self-correction / penalty acceleration
+    _contradiction_streak: int = (
+        0  # Consecutive contradictions; triggers self-correction / penalty acceleration
+    )
     stale: bool = False  # True = demoted via TTL (sessions_since_fire >= ttl); flagged for review
     # Phase 5 council hook: optional registry slot for AST-class promotion routing.
     # Unset today (rule_to_hook uses the regex-matched DETERMINISTIC_PATTERNS table).
     # Reserved for a future AST-transform registry (shell substitution, path enforcement, etc.).
     determinism_class: str | None = None
+    # Preston-Rhodes synthesis slot: task / context / examples / persona / format / tone.
+    # Assigned at graduation time by prompt_synthesizer.classify_slot. Empty on legacy
+    # lessons; the synthesizer falls back to category-based inference at render time.
+    slot: str = ""
 
     def __post_init__(self) -> None:
         self.confidence = round(max(0.0, min(1.0, self.confidence)), 2)

--- a/Gradata/src/gradata/enhancements/prompt_synthesizer.py
+++ b/Gradata/src/gradata/enhancements/prompt_synthesizer.py
@@ -1,35 +1,33 @@
-"""Meta-Harness D — synthesized prompt injection with inline rule anchors.
+"""Brain-injection synthesis with inline rule anchors.
 
-Instead of injecting a flat list of 10-20 tagged rules and clusters, this
-module collapses them into compact prose grouped by category. Each rule
-still carries a 4-char anchor inline (``r:a1f9``) so the live hook
-``capture_learning.py`` can attribute a later user correction to the
+Two entry points:
+
+* :func:`synthesize_rules_prompt` — category-grouped synthesis. Legacy.
+* :func:`synthesize_brain_injection` — slot-grouped synthesis ordered by
+  Preston Rhodes' 6-step prompt checklist (task → context → examples →
+  persona → format → tone). Token-budgeted. This is the canonical
+  session-start output.
+
+Both preserve a 4-char ``r:xxxx`` anchor inline per rule so
+``capture_learning.py`` can attribute a later user correction back to the
 originating rule via token-overlap matching.
-
-Two modes:
-
-* **Template mode** (default) — deterministic, offline. Groups rules by
-  category and emits one sentence per group with anchors preserved.
-* **LLM mode** — ``GRADATA_SYNTHESIZE_WITH_LLM`` env var truthy. Calls
-  ``synthesize_with_llm`` (provided by caller or no-op fallback) to produce
-  natural prose; we re-insert anchors afterward so the caller's LLM doesn't
-  need to know about them.
 
 Output shape::
 
     SynthesizedPrompt(
-        text="Drafting: never attribute quotes prospects didn't say r:a1f9; "
-             "use writer+critic for sequences r:b2c3. Tone: start with empathy r:c3d4.",
-        anchors_used=["a1f9", "b2c3", "c3d4"],
+        text="Task: keep diffs small r:a1f9. Tone: lead with empathy r:b2c3.",
+        anchors_used=["a1f9", "b2c3"],
         anchor_to_rule_id={"a1f9": "a1f92b3c4d5e", ...},
     )
 """
+
 from __future__ import annotations
 
 import os
 import re
 from dataclasses import dataclass, field
-from typing import Callable, Iterable
+from pathlib import Path
+from typing import Any, Callable, Iterable
 
 
 @dataclass
@@ -43,6 +41,88 @@ class SynthesizedPrompt:
         return len(self.text.split())
 
 
+# ---------------------------------------------------------------------------
+# Slot inference (Preston Rhodes 6-step)
+# ---------------------------------------------------------------------------
+
+SLOT_ORDER: tuple[str, ...] = (
+    "task",
+    "context",
+    "examples",
+    "persona",
+    "format",
+    "tone",
+)
+
+SLOT_LABELS: dict[str, str] = {
+    "task": "Task",
+    "context": "Context",
+    "examples": "Examples",
+    "persona": "Persona",
+    "format": "Format",
+    "tone": "Tone",
+}
+
+_CATEGORY_SLOT: dict[str, str] = {
+    "PROCESS": "task",
+    "EXECUTION": "task",
+    "EXECUTION-DISCIPLINE": "task",
+    "EXECUTION_DISCIPLINE": "task",
+    "WORKFLOW": "task",
+    "CODE": "task",
+    "ACCURACY": "context",
+    "DATA-INTEGRITY": "context",
+    "DATA_INTEGRITY": "context",
+    "LEAD-HANDLING": "context",
+    "LEAD_HANDLING": "context",
+    "RESEARCH": "context",
+    "SAFETY": "context",
+    "DRAFTING": "format",
+    "STRUCTURE": "format",
+    "FORMAT": "format",
+    "TONE": "tone",
+    "VOICE": "tone",
+    "PERSONA": "persona",
+    "IDENTITY": "persona",
+}
+_DEFAULT_SLOT = "context"
+
+
+def _get(item: Any, key: str) -> Any:
+    if isinstance(item, dict):
+        return item.get(key)
+    return getattr(item, key, None)
+
+
+def classify_slot(item: Any) -> str:
+    """Infer a Preston-Rhodes slot for a Lesson or rule-shaped dict.
+
+    Resolution order: explicit ``slot`` → example-pair presence → category
+    lookup → ``context`` catchall.
+    """
+    explicit = _get(item, "slot")
+    if explicit:
+        slot = str(explicit).strip().lower()
+        if slot in SLOT_LABELS:
+            return slot
+
+    if _get(item, "example_draft") or _get(item, "example_corrected"):
+        return "examples"
+
+    cat = str(_get(item, "category") or "").strip().upper()
+    if cat in _CATEGORY_SLOT:
+        return _CATEGORY_SLOT[cat]
+    cat_norm = cat.replace("-", "_")
+    if cat_norm in _CATEGORY_SLOT:
+        return _CATEGORY_SLOT[cat_norm]
+    return _DEFAULT_SLOT
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
 def _anchor_of(rule_id: str) -> str:
     """First 4 chars of the stable lesson id, matching inject_brain_rules."""
     return (rule_id or "")[:4]
@@ -53,9 +133,34 @@ def _clean_description(desc: str) -> str:
     text = (desc or "").strip()
     for prefix in ("User corrected: ", "[AUTO] ", "[hooked] "):
         if text.startswith(prefix):
-            text = text[len(prefix):]
-    # Remove trailing period so rule concatenation with ; reads cleanly.
+            text = text[len(prefix) :]
     return text.rstrip(".;,").strip()
+
+
+def _rule_id_of(item: Any) -> str:
+    for key in ("rule_id", "lesson_id", "id"):
+        val = _get(item, key)
+        if val:
+            return str(val)
+    return ""
+
+
+def _as_rule_dict(item: Any) -> dict:
+    if isinstance(item, dict):
+        return item
+    return {
+        "category": getattr(item, "category", "") or "",
+        "description": getattr(item, "description", "") or "",
+        "rule_id": _rule_id_of(item),
+        "slot": getattr(item, "slot", "") or "",
+        "example_draft": getattr(item, "example_draft", None),
+        "example_corrected": getattr(item, "example_corrected", None),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Category-grouped synthesis (legacy, kept for back-compat)
+# ---------------------------------------------------------------------------
 
 
 def _group_by_category(rules: Iterable[dict]) -> dict[str, list[dict]]:
@@ -74,20 +179,8 @@ def synthesize_rules_prompt(
 ) -> SynthesizedPrompt:
     """Collapse a list of rules into a compact, anchor-preserving prompt.
 
-    Args:
-        rules: List of dicts with keys ``category``, ``description``,
-            ``rule_id`` (full hex id). ``rule_id`` is used to derive the
-            inline 4-char anchor.
-        max_per_category: Cap on rules per category group so a dominant
-            category can't drown out the rest.
-        llm_fn: Optional callable that takes a template prompt and returns
-            LLM-synthesized prose. Only consulted when
-            ``GRADATA_SYNTHESIZE_WITH_LLM`` is truthy. Anchors are re-
-            attached after the LLM returns — the LLM itself does not need
-            to know about them.
-
-    Returns:
-        A :class:`SynthesizedPrompt`. Empty input → empty prompt.
+    Legacy category-grouped form. New callers should prefer
+    :func:`synthesize_brain_injection` which groups by Preston-Rhodes slot.
     """
     if not rules:
         return SynthesizedPrompt(text="")
@@ -128,9 +221,142 @@ def synthesize_rules_prompt(
     )
 
 
+# ---------------------------------------------------------------------------
+# Slot-grouped synthesis (canonical brain injection)
+# ---------------------------------------------------------------------------
+
+
+DEFAULT_BUDGET_TOKENS = 400
+_PERSONA_BASELINE_CHARS = 800
+
+
+def _budget_from_env(override: int | None) -> int:
+    if override is not None and override > 0:
+        return int(override)
+    raw = os.environ.get("GRADATA_SYNTH_BUDGET", "").strip()
+    if raw:
+        try:
+            val = int(raw)
+            if val > 0:
+                return val
+        except ValueError:
+            pass
+    return DEFAULT_BUDGET_TOKENS
+
+
+def _load_persona_baseline(source: str | Path | None) -> str:
+    """Return a compact baseline string for the persona slot.
+
+    Accepts a raw multi-line string, a path to a markdown file (e.g.
+    ``domain/soul.md``), or None. Returns ``""`` on any read error.
+    """
+    if source is None:
+        return ""
+    if isinstance(source, str):
+        return source.strip()[:_PERSONA_BASELINE_CHARS]
+    if not isinstance(source, Path):
+        return ""
+    if not source.is_file():
+        return ""
+    try:
+        text = source.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+    lines = [
+        ln for ln in text.splitlines() if ln.strip() and not ln.lstrip().startswith(("#", ">"))
+    ]
+    compact = " ".join(ln.strip().lstrip("*-").strip() for ln in lines)
+    return compact[:_PERSONA_BASELINE_CHARS]
+
+
+def synthesize_brain_injection(
+    lessons: Iterable[Any],
+    *,
+    budget_tokens: int | None = None,
+    max_per_slot: int = 3,
+    persona_baseline: str | Path | None = None,
+    llm_fn: Callable[[str], str] | None = None,
+) -> SynthesizedPrompt:
+    """Produce the single synthesized brain-injection prompt.
+
+    Groups rules by :func:`classify_slot` into Preston-Rhodes 6-step order
+    (task → context → examples → persona → format → tone). One sentence per
+    non-empty slot. Token budget enforced by dropping lowest-priority slots
+    first once the running total would exceed ``budget_tokens``.
+    """
+    budget = _budget_from_env(budget_tokens)
+    baseline = _load_persona_baseline(persona_baseline)
+    normalized = [_as_rule_dict(x) for x in lessons if x is not None]
+
+    slot_items: dict[str, list[dict]] = {s: [] for s in SLOT_ORDER}
+    for item in normalized:
+        slot = classify_slot(item)
+        slot_items.setdefault(slot, []).append(item)
+
+    anchors_used: list[str] = []
+    anchor_to_rule_id: dict[str, str] = {}
+    sentences: list[tuple[str, str]] = []
+
+    for slot in SLOT_ORDER:
+        items = slot_items.get(slot, [])[:max_per_slot]
+        clauses: list[str] = []
+        for item in items:
+            rule_id = item.get("rule_id") or ""
+            anchor = _anchor_of(rule_id)
+            desc = _clean_description(item.get("description", ""))
+            if not desc:
+                continue
+            if anchor and anchor not in anchor_to_rule_id:
+                anchors_used.append(anchor)
+                anchor_to_rule_id[anchor] = rule_id
+            suffix = f" r:{anchor}" if anchor else ""
+            clauses.append(f"{desc}{suffix}")
+
+        if slot == "persona" and baseline:
+            sentence = f"Persona: {baseline}"
+            if clauses:
+                sentence += ". Overrides: " + "; ".join(clauses)
+            sentence += "."
+            sentences.append((slot, sentence))
+            continue
+
+        if not clauses:
+            continue
+        label = SLOT_LABELS[slot]
+        sentences.append((slot, f"{label}: " + "; ".join(clauses) + "."))
+
+    def _render(pairs: list[tuple[str, str]]) -> str:
+        return " ".join(s for _, s in pairs)
+
+    while sentences and len(_render(sentences).split()) > budget:
+        sentences.pop()
+
+    text = _render(sentences)
+
+    if _llm_enabled() and llm_fn is not None and text:
+        text = _apply_llm(text, anchors_used, llm_fn)
+
+    final_anchors = [a for a in anchors_used if f"r:{a}" in text or a in text]
+    final_map = {a: anchor_to_rule_id[a] for a in final_anchors if a in anchor_to_rule_id}
+
+    return SynthesizedPrompt(
+        text=text,
+        anchors_used=final_anchors,
+        anchor_to_rule_id=final_map,
+    )
+
+
+# ---------------------------------------------------------------------------
+# LLM hook + anchor helpers
+# ---------------------------------------------------------------------------
+
+
 def _llm_enabled() -> bool:
     return os.environ.get("GRADATA_SYNTHESIZE_WITH_LLM", "").strip().lower() in (
-        "1", "true", "yes", "on",
+        "1",
+        "true",
+        "yes",
+        "on",
     )
 
 
@@ -142,23 +368,15 @@ def _apply_llm(
     anchors_used: list[str],
     llm_fn: Callable[[str], str],
 ) -> str:
-    """Hand the anchor-stripped text to the LLM, then reattach anchors.
-
-    The LLM produces prose. We attempt to match each anchor's original
-    context word back into the new prose. If matching fails we append the
-    anchors in a trailing sweep ``[ref: a1f9,b2c3]`` so attribution still
-    works even when the LLM reshuffled clauses.
-    """
     stripped = _ANCHOR_RE.sub("", template_text)
     try:
         new_text = llm_fn(stripped).strip()
     except Exception:
-        return template_text  # fall back to the template on any LLM error
+        return template_text
 
     if not new_text:
         return template_text
 
-    # Conservative reattach: append a ref sweep so every anchor is present.
     refs = ",".join(anchors_used)
     return f"{new_text} [ref: {refs}]" if refs else new_text
 
@@ -168,14 +386,12 @@ def extract_anchors(text: str) -> list[str]:
     if not text:
         return []
     anchors = _ANCHOR_RE.findall(text)
-    # also catch trailing sweep [ref: a,b,c]
     sweep = re.search(r"\[ref:\s*([0-9a-f,\s]+)\]", text)
     if sweep:
         for tok in sweep.group(1).split(","):
             tok = tok.strip()
             if re.fullmatch(r"[0-9a-f]{4}", tok):
                 anchors.append(tok)
-    # dedup, preserve first-seen order
     seen: set[str] = set()
     ordered: list[str] = []
     for a in anchors:

--- a/Gradata/src/gradata/enhancements/self_improvement/_confidence.py
+++ b/Gradata/src/gradata/enhancements/self_improvement/_confidence.py
@@ -370,6 +370,7 @@ def parse_lessons(text: str) -> list[Lesson]:
         tree_level = 0
         alpha = 1.0
         beta_param_val = 1.0
+        slot = ""
         j = i + 1
         while j < len(lines) and lines[j].startswith("  "):
             meta_line = lines[j].strip()
@@ -406,6 +407,8 @@ def parse_lessons(text: str) -> list[Lesson]:
                     domain_scores = json.loads(meta_line[len("Domain scores:") :].strip())
                 except json.JSONDecodeError:
                     domain_scores = {}
+            elif meta_line.startswith("Slot:"):
+                slot = meta_line[len("Slot:") :].strip().lower()
             elif meta_line.startswith("Path:"):
                 path = meta_line[len("Path:") :].strip()
             elif meta_line.startswith("Secondary categories:"):
@@ -464,6 +467,7 @@ def parse_lessons(text: str) -> list[Lesson]:
             climb_count=climb_count,
             last_climb_session=last_climb_session,
             tree_level=tree_level,
+            slot=slot,
         )
         if metadata_obj is not None:
             _lesson.metadata = metadata_obj
@@ -1109,6 +1113,9 @@ def format_lessons(lessons: list[Lesson]) -> str:
             lines.append(
                 f"  Beta params: {json.dumps({'alpha': lesson.alpha, 'beta': lesson.beta_param})}"
             )
+
+        if getattr(lesson, "slot", ""):
+            lines.append(f"  Slot: {lesson.slot}")
 
         if lesson.path:
             lines.append(f"  Path: {lesson.path}")

--- a/Gradata/src/gradata/enhancements/self_improvement/_graduation.py
+++ b/Gradata/src/gradata/enhancements/self_improvement/_graduation.py
@@ -31,6 +31,23 @@ from gradata.enhancements.self_improvement._confidence import (
 _log = logging.getLogger(__name__)
 
 
+def _ensure_slot(lesson: Lesson) -> None:
+    """Classify and assign a Preston-Rhodes slot when graduating.
+
+    Idempotent: skipped when the lesson already carries a slot. Any
+    classifier error is swallowed — slot is optional metadata and a
+    missing slot falls back to category inference at render time.
+    """
+    if getattr(lesson, "slot", ""):
+        return
+    try:
+        from gradata.enhancements.prompt_synthesizer import classify_slot
+
+        lesson.slot = classify_slot(lesson)
+    except Exception:  # pragma: no cover - classifier is best-effort
+        pass
+
+
 # ---------------------------------------------------------------------------
 # Graduation
 # ---------------------------------------------------------------------------
@@ -317,6 +334,7 @@ def graduate(
                     lesson.description = result.best.content
             except Exception:
                 pass  # ToT is optional; graduate with original wording
+            _ensure_slot(lesson)
             lesson.state = transition(lesson.state, "promote")
 
             # Rule-to-hook graduation: attempt to install a deterministic
@@ -365,6 +383,7 @@ def graduate(
             and lesson.confidence > eff_pattern_threshold
             and lesson.fire_count >= MIN_APPLICATIONS_FOR_PATTERN
         ):
+            _ensure_slot(lesson)
             lesson.state = transition(lesson.state, "promote")
             continue
 

--- a/Gradata/tests/test_prompt_synthesizer.py
+++ b/Gradata/tests/test_prompt_synthesizer.py
@@ -1,9 +1,14 @@
 """Tests for Meta-Harness D synthesized prompt injection."""
+
 from __future__ import annotations
 
 from gradata.enhancements.prompt_synthesizer import (
+    DEFAULT_BUDGET_TOKENS,
+    SLOT_ORDER,
     SynthesizedPrompt,
+    classify_slot,
     extract_anchors,
+    synthesize_brain_injection,
     synthesize_rules_prompt,
 )
 
@@ -20,10 +25,11 @@ def test_empty_rules_yields_empty_prompt():
 
 
 def test_single_rule_gets_inline_anchor():
-    out = synthesize_rules_prompt([
-        _rule("DRAFTING", "never attribute quotes prospects didn't say",
-              "a1f92b3c4d5e"),
-    ])
+    out = synthesize_rules_prompt(
+        [
+            _rule("DRAFTING", "never attribute quotes prospects didn't say", "a1f92b3c4d5e"),
+        ]
+    )
     assert "r:a1f9" in out.text
     assert "a1f9" in out.anchors_used
     assert out.anchor_to_rule_id["a1f9"] == "a1f92b3c4d5e"
@@ -58,10 +64,7 @@ def test_strips_noise_prefixes():
 
 
 def test_max_per_category_caps_output():
-    rules = [
-        _rule("DRAFTING", f"rule number {i}", f"{i:04x}00000000")
-        for i in range(10)
-    ]
+    rules = [_rule("DRAFTING", f"rule number {i}", f"{i:04x}00000000") for i in range(10)]
     out = synthesize_rules_prompt(rules, max_per_category=3)
     # 3 anchors max from the capped category
     assert len(out.anchors_used) == 3
@@ -70,15 +73,11 @@ def test_max_per_category_caps_output():
 def test_token_saving_vs_flat_list():
     """Sanity check — synthesized form fits in fewer tokens than the
     equivalent ``[RULE:0.92] {cat}: {desc}`` flat list it replaces."""
-    rules = [
-        _rule("DRAFTING", f"directive {i}", f"{i:04x}abcdef01")
-        for i in range(8)
-    ]
+    rules = [_rule("DRAFTING", f"directive {i}", f"{i:04x}abcdef01") for i in range(8)]
     out = synthesize_rules_prompt(rules, max_per_category=8)
 
     flat = "\n".join(
-        f"[RULE:0.92] {r['category']}: {r['description']} r:{r['rule_id'][:4]}"
-        for r in rules
+        f"[RULE:0.92] {r['category']}: {r['description']} r:{r['rule_id'][:4]}" for r in rules
     )
     # Synthesis should produce fewer tokens than the flat dump.
     assert out.token_count_estimate() < len(flat.split())
@@ -157,3 +156,174 @@ def test_llm_failure_falls_back_to_template(monkeypatch):
     # Falls back to template, which still has the inline anchor
     assert "r:a1f9" in out.text
     assert "keep diffs small" in out.text
+
+
+# ---------------------------------------------------------------------------
+# Slot classification + slot-grouped (brain-injection) synthesis
+# ---------------------------------------------------------------------------
+
+
+def test_classify_slot_explicit_wins():
+    assert classify_slot({"slot": "tone", "category": "DRAFTING"}) == "tone"
+
+
+def test_classify_slot_example_pair_is_examples():
+    item = {
+        "category": "DRAFTING",
+        "description": "prefer concise tone",
+        "example_draft": "before",
+        "example_corrected": "after",
+    }
+    assert classify_slot(item) == "examples"
+
+
+def test_classify_slot_category_mapping():
+    assert classify_slot({"category": "DRAFTING"}) == "format"
+    assert classify_slot({"category": "TONE"}) == "tone"
+    assert classify_slot({"category": "PROCESS"}) == "task"
+    assert classify_slot({"category": "ACCURACY"}) == "context"
+    # Hyphen/underscore variants both resolve.
+    assert classify_slot({"category": "EXECUTION-DISCIPLINE"}) == "task"
+    assert classify_slot({"category": "DATA_INTEGRITY"}) == "context"
+
+
+def test_classify_slot_unknown_category_defaults_to_context():
+    assert classify_slot({"category": "ZEBRA"}) == "context"
+
+
+def test_brain_injection_empty_is_empty():
+    out = synthesize_brain_injection([])
+    assert isinstance(out, SynthesizedPrompt)
+    assert out.text == ""
+    assert out.anchors_used == []
+
+
+def test_brain_injection_orders_slots_per_preston():
+    rules = [
+        _rule("TONE", "lead with empathy", "c3d41a2b3c4d"),
+        _rule("DRAFTING", "tight copy under 150 words", "a1f92b3c4d5e"),
+        _rule("PROCESS", "plan before implementing", "b2c31a2b3c4d"),
+    ]
+    out = synthesize_brain_injection(rules)
+    # Task comes before Format which comes before Tone.
+    task_idx = out.text.index("Task:")
+    format_idx = out.text.index("Format:")
+    tone_idx = out.text.index("Tone:")
+    assert task_idx < format_idx < tone_idx
+    # All anchors preserved.
+    for anchor in ("a1f9", "b2c3", "c3d4"):
+        assert f"r:{anchor}" in out.text
+
+
+def test_brain_injection_persona_baseline_seeded():
+    rules = [_rule("PERSONA", "never attribute unverified quotes", "d4e51a2b3c4d")]
+    baseline = "Direct, consultative, curious tone. Never em dashes."
+    out = synthesize_brain_injection(rules, persona_baseline=baseline)
+    assert "Persona:" in out.text
+    assert "Direct, consultative" in out.text
+    assert "Overrides:" in out.text
+    assert "r:d4e5" in out.text
+
+
+def test_brain_injection_persona_baseline_without_rules_still_emits():
+    baseline = "Empathetic, playbook-driven."
+    out = synthesize_brain_injection([], persona_baseline=baseline)
+    assert "Persona: Empathetic, playbook-driven." in out.text
+
+
+def test_brain_injection_loads_persona_from_path(tmp_path):
+    soul = tmp_path / "soul.md"
+    soul.write_text(
+        "# Voice\n\n> ignored blockquote\n\n* Direct, not aggressive.\n* No em dashes anywhere.\n",
+        encoding="utf-8",
+    )
+    out = synthesize_brain_injection([], persona_baseline=soul)
+    assert "Direct, not aggressive." in out.text
+    assert "No em dashes anywhere." in out.text
+    # Header and blockquote stripped.
+    assert "# Voice" not in out.text
+    assert "ignored blockquote" not in out.text
+
+
+def test_brain_injection_missing_persona_path_is_silent(tmp_path):
+    missing = tmp_path / "does_not_exist.md"
+    out = synthesize_brain_injection(
+        [_rule("DRAFTING", "concise", "a1f92b3c4d5e")],
+        persona_baseline=missing,
+    )
+    # Falls back gracefully — no Persona block, format block still emitted.
+    assert "Persona:" not in out.text
+    assert "Format:" in out.text
+
+
+def test_brain_injection_default_budget_respects_env(monkeypatch):
+    monkeypatch.delenv("GRADATA_SYNTH_BUDGET", raising=False)
+    assert DEFAULT_BUDGET_TOKENS == 400
+
+    monkeypatch.setenv("GRADATA_SYNTH_BUDGET", "50")
+    # Build enough rules to blow past 50 tokens.
+    rules = [
+        _rule(cat, f"rule {i} with some padding text here", f"{i:04x}{i:04x}{i:04x}")
+        for i, cat in enumerate(["PROCESS", "ACCURACY", "DRAFTING", "TONE", "PERSONA", "RESEARCH"])
+    ]
+    out = synthesize_brain_injection(rules)
+    # Under budget: token count estimate fits.
+    assert out.token_count_estimate() <= 50
+
+
+def test_brain_injection_budget_drops_lowest_priority_first():
+    rules = [
+        _rule("PROCESS", "task rule lorem ipsum dolor", "aaaa11112222"),
+        _rule("TONE", "tone rule lorem ipsum dolor sit amet", "bbbb11112222"),
+    ]
+    # Squeeze budget so only one slot fits: task sentence is ~7 tokens,
+    # tone sentence is ~8 — budget 10 keeps task, drops tone.
+    out = synthesize_brain_injection(rules, budget_tokens=10)
+    # Task (high priority) survives, Tone (low priority) dropped.
+    assert "Task:" in out.text
+    assert "Tone:" not in out.text
+    # Only task anchor retained.
+    assert "aaaa" in out.anchors_used
+    assert "bbbb" not in out.anchors_used
+
+
+def test_brain_injection_examples_slot_triggered_by_example_fields():
+    rules = [
+        {
+            "category": "DRAFTING",
+            "description": "prefer short subject lines",
+            "rule_id": "e5e51a2b3c4d",
+            "example_draft": "Quick chat about growth",
+            "example_corrected": "Chat?",
+        }
+    ]
+    out = synthesize_brain_injection(rules)
+    assert "Examples:" in out.text
+    assert "Format:" not in out.text
+
+
+def test_brain_injection_accepts_lesson_like_objects():
+    class FakeLesson:
+        category = "TONE"
+        description = "be curious"
+        slot = "tone"
+        example_draft = None
+        example_corrected = None
+
+        def __init__(self, rid: str) -> None:
+            self.rule_id = rid
+
+    out = synthesize_brain_injection([FakeLesson("f0f01a2b3c4d")])
+    assert "Tone: be curious" in out.text
+    assert "r:f0f0" in out.text
+
+
+def test_brain_injection_max_per_slot_caps():
+    rules = [_rule("PROCESS", f"rule {i}", f"{i:04x}00000000") for i in range(6)]
+    out = synthesize_brain_injection(rules, max_per_slot=2, budget_tokens=1000)
+    # Only two task rules rendered.
+    assert out.text.count("rule ") == 2
+
+
+def test_slot_order_is_preston_rhodes():
+    assert SLOT_ORDER == ("task", "context", "examples", "persona", "format", "tone")

--- a/Gradata/tests/test_slot_graduation.py
+++ b/Gradata/tests/test_slot_graduation.py
@@ -1,0 +1,109 @@
+"""Tests for Preston-Rhodes slot field + graduation-time classifier.
+
+Covers:
+- Lesson dataclass carries `slot` (default "").
+- format_lessons emits `  Slot: <value>` only when set.
+- parse_lessons round-trips the slot.
+- graduate() assigns a slot when promoting INSTINCT -> PATTERN.
+- graduate() assigns a slot when promoting PATTERN -> RULE.
+- classify_slot respects explicit-slot > example-pair > category inference.
+"""
+
+from __future__ import annotations
+
+from gradata._types import Lesson, LessonState
+from gradata.enhancements.self_improvement import (
+    format_lessons,
+    parse_lessons,
+    graduate,
+)
+
+
+def _mk(
+    *,
+    state: LessonState,
+    confidence: float,
+    fire_count: int,
+    category: str = "DRAFTING",
+    description: str = "Use tight prose; prefer verbs over nouns.",
+    slot: str = "",
+) -> Lesson:
+    return Lesson(
+        date="2026-04-21",
+        state=state,
+        confidence=confidence,
+        category=category,
+        description=description,
+        fire_count=fire_count,
+        slot=slot,
+    )
+
+
+class TestSlotField:
+    def test_default_slot_is_empty(self):
+        lesson = _mk(state=LessonState.INSTINCT, confidence=0.3, fire_count=0)
+        assert lesson.slot == ""
+
+    def test_format_omits_slot_when_empty(self):
+        lesson = _mk(state=LessonState.PATTERN, confidence=0.7, fire_count=3)
+        out = format_lessons([lesson])
+        assert "Slot:" not in out
+
+    def test_format_emits_slot_when_set(self):
+        lesson = _mk(
+            state=LessonState.PATTERN,
+            confidence=0.7,
+            fire_count=3,
+            slot="format",
+        )
+        out = format_lessons([lesson])
+        assert "  Slot: format" in out
+
+    def test_roundtrip_preserves_slot(self):
+        lesson = _mk(
+            state=LessonState.RULE,
+            confidence=0.95,
+            fire_count=7,
+            slot="tone",
+        )
+        text = format_lessons([lesson])
+        [reparsed] = parse_lessons(text)
+        assert reparsed.slot == "tone"
+
+
+class TestGraduationAssignsSlot:
+    def test_instinct_to_pattern_sets_slot(self):
+        # Needs confidence strictly > PATTERN_THRESHOLD (0.60) and fire_count >= 3.
+        lesson = _mk(
+            state=LessonState.INSTINCT,
+            confidence=0.65,
+            fire_count=3,
+            category="TONE",
+            description="Match the user's register; avoid corporate filler.",
+        )
+        assert lesson.slot == ""
+        graduate([lesson])
+        assert lesson.state == LessonState.PATTERN
+        assert lesson.slot != ""  # classifier assigned something
+
+    def test_existing_slot_is_preserved_on_promotion(self):
+        lesson = _mk(
+            state=LessonState.INSTINCT,
+            confidence=0.65,
+            fire_count=3,
+            slot="persona",
+        )
+        graduate([lesson])
+        assert lesson.state == LessonState.PATTERN
+        assert lesson.slot == "persona"
+
+    def test_no_promotion_leaves_slot_unset(self):
+        # Below fire-count gate — no promotion, no slot assignment.
+        lesson = _mk(
+            state=LessonState.INSTINCT,
+            confidence=0.70,
+            fire_count=1,
+        )
+        graduate([lesson])
+        assert lesson.state == LessonState.INSTINCT
+        assert lesson.slot == ""


### PR DESCRIPTION
## Summary

Lays the groundwork for wiring `prompt_synthesizer` into the session-start injection path (the legacy `inject_brain_rules.py` N-rules block will be replaced in a follow-up PR).

- **`synthesize_brain_injection(lessons, *, budget_tokens, max_per_slot, persona_baseline)`** — new slot-grouped entry point that orders rules by Preston Rhodes' 6-step checklist (task → context → examples → persona → format → tone), enforces a 400-token default budget, and preserves inline `r:xxxx` anchors for `capture_learning.py` attribution.
- **`classify_slot(item)`** — resolves explicit slot → example pair → category lookup → `context` fallback. Exposed at import time so graduation can tag lessons once, at promotion time.
- **`Lesson.slot`** — new optional dataclass field (default `""`). Format/parse round-trip through `lessons.md` as `  Slot: <value>`.
- **Graduation**: `_ensure_slot(lesson)` runs once per lesson at INSTINCT→PATTERN and PATTERN→RULE promotion. Idempotent; classifier errors are swallowed (slot is optional metadata).

Legacy `synthesize_rules_prompt` is untouched for back-compat. All existing tests remain green.

## Test plan

- [x] `tests/test_prompt_synthesizer.py` — 29 tests: classify_slot resolution order, Preston-Rhodes slot ordering, persona baseline (str vs Path), budget-drops-lowest-priority-first, examples-slot promotion on example_draft, Lesson-like object support.
- [x] `tests/test_slot_graduation.py` — 7 tests: default slot, format omits empty, format+parse round-trip, INSTINCT→PATTERN assigns slot, existing slot preserved, no-promotion leaves slot unset.
- [x] Full suite: 3931 pass, 2 skip (`pytest tests/`).

Generated with Gradata