### PR TITLE
feat: bundle handoff-watchdog Claude Code hooks as SDK installer assets (#135)

### DIFF
--- a/Gradata/.gitignore
+++ b/Gradata/.gitignore
@@ -6,3 +6,6 @@ sessions/handoff-*.md
 /0
 /BrainDetail
 bench/results/
+
+# pytest-MagicMock test artifact
+MagicMock/

--- a/Gradata/pyproject.toml
+++ b/Gradata/pyproject.toml
@@ -58,9 +58,23 @@ Documentation = "https://gradata.github.io/gradata/"
 [tool.hatch.build.targets.wheel]
 packages = ["src/gradata"]
 exclude = ["**/__pycache__", "**/*.pyc", "**/*.db", "**/*( 1)*", "**/* (1)*"]
+artifacts = [
+    "src/gradata/hooks/assets/**/*.js",
+]
 
 [tool.hatch.build.targets.sdist]
 exclude = ["**/__pycache__", "**/*.pyc", "**/*.db", "**/*( 1)*", "**/* (1)*"]
+artifacts = [
+    "src/gradata/hooks/assets/**/*.js",
+]
+
+# Setuptools-compatible package data (issue #135) — for non-hatchling builds
+# of the same source tree. Hatchling uses the artifacts entries above.
+[tool.setuptools.package-data]
+gradata = [
+    "hooks/assets/claude_code/user-prompt/*.js",
+    "hooks/assets/claude_code/session-start/*.js",
+]
 
 # --- Ruff (linter + formatter) ---
 [tool.ruff]

--- a/Gradata/src/gradata/cli.py
+++ b/Gradata/src/gradata/cli.py
@@ -1085,7 +1085,18 @@ def cmd_hooks(args):
     if action == "install":
         from gradata.hooks.claude_code import install_hook
 
-        install_hook(profile=getattr(args, "profile", "standard"))
+        project_dir = getattr(args, "project_dir", None)
+        if project_dir:
+            project_dir = Path(project_dir)
+        elif getattr(args, "include_watchdog", False):
+            # Watchdog needs an on-disk JS path; default to CWD when unset.
+            project_dir = Path.cwd()
+
+        install_hook(
+            profile=getattr(args, "profile", "standard"),
+            project_dir=project_dir,
+            include_watchdog=getattr(args, "include_watchdog", False),
+        )
     elif action == "uninstall":
         from gradata.hooks.claude_code import uninstall_hook
 
@@ -1278,6 +1289,16 @@ def main():
         choices=["minimal", "standard", "strict"],
         default="standard",
         help="Hook profile tier (default: standard)",
+    )
+    p_hooks.add_argument(
+        "--project-dir",
+        default=None,
+        help="Project directory whose .claude/hooks/ should receive bundled JS hook assets",
+    )
+    p_hooks.add_argument(
+        "--include-watchdog",
+        action="store_true",
+        help="Force-install the JS handoff watchdog hooks (#127) regardless of profile",
     )
 
     # seed — pre-populate brain with high-confidence starter rules

--- a/Gradata/src/gradata/hooks/_installer.py
+++ b/Gradata/src/gradata/hooks/_installer.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import stat
 import sys
 from pathlib import Path
 
@@ -42,6 +43,39 @@ HOOK_REGISTRY: list[tuple[str, str, str | None, Profile, int, str]] = [
     ("stale_hook_check",     "SessionStart",     None,                   Profile.STANDARD, 5000,  "Gradata: warn on stale generated hooks at session start"),
 ]
 
