### PR TITLE
fix(test): de-flake test_doctor_runs_on_brain

### DIFF
--- a/Gradata/tests/test_pattern_graduation_integration.py
+++ b/Gradata/tests/test_pattern_graduation_integration.py
@@ -495,7 +495,13 @@ class TestFullPipeline:
 
     def test_doctor_runs_on_brain(self, e2e_brain):
         from gradata._doctor import diagnose
-        report = diagnose(brain_dir=e2e_brain.dir)
+
+        # Scope the check to local brain health. Cloud probes (config.toml,
+        # network reachability, auth) are environment-dependent and not what
+        # this test asserts — they make the doctor return "broken" in CI and
+        # on dev machines without cloud credentials, even when the brain
+        # itself is perfectly fine.
+        report = diagnose(brain_dir=e2e_brain.dir, include_cloud=False)
         assert report["status"] in ("healthy", "degraded")
 
     def test_manifest_generates(self, e2e_brain):


### PR DESCRIPTION
Root cause:
`test_doctor_runs_on_brain` calls `diagnose(brain_dir=...)` which defaults to `include_cloud=True`. The cloud probes (`_check_cloud_config`, `_check_cloud_reachable`, `_check_cloud_auth`) check `~/.gradata/config.toml` and dial `api.gradata.ai`. In CI runners (and on dev machines without cloud credentials) `cloud_config` returns `fail` because `[cloud]` credentials are missing, which flips overall status to `broken`. The test only intends to assert the local brain is healthy.

Fix:
Pass `include_cloud=False` to scope the doctor to local brain checks (python, sqlite, system.db, manifest, etc.) — exactly what the fixture sets up. No production behavior changes; doctor implementation untouched.

Result: 4112 pass, 4 skipped, 0 fail (local `pytest -m "not integration"`).