### PR TITLE
feat: examples + output_shape on Lesson schema (#129)

### DIFF
--- a/Gradata/src/gradata/_types.py
+++ b/Gradata/src/gradata/_types.py
@@ -136,6 +136,26 @@ class RuleMetadata:
 
 
 @dataclass
+class Example:
+    """A good/bad pair illustrating a lesson (issue #129).
+
+    Populated only from real surviving corrections — never LLM-generated.
+    Both ``good`` and ``bad`` should be one short sentence each so that
+    rendering inside ``<rule>`` blocks stays cheap on injection budget.
+    """
+
+    good: str = ""
+    bad: str = ""
+
+    def to_dict(self) -> dict:
+        return {"good": self.good, "bad": self.bad}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Example":
+        return cls(good=str(data.get("good", "")), bad=str(data.get("bad", "")))
+
+
+@dataclass
 class Lesson:
     """A single learned lesson with confidence tracking."""
 
@@ -188,6 +208,16 @@ class Lesson:
     # Assigned at graduation time by prompt_synthesizer.classify_slot. Empty on legacy
     # lessons; the synthesizer falls back to category-based inference at render time.
     slot: str = ""
+    # ── Issue #129: examples + output_shape (prompt-injection standard) ──
+    # Optional list of good/bad pairs, populated only when the lesson has
+    # surviving evidence (real corrections). Rendered inside <rule> blocks
+    # by the brain-injection template. Defaults to empty list for
+    # back-compat: pre-upgrade serialized lessons load without Examples.
+    examples: list[Example] = field(default_factory=list)
+    # Short tag describing the shape this lesson governs ("tone",
+    # "format:markdown-table", "length<=200w", …). ``None`` when the
+    # lesson is a pure constraint (no output-shape opinion).
+    output_shape: str | None = None
 
     def __post_init__(self) -> None:
         self.confidence = round(max(0.0, min(1.0, self.confidence)), 2)

--- a/Gradata/src/gradata/enhancements/self_improvement/_confidence.py
+++ b/Gradata/src/gradata/enhancements/self_improvement/_confidence.py
@@ -16,6 +16,7 @@ import re
 
 from gradata._types import (
     CorrectionType,
+    Example,
     Lesson,
     LessonState,
     transition,
@@ -371,6 +372,8 @@ def parse_lessons(text: str) -> list[Lesson]:
         alpha = 1.0
         beta_param_val = 1.0
         slot = ""
+        examples: list[Example] = []
+        output_shape: str | None = None
         j = i + 1
         while j < len(lines) and lines[j].startswith("  "):
             meta_line = lines[j].strip()
@@ -409,6 +412,18 @@ def parse_lessons(text: str) -> list[Lesson]:
                     domain_scores = {}
             elif meta_line.startswith("Slot:"):
                 slot = meta_line[len("Slot:") :].strip().lower()
+            elif meta_line.startswith("Examples:"):
+                # Issue #129: persisted as JSON array of {good, bad} pairs
+                try:
+                    raw_examples = json.loads(meta_line[len("Examples:") :].strip())
+                    if isinstance(raw_examples, list):
+                        for ex in raw_examples:
+                            if isinstance(ex, dict):
+                                examples.append(Example.from_dict(ex))
+                except (json.JSONDecodeError, ValueError, TypeError):
+                    pass
+            elif meta_line.startswith("Output shape:"):
+                output_shape = meta_line[len("Output shape:") :].strip() or None
             elif meta_line.startswith("Path:"):
                 path = meta_line[len("Path:") :].strip()
             elif meta_line.startswith("Secondary categories:"):
@@ -468,6 +483,8 @@ def parse_lessons(text: str) -> list[Lesson]:
             last_climb_session=last_climb_session,
             tree_level=tree_level,
             slot=slot,
+            examples=examples,
+            output_shape=output_shape,
         )
         if metadata_obj is not None:
             _lesson.metadata = metadata_obj
@@ -1116,6 +1133,18 @@ def format_lessons(lessons: list[Lesson]) -> str:
 
         if getattr(lesson, "slot", ""):
             lines.append(f"  Slot: {lesson.slot}")
+
+        # Issue #129: examples + output_shape — only write when populated.
+        _examples = getattr(lesson, "examples", None) or []
+        if _examples:
+            payload = [
+                e.to_dict() if hasattr(e, "to_dict") else dict(e)
+                for e in _examples
+            ]
+            lines.append(f"  Examples: {json.dumps(payload, ensure_ascii=False)}")
+        _output_shape = getattr(lesson, "output_shape", None)
+        if _output_shape:
+            lines.append(f"  Output shape: {_output_shape}")
 
         if lesson.path:
             lines.append(f"  Path: {lesson.path}")

--- a/Gradata/src/gradata/rules/rule_engine/_formatting.py
+++ b/Gradata/src/gradata/rules/rule_engine/_formatting.py
@@ -331,14 +331,40 @@ def format_rules_for_prompt(
     ]
 
     for rule in rules:
-        lines.append(f"- {rule.instruction}")
+        lesson = rule.lesson
+        # Issue #129: when a lesson carries Example pairs and/or an
+        # output_shape, render the rule as a structured XML block so the
+        # agent sees <good>/<bad>/<shape> alongside the goal. Falls back
+        # to the legacy bullet form when none of those fields are set.
+        examples = list(getattr(lesson, "examples", None) or [])
+        output_shape = getattr(lesson, "output_shape", None)
+        if examples or output_shape:
+            lines.append("<rule>")
+            goal = (rule.instruction or lesson.description or "").strip()
+            lines.append(f"  <goal>{goal}</goal>")
+            if output_shape:
+                lines.append(f"  <shape>{output_shape}</shape>")
+            for ex in examples:
+                good = (getattr(ex, "good", "") or "").strip()
+                bad = (getattr(ex, "bad", "") or "").strip()
+                if good:
+                    lines.append(f"  <good>{good}</good>")
+                if bad:
+                    lines.append(f"  <bad>{bad}</bad>")
+            lines.append("</rule>")
+        else:
+            lines.append(f"- {rule.instruction}")
 
         # Include few-shot examples only for low-confidence rules with misfires
-        lesson = rule.lesson
         needs_reinforcement = lesson.confidence < 0.70 and getattr(lesson, "misfire_count", 0) > 1
         example_draft = getattr(lesson, "example_draft", None)
         example_corrected = getattr(lesson, "example_corrected", None)
-        if needs_reinforcement and example_draft is not None and example_corrected is not None:
+        if (
+            not (examples or output_shape)
+            and needs_reinforcement
+            and example_draft is not None
+            and example_corrected is not None
+        ):
             lines.append(f'   e.g. "{example_draft[:80]}" -> "{example_corrected[:80]}"')
 
     lines.append("</brain-rules>")
@@ -459,4 +485,27 @@ def capture_example_from_correction(
     """
     lesson.example_draft = draft[:_EXAMPLE_MAX_CHARS]
     lesson.example_corrected = corrected[:_EXAMPLE_MAX_CHARS]
+
+    # Issue #129: also append a structured Example so the brain-injection
+    # template can render <good>/<bad> for this lesson. Real surviving
+    # corrections only — never LLM-fabricated.
+    try:
+        from gradata._types import Example as _Example
+
+        good_text = corrected[:_EXAMPLE_MAX_CHARS].strip()
+        bad_text = draft[:_EXAMPLE_MAX_CHARS].strip()
+        if good_text and bad_text:
+            existing = list(getattr(lesson, "examples", None) or [])
+            # De-dupe: skip if the same pair is already attached.
+            already = any(
+                getattr(e, "good", "") == good_text and getattr(e, "bad", "") == bad_text
+                for e in existing
+            )
+            if not already:
+                existing.append(_Example(good=good_text, bad=bad_text))
+                # Cap to keep injection budget bounded.
+                lesson.examples = existing[-3:]
+    except Exception:  # noqa: BLE001 — never fail correction capture on Example back-compat
+        pass
+
     return lesson

--- a/Gradata/tests/test_lesson_examples.py
+++ b/Gradata/tests/test_lesson_examples.py
@@ -1,0 +1,145 @@
+"""Tests for issue #129: Lesson.examples + Lesson.output_shape.
+
+Covers:
+    a. Lesson dataclass round-trip (format_lessons -> parse_lessons).
+    b. Backward-compat: legacy markdown without Examples/Output shape.
+    c. Rule engine formatting: structured <rule>/<good>/<bad>/<shape>
+       XML when populated, legacy bullet otherwise.
+    d. capture_example_from_correction appends de-duped Example, capped at 3.
+"""
+
+from __future__ import annotations
+
+from gradata._types import Example, Lesson, LessonState
+from gradata.enhancements.self_improvement import format_lessons, parse_lessons
+from gradata.rules.rule_engine import (
+    AppliedRule,
+    capture_example_from_correction,
+    format_rules_for_prompt,
+)
+
+
+def _make_lesson(**kwargs) -> Lesson:
+    base = dict(
+        date="2025-01-01",
+        state=LessonState.RULE,
+        confidence=0.92,
+        category="DRAFTING",
+        description="Use markdown tables for tabular comparisons",
+    )
+    base.update(kwargs)
+    return Lesson(**base)
+
+
+def test_lesson_round_trip_preserves_examples_and_output_shape():
+    """Round-trip: format_lessons() -> parse_lessons() preserves new fields."""
+    lesson = _make_lesson(
+        examples=[
+            Example(good="Use a table with 3 columns", bad="Use a long paragraph"),
+            Example(good="Header row uses bold", bad="Header row left plain"),
+        ],
+        output_shape="format:markdown-table",
+    )
+
+    rendered = format_lessons([lesson])
+    parsed = parse_lessons(rendered)
+
+    assert len(parsed) == 1
+    p = parsed[0]
+    assert p.output_shape == "format:markdown-table"
+    assert len(p.examples) == 2
+    assert p.examples[0].good == "Use a table with 3 columns"
+    assert p.examples[0].bad == "Use a long paragraph"
+    assert p.examples[1].good == "Header row uses bold"
+    assert p.examples[1].bad == "Header row left plain"
+    # Core fields preserved too
+    assert p.category == "DRAFTING"
+    assert p.state == LessonState.RULE
+    assert p.confidence == 0.92
+
+
+def test_legacy_lesson_markdown_parses_without_examples():
+    """Backward-compat: lessons.md predating issue #129 must still parse."""
+    legacy = (
+        "[2024-12-15] [RULE:0.91] TONE: Be concise — avoid filler phrases\n"
+        "  Root cause: filler dilutes the signal\n"
+        "  Fire count: 4 | Sessions since fire: 1 | Misfires: 0\n"
+    )
+
+    parsed = parse_lessons(legacy)
+
+    assert len(parsed) == 1
+    p = parsed[0]
+    assert p.examples == []
+    assert p.output_shape is None
+    assert p.category == "TONE"
+    assert p.fire_count == 4
+
+
+def test_format_rules_for_prompt_renders_structured_xml_when_populated():
+    """When examples or output_shape is set, render <rule><goal/><shape/><good/><bad/></rule>;
+    otherwise fall back to the legacy bullet form."""
+    rich_lesson = _make_lesson(
+        examples=[Example(good="3-column table", bad="long paragraph")],
+        output_shape="format:markdown-table",
+    )
+    plain_lesson = _make_lesson(
+        category="TONE",
+        description="Be concise",
+        examples=[],
+        output_shape=None,
+    )
+
+    rich = AppliedRule(
+        rule_id="DRAFTING:0001",
+        lesson=rich_lesson,
+        relevance=1.0,
+        instruction="Use markdown tables for tabular comparisons",
+    )
+    plain = AppliedRule(
+        rule_id="TONE:0002",
+        lesson=plain_lesson,
+        relevance=1.0,
+        instruction="Be concise",
+    )
+
+    # Rich rule: structured XML.
+    out_rich = format_rules_for_prompt([rich], merge=False, entropy_search=False)
+    assert "<brain-rules>" in out_rich
+    assert "<rule>" in out_rich and "</rule>" in out_rich
+    assert "<goal>Use markdown tables for tabular comparisons</goal>" in out_rich
+    assert "<shape>format:markdown-table</shape>" in out_rich
+    assert "<good>3-column table</good>" in out_rich
+    assert "<bad>long paragraph</bad>" in out_rich
+
+    # Plain rule: legacy bullet, no <rule> wrapper.
+    out_plain = format_rules_for_prompt([plain], merge=False, entropy_search=False)
+    assert "<rule>" not in out_plain
+    assert "- Be concise" in out_plain
+
+
+def test_capture_example_appends_dedup_and_caps_at_three():
+    """capture_example_from_correction appends Example(good, bad), de-dupes
+    identical pairs, and caps the list at 3 entries."""
+    lesson = _make_lesson()
+
+    # First capture
+    capture_example_from_correction(lesson, draft="bad v1", corrected="good v1")
+    assert len(lesson.examples) == 1
+    assert lesson.examples[0].good == "good v1"
+    assert lesson.examples[0].bad == "bad v1"
+
+    # Duplicate is skipped
+    capture_example_from_correction(lesson, draft="bad v1", corrected="good v1")
+    assert len(lesson.examples) == 1
+
+    # Append two more distinct
+    capture_example_from_correction(lesson, draft="bad v2", corrected="good v2")
+    capture_example_from_correction(lesson, draft="bad v3", corrected="good v3")
+    assert len(lesson.examples) == 3
+
+    # Fourth distinct trims to most recent 3 (cap=3)
+    capture_example_from_correction(lesson, draft="bad v4", corrected="good v4")
+    assert len(lesson.examples) == 3
+    assert [e.good for e in lesson.examples] == ["good v2", "good v3", "good v4"]
+    assert [e.bad for e in lesson.examples] == ["bad v2", "bad v3", "bad v4"]


### PR DESCRIPTION
Closes #129.

## Changes
- New `Example` dataclass with `good`/`bad` fields
- New optional fields on `Lesson`: `examples: list[Example]`, `output_shape: str | None`
- Markdown round-trip preserved (parse_lessons + format_lessons)
- Rule injection emits structured `<rule><goal/><shape/><good/><bad/></rule>` XML when populated
- `capture_example_from_correction` populates examples on graduation (de-duped, cap=3)
- 4 new tests cover round-trip + back-compat + rendering + capture

## Test plan
- `pytest tests/test_lesson_examples.py -xvs` — 4/4 pass
- Full suite (excluding integration): 4115 pass, 1 pre-existing flake (`test_doctor_runs_on_brain`, fixed in #157)

## Layering check
No Layer 0 -> 2 imports introduced.