+# ---------------------------------------------------------------------------
+# JS asset registry — Claude-Code-specific Node hooks bundled as package data.
+# Tuple shape: (asset_subdir, asset_filename, event, matcher, profile, timeout, description)
+# These run via `node <project>/.claude/hooks/<subdir>/<filename>` instead of
+# `python -m gradata.hooks.<module>`. They wire features (like the handoff
+# watchdog from #127) into Claude Code's runtime — features that need access
+# to JS-only surfaces such as the statusline bridge file.
+# ---------------------------------------------------------------------------
+
+JS_HOOK_REGISTRY: list[tuple[str, str, str, str | None, Profile, int, str]] = [
+    (
+        "user-prompt",
+        "handoff-watchdog.js",
+        "UserPromptSubmit",
+        None,
+        Profile.STANDARD,
+        5000,
+        "Gradata: handoff watchdog — emit handoff directive on context pressure",
+    ),
+    (
+        "session-start",
+        "handoff-inject.js",
+        "SessionStart",
+        None,
+        Profile.STANDARD,
+        5000,
+        "Gradata: handoff inject — replay previous-session handoff on start",
+    ),
+]
+
+# Where bundled JS asset sources live inside the installed package
+_JS_ASSETS_ROOT = Path(__file__).parent / "assets" / "claude_code"
+
 SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
 
 
@@ -49,8 +83,13 @@ SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
 # Generate settings dict
 # ---------------------------------------------------------------------------
 
-def generate_settings(profile: str = "standard") -> dict:
-    """Generate a Claude Code settings dict with hooks for the given profile."""
+def generate_settings(profile: str = "standard", project_dir: Path | None = None) -> dict:
+    """Generate a Claude Code settings dict with hooks for the given profile.
+
+    If ``project_dir`` is supplied, the JS hooks bundled under
+    ``assets/claude_code/`` are also registered (referenced via their
+    on-disk path under ``<project_dir>/.claude/hooks/``).
+    """
     mapping = {"minimal": Profile.MINIMAL, "standard": Profile.STANDARD, "strict": Profile.STRICT}
     max_profile = mapping.get(profile.lower().strip(), Profile.STANDARD)
 
@@ -77,6 +116,26 @@ def generate_settings(profile: str = "standard") -> dict:
             group["matcher"] = matcher
 
         hooks_by_event[event].append(group)
+
+    # JS asset hooks — only register if a project_dir is supplied, since the
+    # `node <path>` command needs an actual on-disk script.
+    if project_dir is not None:
+        for subdir, filename, event, matcher, min_profile, timeout, description in JS_HOOK_REGISTRY:
+            if min_profile > max_profile:
+                continue
+            script_path = Path(project_dir) / ".claude" / "hooks" / subdir / filename
+            hook_entry = {
+                "type": "command",
+                "command": f"node {script_path}",
+                "timeout": timeout,
+            }
+            hooks_by_event.setdefault(event, []).append(
+                {
+                    "hooks": [hook_entry],
+                    "description": description,
+                    **({"matcher": matcher} if matcher else {}),
+                }
+            )
 
     return {"hooks": hooks_by_event}
 
@@ -118,15 +177,58 @@ def _is_gradata_hook(hook_group: dict) -> bool:
 # Public API
 # ---------------------------------------------------------------------------
 
-def install(profile: str = "standard") -> None:
-    """Install Gradata hooks into ~/.claude/settings.json."""
+def install(profile: str = "standard", project_dir: Path | None = None,
+            include_watchdog: bool = False) -> None:
+    """Install Gradata hooks into ~/.claude/settings.json.
+
+    Args:
+        profile: Hook profile tier — minimal, standard, or strict.
+        project_dir: If supplied, JS asset hooks are copied into
+            ``<project_dir>/.claude/hooks/`` (when the directory exists or the
+            user opted in) and registered in settings. Required when
+            ``include_watchdog`` is True at MINIMAL profile or to override the
+            default profile-tier behavior.
+        include_watchdog: Force-include the JS handoff watchdog hooks even if
+            the chosen profile would not normally activate them. No-op without
+            ``project_dir``.
+    """
     settings = _load_settings()
 
     # Remove any existing Gradata hooks first
     uninstall_from(settings)
 
