### PR TITLE
fix(cloud/client): push events with watermark + backfill script (Bug 2)

### DIFF
--- a/Gradata/scripts/backfill_to_cloud.py
+++ b/Gradata/scripts/backfill_to_cloud.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+backfill_to_cloud.py — One-shot historical event replay.
+
+Pushes every event in events.jsonl to gradata-cloud /sync. Idempotent —
+server upserts on (brain_id, event_id), so re-running is safe.
+
+Use after fixing Bug 1 (PR #11) + Bug 2 (PRs #12 + #161). Resets the local
+sync state so the entire jsonl is replayed.
+
+Usage:
+    python scripts/backfill_to_cloud.py [--dry-run]
+
+Requires:
+    GRADATA_API_KEY env var
+    BRAIN_DIR env var (or pass --brain-dir)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from gradata.cloud.client import CloudClient
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--brain-dir",
+        default=os.environ.get("BRAIN_DIR"),
+        help="Brain directory (default: $BRAIN_DIR)",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Count events to push without actually pushing",
+    )
+    args = p.parse_args()
+
+    if not args.brain_dir:
+        print("ERROR: --brain-dir or $BRAIN_DIR required", file=sys.stderr)
+        return 2
+
+    brain_dir = Path(args.brain_dir)
+    events_jsonl = brain_dir / "events.jsonl"
+    if not events_jsonl.exists():
+        print(f"ERROR: {events_jsonl} not found", file=sys.stderr)
+        return 2
+
+    # Count events first
+    total = 0
+    by_type: dict[str, int] = {}
+    with open(events_jsonl) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                ev = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            total += 1
+            etype = ev.get("type", "unknown")
+            by_type[etype] = by_type.get(etype, 0) + 1
+
+    print(f"Found {total} events in {events_jsonl}")
+    for etype, n in sorted(by_type.items(), key=lambda kv: -kv[1]):
+        print(f"  {etype:30s}  {n}")
+
+    if args.dry_run:
+        print("\n--dry-run: not pushing")
+        return 0
+
+    # Reset sync state so every event replays
+    state_file = brain_dir / ".gradata-sync-state.json"
+    if state_file.exists():
+        backup = state_file.with_suffix(".json.pre-backfill.bak")
+        state_file.rename(backup)
+        print(f"Backed up sync state to {backup}")
+    state_file.write_text(json.dumps({"last_sync_at": "", "last_event_id": ""}))
+
+    # Connect + sync in a loop until empty
+    client = CloudClient(brain_dir=brain_dir)
+    if not client.connect():
+        print("ERROR: client.connect() failed", file=sys.stderr)
+        return 3
+
+    pushed = 0
+    iterations = 0
+    while True:
+        iterations += 1
+        result = client.sync()
+        if result is None or result is False:
+            print(f"sync() returned {result!r} on iteration {iterations}, stopping")
+            break
+        if isinstance(result, int):
+            n = result
+        elif isinstance(result, dict):
+            n = result.get("ingested_count", 0)
+        else:
+            n = 0
+        pushed += n
+        print(f"  iter {iterations}: +{n} events (total {pushed})")
+        if n == 0:
+            break
+        if iterations > 200:
+            print("Aborting: 200 iterations without completion")
+            break
+
+    print(f"\nDone. Pushed {pushed}/{total} events in {iterations} iterations.")
+    return 0 if pushed > 0 or total == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Gradata/src/gradata/cloud/client.py
+++ b/Gradata/src/gradata/cloud/client.py
@@ -14,12 +14,13 @@ the zero-dependency guarantee for the base SDK.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
 from pathlib import Path
 from typing import Any
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from gradata._http import require_https
@@ -29,6 +30,10 @@ logger = logging.getLogger("gradata.cloud")
 DEFAULT_ENDPOINT = "https://api.gradata.ai/api/v1"
 ENV_API_KEY = "GRADATA_API_KEY"
 ENV_ENDPOINT = "GRADATA_ENDPOINT"
+
+
+class _TooLargeError(Exception):
+    """Raised when the server returns HTTP 413 (batch too large)."""
 
 
 class CloudClient:
@@ -120,27 +125,134 @@ class CloudClient:
     # A compromised cloud server could inject malicious prompt instructions.
     # Rules are ALWAYS computed locally from the brain's own lessons.
 
