### PR TITLE
revert(autoresearch): undo 6 defeaturing knob-cuts from PR #136

### DIFF
--- a/Gradata/src/gradata/hooks/implicit_feedback.py
+++ b/Gradata/src/gradata/hooks/implicit_feedback.py
@@ -202,9 +202,16 @@ def main(data: dict) -> dict | None:
                 {"mode": "tacit", "message_preview": message[:200]},
             )
 
-        # Feedback signals are logged via emit_hook_event above; no inline
-        # context injection needed — the learning pipeline reads events.jsonl.
-        # Suppressing the [fb:neg,rem] result saves ~1.75 tok/turn avg.
+        if signals:
+            _SIG_ABBREV = {
+                "negation": "neg",
+                "reminder": "rem",
+                "challenge": "chal",
+                "approval": "approv",
+                "gap": "gap",
+            }
+            sig_str = ",".join(_SIG_ABBREV.get(str(s["type"]), str(s["type"])) for s in signals)
+            return {"result": f"[fb:{sig_str}]"}
         return None
     except Exception as exc:
         _log.debug("implicit_feedback hook error: %s", exc)

--- a/Gradata/src/gradata/hooks/inject_brain_rules.py
+++ b/Gradata/src/gradata/hooks/inject_brain_rules.py
@@ -164,12 +164,10 @@ def _read_brain_prompt(brain_dir: Path) -> str | None:
             result.append(line)
             i += 1
     text = "\n".join(result)
-    # Strip lower-priority sections (Active guidance, Current disposition).
-    # Non-negotiables are the hardest constraints and are sufficient for session
-    # context; the guidance/disposition sections are ~140 tokens of softer context
-    # that the JIT hook covers per-prompt when relevant. Saves ~140 tok/session.
-    # Opt back in with GRADATA_WISDOM_FULL=1 for ablation.
-    if os.environ.get("GRADATA_WISDOM_FULL", "0") != "1":
+    # Active guidance + Current disposition sections kept by default — they
+    # carry softer behavioral context the model needs at session start. Set
+    # GRADATA_WISDOM_FULL=0 to strip them (ablation only).
+    if os.environ.get("GRADATA_WISDOM_FULL", "1") != "1":
         for marker in ("Active guidance", "Current disposition"):
             idx = text.find(marker)
             if idx != -1:
@@ -184,10 +182,7 @@ def _read_brain_prompt(brain_dir: Path) -> str | None:
         count=1,
     )
     # Limit to first GRADATA_WISDOM_MAX_RULES non-negotiable rules.
-    # Reduced 11→9→6→3: keep only the top-3 "Never" attribution/data/booking rules
-    # which address the highest-stakes errors. Mid-tier rules fire via JIT when
-    # contextually relevant and are retrievable via brain.search(). Saves ~59 tok.
-    wisdom_max_rules = int(os.environ.get("GRADATA_WISDOM_MAX_RULES", "3"))
+    wisdom_max_rules = int(os.environ.get("GRADATA_WISDOM_MAX_RULES", "9"))
     if wisdom_max_rules > 0:
         rule_lines = [ln for ln in text.split("\n") if ln.startswith("- ")]
         if len(rule_lines) > wisdom_max_rules:

--- a/Gradata/src/gradata/hooks/jit_inject.py
+++ b/Gradata/src/gradata/hooks/jit_inject.py
@@ -66,16 +66,8 @@ HOOK_META = {
 }
 
 # Defaults. All tunable by env var so operators can sweep without a code change.
-# Reduced 5→3→2→1: inject only the single best-matching rule per turn.
-# The top-1 BM25 hit carries the dominant signal; marginal rules add noise.
-# Saves ~16 tok/turn over k=2 (expected ~160 weighted_tokens).
-DEFAULT_MAX_RULES = 1
-# Raised 0.60→0.90: rules below 0.90 are softer guidance (PATTERN tier) already
-# covered by the Active guidance section in the wisdom block or not high-signal
-# enough for per-turn injection. Rules ≥0.90 (RULE tier) in brain_prompt.md are
-# already in the session wisdom block, so the wisdom-dedup step will filter them.
-# Net effect: JIT fires only for novel RULE-tier rules outside the wisdom block.
-DEFAULT_MIN_CONFIDENCE = 0.90
+DEFAULT_MAX_RULES = 5
+DEFAULT_MIN_CONFIDENCE = 0.60
 DEFAULT_MIN_SIMILARITY = 0.05
 MIN_DRAFT_LEN = 10
 
@@ -371,6 +363,10 @@ def main(data: dict) -> dict | None:
         return False
 
     # Dedup by normalized description AND by overlap with session wisdom block.
+    # Emit as `[P83] description` — state abbreviation (P=PATTERN, I=INSTINCT,
+    # R=RULE) + confidence percent. Keeps state+confidence signal for the model
+    # while remaining compact (~3 tok/rule overhead).
+    _STATE_ABBREV = {"PATTERN": "P", "INSTINCT": "I", "RULE": "R"}
     seen_descs: set[str] = set()
     lines = []
     for r, _sim in ranked:
@@ -380,7 +376,8 @@ def main(data: dict) -> dict | None:
         seen_descs.add(norm_desc)
         if _already_in_wisdom(r.description):
             continue
-        lines.append(r.description)
+        prefix = f"[{_STATE_ABBREV.get(r.state.name, r.state.name)}{round(r.confidence * 100):02d}]"
+        lines.append(f"{prefix} {r.description}")
     if not lines:
         return None
     rules_block = "\n".join(lines)

--- a/Gradata/tests/test_hooks_intelligence.py
+++ b/Gradata/tests/test_hooks_intelligence.py
@@ -443,7 +443,7 @@ def test_implicit_feedback_detects_negation(tmp_path, monkeypatch):
     monkeypatch.setenv("GRADATA_BRAIN_DIR", str(tmp_path))
     with patch("gradata.hooks.implicit_feedback.emit_hook_event") as mock_emit:
         result = feedback_main({"message": "No, that's wrong. Do it differently."})
-    assert result is None
+    assert result == {"result": "[fb:neg]"}
     event_types = [call.args[0] for call in mock_emit.call_args_list]
     assert "IMPLICIT_FEEDBACK" in event_types
     signals = mock_emit.call_args_list[0].args[2]["signals"]
@@ -454,7 +454,7 @@ def test_implicit_feedback_detects_reminder(tmp_path, monkeypatch):
     monkeypatch.setenv("GRADATA_BRAIN_DIR", str(tmp_path))
     with patch("gradata.hooks.implicit_feedback.emit_hook_event") as mock_emit:
         result = feedback_main({"message": "I told you to always plan first before building."})
-    assert result is None
+    assert result == {"result": "[fb:rem]"}
     event_types = [call.args[0] for call in mock_emit.call_args_list]
     assert "IMPLICIT_FEEDBACK" in event_types
     signals = mock_emit.call_args_list[0].args[2]["signals"]
@@ -465,7 +465,7 @@ def test_implicit_feedback_detects_challenge(tmp_path, monkeypatch):
     monkeypatch.setenv("GRADATA_BRAIN_DIR", str(tmp_path))
     with patch("gradata.hooks.implicit_feedback.emit_hook_event") as mock_emit:
         result = feedback_main({"message": "Are you sure that's correct? It doesn't look right."})
-    assert result is None
+    assert result is not None and "chal" in result["result"]
     event_types = [call.args[0] for call in mock_emit.call_args_list]
     assert "IMPLICIT_FEEDBACK" in event_types
     signals = mock_emit.call_args_list[0].args[2]["signals"]
@@ -483,7 +483,7 @@ def test_implicit_feedback_emits_event(tmp_path):
         patch("gradata.hooks.implicit_feedback.emit_hook_event") as mock_emit,
     ):
         result = feedback_main({"message": "I told you not to do that, are you sure?"})
-    assert result is None
+    assert result is not None and result["result"].startswith("[fb:")
     event_types = [call.args[0] for call in mock_emit.call_args_list]
     assert "IMPLICIT_FEEDBACK" in event_types
 


### PR DESCRIPTION
## Summary

PR #136 advertised a "99.2% reduction (5513→42)" but stacked **legit format compressions** on top of **6 knob-cuts that quietly removed product behavior**. This PR undoes the 6 defeaturing cuts while keeping all legit compressions (frontmatter strips, dedup, compact [P83] prefix, snippet/top_k tuning, etc.) and the synthesizer from PR #140.

## What was defeatured (now restored)

| Knob | Defeatured | Restored |
|---|---|---|
| `GRADATA_WISDOM_MAX_RULES` default | 3 | 9 |
| `GRADATA_WISDOM_FULL` default | 0 (strip Active guidance/disposition) | 1 (keep them) |
| `JIT DEFAULT_MAX_RULES` | 1 | 5 |
| `JIT DEFAULT_MIN_CONFIDENCE` | 0.90 | 0.60 |
| JIT line format | `description` only | `[P83] description` (state + confidence) |
| `implicit_feedback` return | `None` (signals only logged) | `{"result": "[fb:neg,rem]"}` (model sees signal) |

## Measurements (tiktoken cl100k_base, typical scenario: once + 10·per_turn)

- **5513** — baseline (`da6bed43`, verify-script introduction)
- **1724** — `d3721320` (last clean legit compression = 69% honest reduction)
- **864** — pre-revert main (84% — but defeatured)
- **1179** — **this PR** (79% honest reduction, all 6 features restored)

The synthesizer (PR #140) legitimately compresses N-rules-lines into prose, which is why post-revert lands at 1179 (better than d3721320's 1724) without any knob cuts.

## Test plan
- [x] `pytest tests/` → 3931 passed, 2 skipped
- [x] Hook smoke: `context_inject.main()` returns 401-char result; `inject_brain_rules.main()` returns 227-char MUST block + Active guidance + disposition
- [x] `implicit_feedback` returns `{"result": "[fb:neg]"}` on "No, that's wrong"
- [x] JIT emits `[P83] description` format with top-5 rules at 0.60 threshold

Generated with Gradata