-    # Generate new hooks
-    new = generate_settings(profile)
+    # Copy JS asset files when a project_dir is supplied. We always copy when
+    # asked — registry filtering controls which entries land in settings.json.
+    js_target = None
+    if project_dir is not None:
+        js_target = install_js_hooks(Path(project_dir))
+
+    # Generate new hooks (settings entries — JS entries only added when
+    # project_dir is supplied so the `node <path>` command is real on disk).
+    new = generate_settings(
+        profile,
+        project_dir=Path(project_dir) if project_dir is not None else None,
+    )
+
+    # If include_watchdog forces the JS hooks on a profile that would have
+    # filtered them out, splice them in explicitly.
+    if include_watchdog and project_dir is not None:
+        for subdir, filename, event, matcher, _min_profile, timeout, description in JS_HOOK_REGISTRY:
+            script_path = Path(project_dir) / ".claude" / "hooks" / subdir / filename
+            entry = {
+                "hooks": [{
+                    "type": "command",
+                    "command": f"node {script_path}",
+                    "timeout": timeout,
+                }],
+                "description": description,
+            }
+            if matcher:
+                entry["matcher"] = matcher
+            event_groups = new["hooks"].setdefault(event, [])
+            # Idempotent: skip if a group with the same description already exists
+            if not any(g.get("description") == description for g in event_groups):
+                event_groups.append(entry)
 
     existing_hooks = settings.setdefault("hooks", {})
     for event, groups in new["hooks"].items():
@@ -139,6 +241,8 @@ def install(profile: str = "standard") -> None:
     count = sum(len(groups) for groups in new["hooks"].values())
     _log.info("Gradata hooks installed (%d hooks, profile=%s)", count, profile)
     _log.info("  Settings: %s", SETTINGS_PATH)
+    if js_target is not None:
+        _log.info("  JS assets: %s", js_target)
 
     # Activation telemetry — fires once per machine, only if opted in.
     try:
@@ -147,6 +251,50 @@ def install(profile: str = "standard") -> None:
         _telemetry.send_once("first_hook_installed")
     except Exception:
         pass
+
+
+def install_js_hooks(project_dir: Path) -> Path:
+    """Copy bundled JS hook assets into ``<project_dir>/.claude/hooks/``.
+
+    Idempotent: existing files with identical content are left alone; differing
+    files are overwritten (the SDK ships the canonical version). Preserves the
+    executable bit on Unix-like systems.
+
+    Returns the destination root (``<project_dir>/.claude/hooks/``) so callers
+    can log it.
+    """
+    project_dir = Path(project_dir)
+    target_root = project_dir / ".claude" / "hooks"
+    target_root.mkdir(parents=True, exist_ok=True)
+
+    if not _JS_ASSETS_ROOT.is_dir():
+        _log.warning("JS asset root missing: %s", _JS_ASSETS_ROOT)
+        return target_root
+
+    for subdir, filename, *_rest in JS_HOOK_REGISTRY:
+        src = _JS_ASSETS_ROOT / subdir / filename
+        if not src.is_file():
+            _log.warning("JS asset not bundled: %s", src)
+            continue
+        dst_dir = target_root / subdir
+        dst_dir.mkdir(parents=True, exist_ok=True)
+        dst = dst_dir / filename
+
+        new_bytes = src.read_bytes()
+        if dst.is_file() and dst.read_bytes() == new_bytes:
+            _log.debug("JS hook unchanged: %s", dst)
+            continue
+
+        dst.write_bytes(new_bytes)
+        # Preserve executable bit (no-op on Windows)
+        try:
+            mode = dst.stat().st_mode
+            dst.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        except OSError:
+            pass
+        _log.info("Installed JS hook: %s", dst)
+
+    return target_root
 
 
 def uninstall() -> None:

--- a/Gradata/src/gradata/hooks/assets/claude_code/session-start/handoff-inject.js
+++ b/Gradata/src/gradata/hooks/assets/claude_code/session-start/handoff-inject.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * handoff-inject.js — SessionStart hook
+ *
+ * Pairs with user-prompt/handoff-watchdog.js: when the previous session
+ * crossed GRADATA_HANDOFF_THRESHOLD and wrote a handoff doc to
+ * <BRAIN_DIR>/handoffs/, this hook injects it on the next session's
+ * SessionStart and moves the file to handoffs/consumed/ so it only
+ * fires once.
+ *
+ * Mirrors gradata.contrib.patterns.handoff.pick_latest_unconsumed +
+ * consume_handoff so SDK consumers and Claude Code agree on the file layout.
+ *
+ * Self-contained — BRAIN_DIR is resolved from BRAIN_DIR or GRADATA_BRAIN_DIR
+ * env vars, falling back to ~/.gradata/brain.
+ */
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+function resolveBrainDir() {
+  const env = process.env.BRAIN_DIR || process.env.GRADATA_BRAIN_DIR;
+  if (env) return env;
+  return path.join(os.homedir(), '.gradata', 'brain');
+}
+const BRAIN_DIR = resolveBrainDir();
+
+const handoffDir = path.join(BRAIN_DIR, 'handoffs');
+if (!fs.existsSync(handoffDir)) process.exit(0);
+
+// Pick latest *.handoff.md at the top level (skip consumed/).
+let latest = null;
+try {
+  const entries = fs.readdirSync(handoffDir, { withFileTypes: true });
+  let best = 0;
+  for (const e of entries) {
+    if (!e.isFile() || !e.name.endsWith('.handoff.md')) continue;
+    const p = path.join(handoffDir, e.name);
+    const m = fs.statSync(p).mtimeMs;
+    if (m > best) { best = m; latest = p; }
+  }
+} catch (_) { process.exit(0); }
+
+if (!latest) process.exit(0);
+
+let body = '';
+try { body = fs.readFileSync(latest, 'utf-8'); } catch (_) { process.exit(0); }
+if (!body.trim()) process.exit(0);
+
+// Move to consumed/ (preserve for audit — matches SDK consume_handoff).
+try {
+  const consumedDir = path.join(handoffDir, 'consumed');
+  fs.mkdirSync(consumedDir, { recursive: true });
+  fs.renameSync(latest, path.join(consumedDir, path.basename(latest)));
+} catch (_) { /* best-effort: a stale file is preferable to breaking startup */ }
+
+const injection = [
+  '<handoff from-prev-session path="' + latest + '">',
+  body.trim(),
+  '</handoff>',
+  '',
+  'The previous session crossed the context-pressure threshold and left this',
+  'handoff. Resume from "Next action" — do not re-plan.',
+].join('\n');
+
+process.stdout.write(JSON.stringify({ result: injection }));