-    def sync(self) -> dict:
-        """Sync local brain state to cloud.
+    def sync(self, batch_size: int = 500) -> int:
+        """Sync raw events from events.jsonl to cloud with watermark cursor.
 
-        Uploads new events since last sync. Returns sync status.
+        Reads events.jsonl, filters to events newer than the last watermark,
+        and batches them to /sync in chunks of `batch_size`. Advances the
+        cursor after each successful batch so the method is resumable and
+        idempotent (server upserts on event_id).
+
+        Returns total number of events ingested (0 if not connected or no events).
         """
         if not self.connected:
-            return {"status": "not_connected"}
+            return 0
+
+        events_path = self.brain_dir / "events.jsonl"
+        if not events_path.exists():
+            return 0
+
+        state = self._read_sync_state()
+        last_watermark = state.get("last_sync_at", "")
 
         try:
-            # Backend route: POST /api/v1/sync (see cloud/app/routes/sync.py).
-            # DEFAULT_ENDPOINT already includes /api/v1 so we append /sync only.
-            return self._post(
-                "/sync",
-                {
-                    "brain_id": self._brain_id,
-                    "manifest": self._read_local_manifest(),
-                },
-            )
-        except Exception as e:
-            logger.warning("Sync failed: %s", e)
-            return {"status": "error", "error": str(e)}
+            all_lines = events_path.read_text(encoding="utf-8").splitlines()
+        except OSError as e:
+            logger.warning("Sync: cannot read events.jsonl: %s", e)
+            return 0
+
+        pending: list[dict] = []
+        for line in all_lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                ev = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            ts = ev.get("ts", "")
+            if ts > last_watermark:
+                pending.append(ev)
+
+        if not pending:
+            logger.debug("Sync: no new events since watermark=%r", last_watermark)
+            return 0
+
+        manifest = self._read_local_manifest()
+        total_ingested = 0
+        offset = 0
+        current_batch = batch_size
+
+        while offset < len(pending):
+            chunk = pending[offset : offset + current_batch]
+            payload_events = [self._format_event(ev) for ev in chunk]
+
+            try:
+                resp = self._post(
+                    "/sync",
+                    {
+                        "brain_name": manifest.get("metadata", {}).get("name", self.brain_dir.name),
+                        "manifest": manifest,
+                        "events": payload_events,
+                        "cursor": last_watermark,
+                    },
+                )
+            except _TooLargeError:
+                # Server returned 413 — halve the batch and retry this chunk.
+                current_batch = max(1, current_batch // 2)
+                logger.warning(
+                    "Sync: 413 from server — reducing batch size to %d", current_batch
+                )
+                continue
+            except Exception as e:
+                logger.error("Sync: POST failed at offset=%d: %s", offset, e)
+                return total_ingested
+
+            ingested = resp.get("ingested_count", 0)
+            watermark = resp.get("new_watermark")
+            total_ingested += ingested
+            if watermark:
+                last_watermark = watermark
+                self._write_sync_state({"last_sync_at": last_watermark})
+
+            offset += len(chunk)
+            # Reset batch size to default for next chunk after a 413 recovery.
+            current_batch = batch_size
+
+        logger.info(
+            "Sync: ingested %d events (watermark=%r)", total_ingested, last_watermark
+        )
+        return total_ingested
+
+    # ── Sync state helpers ────────────────────────────────────────────────────
+
+    def _read_sync_state(self) -> dict:
+        state_path = self.brain_dir / ".gradata-sync-state.json"
+        if state_path.exists():
+            try:
+                return json.loads(state_path.read_text(encoding="utf-8"))
+            except Exception:
+                return {}
+        return {}
+
+    def _write_sync_state(self, state: dict) -> None:
+        state_path = self.brain_dir / ".gradata-sync-state.json"
+        try:
+            state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+        except OSError as e:
+            logger.warning("Sync: cannot write sync state: %s", e)
+
+    @staticmethod
+    def _format_event(ev: dict) -> dict:
+        """Convert an events.jsonl row to the /sync EventPayload shape.
+
+        Computes a deterministic event_id from (ts, type, source) so the
+        server can upsert idempotently on (brain_id, event_id).
+        """
+        ts = ev.get("ts", "")
+        event_type = ev.get("type", "")
+        source = ev.get("source", "")
+        raw = f"{ts}:{event_type}:{source}"
+        event_id = hashlib.sha256(raw.encode()).hexdigest()[:32]
+        return {
+            "event_id": event_id,
+            "type": event_type,
+            "source": source,
+            "data": ev.get("data", {}),
+            "tags": ev.get("tags", []),
+            "session": ev.get("session"),
+            "created_at": ts or None,
+        }
 
     # ── Internal helpers ──────────────────────────────────────────────
 
@@ -161,6 +273,10 @@ class CloudClient:
         try:
             with urlopen(req, timeout=30) as resp:
                 return json.loads(resp.read().decode("utf-8"))
+        except HTTPError as e:
+            if e.code == 413:
+                raise _TooLargeError() from e
+            raise ConnectionError(f"Cloud API request failed: {e}") from e
         except URLError as e:
             raise ConnectionError(f"Cloud API request failed: {e}") from e
 

--- a/Gradata/tests/test_cloud_client_sync.py
+++ b/Gradata/tests/test_cloud_client_sync.py
@@ -1,0 +1,171 @@
+"""Tests for CloudClient.sync() — watermark cursor + idempotency (Bug 2 fix)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from gradata.cloud.client import CloudClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_client(brain_dir: Path) -> CloudClient:
+    client = CloudClient(brain_dir, api_key="gd_test", endpoint="https://api.gradata.ai/api/v1")
+    client.connected = True
+    client._brain_id = "brain-test"
+    return client
+
+
+def _write_events(path: Path, events: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(ev) for ev in events) + "\n",
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestSyncNoEvents:
+    def test_no_events_file_returns_zero(self, tmp_path: Path):
+        """sync() returns 0 when events.jsonl does not exist."""
+        client = _make_client(tmp_path)
+        assert client.sync() == 0
+
+    def test_empty_events_file_returns_zero(self, tmp_path: Path):
+        """sync() returns 0 when events.jsonl is empty."""
+        (tmp_path / "events.jsonl").write_text("", encoding="utf-8")
+        client = _make_client(tmp_path)
+        assert client.sync() == 0
+
+    def test_not_connected_returns_zero(self, tmp_path: Path):
+        client = CloudClient(tmp_path, api_key="gd_test", endpoint="https://api.gradata.ai/api/v1")
+        assert client.sync() == 0
+
+
+class TestSyncThreeEvents:
+    def test_posts_once_and_advances_watermark(self, tmp_path: Path):
+        """3 unsynced events → one POST, watermark advances."""
+        events = [
+            {"ts": "2026-01-01T10:00:00Z", "type": "CORRECTION", "source": "brain"},
+            {"ts": "2026-01-01T11:00:00Z", "type": "LESSON_FIRED", "source": "brain"},
+            {"ts": "2026-01-01T12:00:00Z", "type": "CORRECTION", "source": "brain"},
+        ]
+        _write_events(tmp_path / "events.jsonl", events)
+        client = _make_client(tmp_path)
+
+        resp_body = {"status": "ok", "ingested_count": 3, "new_watermark": "2026-01-01T12:00:00Z"}
+        with patch.object(client, "_post", return_value=resp_body) as mock_post:
+            result = client.sync()
+
+        assert result == 3
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args[0]
+        assert call_args[0] == "/sync"
+        payload = call_args[1]
+        assert len(payload["events"]) == 3
+        # All events must have event_id (deterministic hash)
+        assert all(ev["event_id"] for ev in payload["events"])
+
+        # Watermark was saved
+        state = json.loads((tmp_path / ".gradata-sync-state.json").read_text())
+        assert state["last_sync_at"] == "2026-01-01T12:00:00Z"
+
+
+class TestSyncBatching:
+    def test_1500_events_sends_three_batches(self, tmp_path: Path):
+        """1500 events with batch_size=500 → 3 POST calls, watermark advances after each."""
+        events = [
+            {"ts": f"2026-01-01T{i:05d}Z", "type": "CORRECTION", "source": "brain"}
+            for i in range(1500)
+        ]
+        _write_events(tmp_path / "events.jsonl", events)
+        client = _make_client(tmp_path)
+
+        call_count = [0]
+
+        def fake_post(path, data):
+            call_count[0] += 1
+            batch = data["events"]
+            last_ts = batch[-1]["created_at"]
+            return {"status": "ok", "ingested_count": len(batch), "new_watermark": last_ts}
+
+        with patch.object(client, "_post", side_effect=fake_post):
+            result = client.sync(batch_size=500)
+
+        assert call_count[0] == 3
+        assert result == 1500
+
+    def test_watermark_filters_already_synced_events(self, tmp_path: Path):
+        """Re-running sync() after success sends 0 events (watermark already advanced)."""
+        events = [
+            {"ts": "2026-01-01T10:00:00Z", "type": "CORRECTION", "source": "brain"},
+            {"ts": "2026-01-01T11:00:00Z", "type": "CORRECTION", "source": "brain"},
+        ]
+        _write_events(tmp_path / "events.jsonl", events)
+        # Pre-set watermark past all events
+        (tmp_path / ".gradata-sync-state.json").write_text(
+            json.dumps({"last_sync_at": "2026-01-01T11:00:00Z"}), encoding="utf-8"
+        )
+        client = _make_client(tmp_path)
+
+        with patch.object(client, "_post") as mock_post:
+            result = client.sync()
+
+        assert result == 0
+        mock_post.assert_not_called()
+
+
+class TestSync413Retry:
+    def test_413_halves_batch_and_retries(self, tmp_path: Path):
+        """413 from server causes batch to halve and retry from same offset."""
+        from gradata.cloud.client import _TooLargeError
+
+        events = [
+            {"ts": f"2026-01-{i:02d}T10:00:00Z", "type": "CORRECTION", "source": "brain"}
+            for i in range(1, 5)
+        ]
+        _write_events(tmp_path / "events.jsonl", events)
+        client = _make_client(tmp_path)
+
+        call_count = [0]
+
+        def fake_post(path, data):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # First call with batch_size=4 → 413
+                raise _TooLargeError()
+            # Second call with batch_size=2 → success
+            batch = data["events"]
+            last_ts = batch[-1]["created_at"]
+            return {"status": "ok", "ingested_count": len(batch), "new_watermark": last_ts}
+
+        with patch.object(client, "_post", side_effect=fake_post):
+            result = client.sync(batch_size=4)
+
+        # Called at least twice: once with 413, once (or more) with halved batch
+        assert call_count[0] >= 2
+        assert result > 0
+
+
+class TestSyncEventIdDeterminism:
+    def test_event_id_is_deterministic(self):
+        """Same event always maps to same event_id (idempotency guarantee)."""
+        ev = {"ts": "2026-01-01T10:00:00Z", "type": "CORRECTION", "source": "brain"}
+        id1 = CloudClient._format_event(ev)["event_id"]
+        id2 = CloudClient._format_event(ev)["event_id"]
+        assert id1 == id2
+        assert len(id1) == 32  # sha256 hex truncated to 32 chars
+
+    def test_different_events_get_different_ids(self):
+        """Different ts/type/source → different event_id."""
+        ev_a = {"ts": "2026-01-01T10:00:00Z", "type": "CORRECTION", "source": "brain"}
+        ev_b = {"ts": "2026-01-01T10:00:00Z", "type": "LESSON_FIRED", "source": "brain"}
+        assert CloudClient._format_event(ev_a)["event_id"] != CloudClient._format_event(ev_b)["event_id"]


### PR DESCRIPTION
Replaces #161 (which had 43 unrelated commits diverged from main, unmergeable).

## What
- `client.sync()` reads events.jsonl, filters by last_sync_at watermark, batches 500/req, advances cursor on 200, retries smaller batch on 413
- Sync state at `<BRAIN_DIR>/.gradata-sync-state.json` (events.jsonl untouched, append-only)
- Server-side idempotency on (brain_id, event_id) — safe to re-run
- `scripts/backfill_to_cloud.py` — one-shot historical replay for the ~5,800 events the broken sync silently dropped

## Tests
- 9/9 new tests in tests/test_cloud_client_sync.py pass

## Pairs with
- gradata-cloud #12 (merged) — server `/sync` ingests events with watermark
- gradata-cloud #11 (merged) — backend brain_id mismatch fix
- gradata-cloud #10 (merged) — decay chart math fix