--- a/Gradata/src/gradata/hooks/assets/claude_code/user-prompt/handoff-watchdog.js
+++ b/Gradata/src/gradata/hooks/assets/claude_code/user-prompt/handoff-watchdog.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * handoff-watchdog.js — UserPromptSubmit hook
+ *
+ * Wires the Python SDK's HandoffWatchdog pattern (gradata.contrib.patterns.handoff,
+ * issue #127) into Claude Code's runtime.
+ *
+ * Statusline writes used_pct to a bridge file each render; we read it here
+ * instead of re-estimating from the transcript. When pressure crosses
+ * GRADATA_HANDOFF_THRESHOLD (default 0.65), emit a directive telling the
+ * current agent to write a handoff doc to <BRAIN_DIR>/handoffs/ before the
+ * context compacts.
+ *
+ * Self-contained — does not require any sibling JS file. BRAIN_DIR is resolved
+ * from the BRAIN_DIR or GRADATA_BRAIN_DIR env var, falling back to ~/.gradata/brain.
+ *
+ * Silent on failure. Never blocks the prompt.
+ */
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+function resolveBrainDir() {
+  const env = process.env.BRAIN_DIR || process.env.GRADATA_BRAIN_DIR;
+  if (env) return env;
+  return path.join(os.homedir(), '.gradata', 'brain');
+}
+const BRAIN_DIR = resolveBrainDir();
+
+let input = '';
+try { input = fs.readFileSync(0, 'utf-8'); } catch (_) { process.exit(0); }
+
+let session = '';
+try {
+  const parsed = JSON.parse(input);
+  session = parsed.session_id || '';
+} catch (_) { /* silent */ }
+if (!session) process.exit(0);
+
+// Read threshold (default 0.65, overridable via env). Clamp to [0.10, 0.95]
+// to match the SDK's HandoffWatchdog bounds.
+function readThreshold() {
+  const raw = process.env.GRADATA_HANDOFF_THRESHOLD;
+  if (!raw) return 0.65;
+  const v = parseFloat(raw);
+  if (Number.isNaN(v) || v < 0.10 || v > 0.95) return 0.65;
+  return v;
+}
+const threshold = readThreshold();
+
+// Statusline bridge file — written on each render, carries buffer-normalized
+// used_pct. If absent, the statusline hasn't run yet this session; bail.
+const bridgePath = path.join(os.tmpdir(), `claude-ctx-${session}.json`);
+if (!fs.existsSync(bridgePath)) process.exit(0);
+
+let usedPct = 0;
+try {
+  const bridge = JSON.parse(fs.readFileSync(bridgePath, 'utf-8'));
+  usedPct = Number(bridge.used_pct) || 0;
+} catch (_) { process.exit(0); }
+
+if (usedPct / 100 < threshold) process.exit(0);
+
+const handoffDir = path.join(BRAIN_DIR, 'handoffs');
+try { fs.mkdirSync(handoffDir, { recursive: true }); } catch (_) { /* silent */ }
+const handoffPath = path.join(handoffDir, `${session}.handoff.md`);
+
+// Self-healing: the handoff is "done" only when the file actually exists on
+// disk. If the agent ignored the directive on the first fire, we keep
+// nagging on every subsequent prompt until the file is written. The sentinel
+// just tracks whether we've *ever* fired so we can soften the wording on
+// retries.
+if (fs.existsSync(handoffPath)) process.exit(0);
+
+const sentinel = path.join(os.tmpdir(), `gradata-handoff-fired-${session}.flag`);
+const isRetry = fs.existsSync(sentinel);
+try { fs.writeFileSync(sentinel, String(Date.now())); } catch (_) { /* silent */ }
+
+// Emit directive — the current agent sees this as system context and writes
+// the handoff doc itself. Shape mirrors gradata.contrib.patterns.handoff
+// so the SessionStart injector can parse it back on the next session.
+const directive = [
+  '<handoff-watchdog threshold="' + Math.round(threshold * 100) + '" used="' + usedPct + '"' + (isRetry ? ' retry="true"' : '') + '>',
+  (isRetry
+    ? 'REMINDER: the handoff doc was requested on a previous prompt but has not been written yet. Write it now before responding — context pressure is still at ' + usedPct + '%.'
+    : 'Context pressure has crossed the handoff threshold (' + usedPct + '% used, threshold ' + Math.round(threshold * 100) + '%).'),
+  'Write a compact resume doc to:',
+  '  ' + handoffPath,
+  '',
+  'Shape (match exactly so the next session can parse it):',
+  '  # Handoff — <task-id>',
+  '  _from_: <agent-name>  _at_: <ISO-timestamp>',
+  '  _rules_ts_: <ISO-timestamp>',
+  '',
+  '  ## Where we left off',
+  '  <2-4 sentences on current state>',
+  '',
+  '  ## Next action',
+  '  <the exact next step — command, file, or decision>',
+  '',
+  '  ## Open questions',
+  '  - <anything unresolved>',
+  '',
+  '  ## Artifacts',
+  '  - <PRs, file paths, commit SHAs>',
+  '',
+  'Do this now, then continue with the user\'s current message. The next',
+  'Claude Code session will inject this doc on SessionStart so you pick up',
+  'exactly where this one left off.',
+  '</handoff-watchdog>',
+].join('\n');
+
+process.stdout.write(JSON.stringify({ result: directive }));

--- a/Gradata/src/gradata/hooks/claude_code.py
+++ b/Gradata/src/gradata/hooks/claude_code.py
@@ -15,11 +15,12 @@ import json
 import sys
 
 
-def install_hook(profile: str = "standard") -> None:
+def install_hook(profile: str = "standard", project_dir=None,
+                 include_watchdog: bool = False) -> None:
     """Add Gradata hooks to Claude Code settings."""
     from gradata.hooks._installer import install
 
-    install(profile)
+    install(profile, project_dir=project_dir, include_watchdog=include_watchdog)
 
 
 def uninstall_hook() -> None:

--- a/Gradata/tests/test_handoff_js_installer.py
+++ b/Gradata/tests/test_handoff_js_installer.py
@@ -1,0 +1,172 @@
+"""Tests for the JS hook bundling/installer flow (issue #135)."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from gradata.hooks._installer import (
+    JS_HOOK_REGISTRY,
+    _JS_ASSETS_ROOT,
+    install_js_hooks,
+    generate_settings,
+)
+
+
+def test_js_assets_bundled_in_package():
+    """The two JS hook files must ship as package data."""
+    assert _JS_ASSETS_ROOT.is_dir(), f"Missing assets root: {_JS_ASSETS_ROOT}"
+    watchdog = _JS_ASSETS_ROOT / "user-prompt" / "handoff-watchdog.js"
+    inject = _JS_ASSETS_ROOT / "session-start" / "handoff-inject.js"
+    assert watchdog.is_file(), "handoff-watchdog.js missing from assets"
+    assert inject.is_file(), "handoff-inject.js missing from assets"
+    # Sanity: both should reference the directives the SDK expects.
+    assert "handoff-watchdog" in watchdog.read_text(encoding="utf-8")
+    assert "handoff" in inject.read_text(encoding="utf-8").lower()
+
+
+def test_install_js_hooks_copies_files(tmp_path: Path):
+    """install_js_hooks must drop both files into the right subdirs."""
+    project_dir = tmp_path / "myproj"
+    project_dir.mkdir()
+
+    target_root = install_js_hooks(project_dir)
+    assert target_root == project_dir / ".claude" / "hooks"
+
+    watchdog = target_root / "user-prompt" / "handoff-watchdog.js"
+    inject = target_root / "session-start" / "handoff-inject.js"
+
+    assert watchdog.is_file()
+    assert inject.is_file()
+
+    # Content matches the bundled source byte-for-byte
+    src_watchdog = _JS_ASSETS_ROOT / "user-prompt" / "handoff-watchdog.js"
+    assert watchdog.read_bytes() == src_watchdog.read_bytes()
+
+
+def test_install_js_hooks_idempotent(tmp_path: Path):
+    """Re-running install_js_hooks must not duplicate or clobber unchanged files."""
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+
+    install_js_hooks(project_dir)
+    watchdog = project_dir / ".claude" / "hooks" / "user-prompt" / "handoff-watchdog.js"
+    mtime1 = watchdog.stat().st_mtime_ns
+    original_bytes = watchdog.read_bytes()
+
+    # Second invocation — same content already on disk, file should be left alone
+    install_js_hooks(project_dir)
+    assert watchdog.read_bytes() == original_bytes
+    # mtime should not have changed (we didn't rewrite)
+    assert watchdog.stat().st_mtime_ns == mtime1
+
+
+def test_install_js_hooks_overwrites_drift(tmp_path: Path):
+    """If a user-edited copy diverges from the canonical asset, the SDK rewrites it."""
+    project_dir = tmp_path / "p"
+    project_dir.mkdir()
+    install_js_hooks(project_dir)
+    watchdog = project_dir / ".claude" / "hooks" / "user-prompt" / "handoff-watchdog.js"
+
+    watchdog.write_text("// stale", encoding="utf-8")
+    install_js_hooks(project_dir)
+
+    # Canonical content restored
+    assert "handoff-watchdog" in watchdog.read_text(encoding="utf-8")
+
+
+def test_generate_settings_registers_js_hooks_with_project_dir(tmp_path: Path):
+    """generate_settings(project_dir=...) must include JS hook entries at STANDARD."""
+    settings = generate_settings("standard", project_dir=tmp_path)
+    hooks = settings["hooks"]
+
+    # JS watchdog lands on UserPromptSubmit
+    descs = [g.get("description", "") for g in hooks.get("UserPromptSubmit", [])]
+    assert any("handoff watchdog" in d for d in descs)
+
+    descs_ss = [g.get("description", "") for g in hooks.get("SessionStart", [])]
+    assert any("handoff inject" in d for d in descs_ss)
+
+    # And the command points to a node invocation under project_dir
+    for group in hooks.get("UserPromptSubmit", []):
+        if "handoff watchdog" in group.get("description", ""):
+            cmd = group["hooks"][0]["command"]
+            assert cmd.startswith("node ")
+            assert "handoff-watchdog.js" in cmd
+            assert str(tmp_path) in cmd
+
+
+def test_generate_settings_omits_js_hooks_without_project_dir():
+    """Without project_dir, JS hooks are not registered (no real on-disk path)."""
+    settings = generate_settings("standard", project_dir=None)
+    for groups in settings["hooks"].values():
+        for g in groups:
+            assert "handoff watchdog" not in g.get("description", "")
+            assert "handoff inject" not in g.get("description", "")
+
+
+# ---------------------------------------------------------------------------
+# Integration: simulate Claude Code invoking the watchdog with a bridge file
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+def test_handoff_watchdog_emits_directive_when_pressure_high(tmp_path: Path):
+    """End-to-end: copy hook into a fresh .claude/, fake the bridge file, run the JS."""
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    install_js_hooks(project_dir)
+    watchdog = project_dir / ".claude" / "hooks" / "user-prompt" / "handoff-watchdog.js"
+    assert watchdog.is_file()
+
+    brain_dir = tmp_path / "brain"
+    brain_dir.mkdir()
+
+    # Fake the statusline bridge file to look like high context pressure.
+    session_id = "test-session-135"
+    tmpdir = tempfile.gettempdir()
+    bridge_path = Path(tmpdir) / f"claude-ctx-{session_id}.json"
+    bridge_path.write_text(json.dumps({"used_pct": 85}), encoding="utf-8")
+
+    # Clean up any existing handoff/sentinel for this session
+    for name in (
+        f"gradata-handoff-fired-{session_id}.flag",
+    ):
+        p = Path(tmpdir) / name
+        if p.exists():
+            p.unlink()
+
+    env = os.environ.copy()
+    env["BRAIN_DIR"] = str(brain_dir)
+    env["GRADATA_HANDOFF_THRESHOLD"] = "0.5"
+
+    try:
+        proc = subprocess.run(
+            ["node", str(watchdog)],
+            input=json.dumps({"session_id": session_id}),
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+        )
+    finally:
+        # cleanup
+        if bridge_path.exists():
+            bridge_path.unlink()
+        sentinel = Path(tmpdir) / f"gradata-handoff-fired-{session_id}.flag"
+        if sentinel.exists():
+            sentinel.unlink()
+
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip(), "watchdog should emit a directive at 85% used"
+
+    payload = json.loads(proc.stdout)
+    assert "result" in payload
+    assert "<handoff-watchdog" in payload["result"]
+    assert "handoff" in payload["result"].lower()


### PR DESCRIPTION
Closes #135.

Bundles `handoff-watchdog.js` + `handoff-inject.js` under `src/gradata/hooks/assets/claude_code/{user-prompt,session-start}/`.

## Changes
- New `install_js_hooks(project_dir)` in `_installer.py` (idempotent, byte-compare diff before write, preserves +x bit)
- New `JS_HOOK_REGISTRY` (js_asset variant) at STANDARD profile tier
- CLI flags: `gradata hooks install --project-dir <path> --include-watchdog`
- `pyproject.toml` package-data + hatch artifacts entries so JS ships in the wheel
- Self-contained JS hooks: BRAIN_DIR resolved from env vars + ~/.gradata/brain fallback (no require chain)

## Tests
- 7 new tests in `test_handoff_js_installer.py` — all pass:
  - bundle present, copy correctness, idempotency, drift overwrite, settings registration with/without project_dir, real-node integration
- Full suite: 4118 passed (+1 fixed flake in #157)

## Bonus
- Added `MagicMock/` to `.gitignore` (pytest test-artifact pollution from string-cast MagicMock paths)