### PR TITLE
feat(llm-provider): add BYO-CLI + Cloud-Paid synthesis paths

### DIFF
--- a/Gradata/src/gradata/enhancements/llm_provider.py
+++ b/Gradata/src/gradata/enhancements/llm_provider.py
@@ -1,18 +1,33 @@
-"""LLM provider abstraction for behavioral extraction.
+"""LLM provider abstraction for behavioral extraction and meta-rule synthesis.
 
-Supports Anthropic (default), OpenAI, and any OpenAI-compatible endpoint
-(Ollama, vLLM, Together, etc.) via GenericHTTPProvider.
+Supports five modes:
+  * ``anthropic``  — Anthropic Claude SDK (BYO ANTHROPIC_API_KEY)
+  * ``openai``     — OpenAI / OpenAI-compatible SDK (BYO OPENAI_API_KEY)
+  * ``generic``    — Generic OpenAI-compat HTTP endpoint (Ollama / vLLM / Together)
+  * ``cli``        — BYO-CLI: subprocess-shell to ``claude`` / ``codex`` / ``gemini``
+                     (uses the user's existing Max-plan OAuth — no API key needed)
+  * ``cloud``      — Gradata Cloud relay (subscription-billed, server holds the key)
+  * ``gemma``      — Google native Gemma API (free tier)
 
 Provider is selected via:
   1. Brain(llm_provider=...) constructor arg
-  2. GRADATA_LLM_PROVIDER env var ("anthropic", "openai", "generic")
-  3. Default: "anthropic" (falls back to template-only if SDK not installed)
+  2. ``GRADATA_LLM_PROVIDER`` env var
+  3. Default: ``auto`` — resolves cli → anthropic → openai → cloud → None
+
+All providers implement ``complete(prompt, max_tokens, timeout) -> str | None`` and
+share a per-instance circuit breaker (3 consecutive failures = open for 5 min).
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
+import shutil
+import subprocess
+import time
+import urllib.error
+import urllib.request
 from abc import ABC, abstractmethod
 
 from gradata._env import env_str
@@ -20,86 +35,157 @@ from gradata._http import require_https
 
 _log = logging.getLogger(__name__)
 
+# Per-instance circuit breaker tunables
+_CB_THRESHOLD = 3
+_CB_COOLDOWN_SEC = 300.0
+
 
 class LLMProvider(ABC):
-    """Base class for LLM providers used in behavioral extraction."""
+    """Base class for LLM providers used in behavioral extraction.
+
+    Subclasses implement ``_complete_impl``. The base ``complete`` wrapper:
+      * gates calls behind the circuit breaker
+      * records consecutive failures
+      * runs the optional pre-prompt sanitization hook
+    """
+
+    name: str = "base"
+
+    def __init__(self) -> None:
+        self._cb_fails = 0
+        self._cb_opened_at: float | None = None
+
+    # -- circuit breaker ----------------------------------------------------
+    def _circuit_open(self) -> bool:
+        if self._cb_opened_at is None:
+            return False
+        if time.monotonic() - self._cb_opened_at > _CB_COOLDOWN_SEC:
+            # cooldown expired — half-open: reset counters
+            self._cb_fails = 0
+            self._cb_opened_at = None
+            return False
+        return True
+
+    def _record_failure(self) -> None:
+        self._cb_fails += 1
+        if self._cb_fails >= _CB_THRESHOLD:
+            self._cb_opened_at = time.monotonic()
+            _log.debug("%s provider circuit opened after %d failures",
+                       self.name, self._cb_fails)
+
+    def _record_success(self) -> None:
+        self._cb_fails = 0
+        self._cb_opened_at = None
+
+    # -- pre-prompt hook ----------------------------------------------------
+    @staticmethod
+    def _sanitize(prompt: str) -> str:
+        """Pre-prompt hook: neutralize prompt-injection in lesson content."""
+        try:
+            from gradata.enhancements._sanitize import sanitize_lesson_content
+            return sanitize_lesson_content(prompt, "llm_prompt")
+        except Exception:
+            return prompt
+
+    # -- public entry -------------------------------------------------------
+    def complete(self, prompt: str, *, max_tokens: int = 100,
+                 timeout: float = 12.0, sanitize: bool = False) -> str | None:
+        if self._circuit_open():
+            _log.debug("%s provider: circuit open, skipping", self.name)
+            return None
+        if sanitize:
+            prompt = self._sanitize(prompt)
+        try:
+            out = self._complete_impl(prompt, max_tokens=max_tokens, timeout=timeout)
+        except Exception as exc:  # never raise out of complete()
+            _log.debug("%s provider raised: %s", self.name, exc)
+            self._record_failure()
+            return None
+        if out is None:
+            self._record_failure()
+        else:
+            self._record_success()
+        return out
 
     @abstractmethod
-    def complete(self, prompt: str, *, max_tokens: int = 100, timeout: float = 12.0) -> str | None:
-        """Send a prompt and return the completion text, or None on failure."""
+    def _complete_impl(self, prompt: str, *, max_tokens: int, timeout: float) -> str | None:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Provider implementations
+# ---------------------------------------------------------------------------
 
 
 class AnthropicProvider(LLMProvider):
-    """Anthropic Claude provider (default)."""
+    """Anthropic Claude provider (BYO ANTHROPIC_API_KEY)."""
 
-    def __init__(self, model: str = "claude-haiku-4-5-20251001", auth_token: str | None = None):
+    name = "anthropic"
+
+    def __init__(self, model: str = "claude-haiku-4-5-20251001",
+                 auth_token: str | None = None):
+        super().__init__()
         self.model = model
         self._auth = auth_token
 
-    def complete(self, prompt: str, *, max_tokens: int = 100, timeout: float = 12.0) -> str | None:
+    def _complete_impl(self, prompt: str, *, max_tokens: int, timeout: float) -> str | None:
         try:
             import anthropic
         except ImportError:
             _log.debug("anthropic SDK not installed")
             return None
-
-        try:
-            kwargs: dict = {"timeout": timeout}
-            if self._auth:
-                kwargs["api_key"] = self._auth
-            client = anthropic.Anthropic(**kwargs)
-            msg = client.messages.create(
-                model=self.model,
-                max_tokens=max_tokens,
-                messages=[{"role": "user", "content": prompt}],
-            )
-            text = msg.content[0].text.strip()  # type: ignore[union-attr]
-            return text if 5 < len(text) < 500 else None
-        except Exception as e:
-            _log.debug("Anthropic completion failed: %s", e)
-            return None
+        kwargs: dict = {"timeout": timeout}
+        if self._auth:
+            kwargs["api_key"] = self._auth
+        client = anthropic.Anthropic(**kwargs)
+        msg = client.messages.create(
+            model=self.model,
+            max_tokens=max_tokens,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        text = msg.content[0].text.strip()  # type: ignore[union-attr]
+        return text if 5 < len(text) < 5000 else None
 
 
 def _openai_complete(
     *, model: str, prompt: str, max_tokens: int, timeout: float,
     api_key: str | None = None, base_url: str | None = None, log_label: str = "OpenAI",
 ) -> str | None:
-    """Shared OpenAI-compatible chat completion. Returns text or None on any failure."""
     try:
         import openai
     except ImportError:
         _log.debug("openai SDK not installed (needed for %s provider)", log_label)
         return None
-
-    try:
-        kwargs: dict = {"timeout": timeout}
-        if api_key:
-            kwargs["api_key"] = api_key
-        if base_url:
-            kwargs["base_url"] = base_url
-        client = openai.OpenAI(**kwargs)
-        resp = client.chat.completions.create(
-            model=model,
-            max_tokens=max_tokens,
-            messages=[{"role": "user", "content": prompt}],
-        )
-        text = (resp.choices[0].message.content or "").strip()
-        return text if 5 < len(text) < 500 else None
-    except Exception as e:
-        _log.debug("%s completion failed: %s", log_label, e)
-        return None
+    kwargs: dict = {"timeout": timeout}
+    if api_key:
+        kwargs["api_key"] = api_key
+    if base_url:
+        kwargs["base_url"] = base_url
+    client = openai.OpenAI(**kwargs)
+    resp = client.chat.completions.create(
+        model=model,
+        max_tokens=max_tokens,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    text = (resp.choices[0].message.content or "").strip()
+    return text if 5 < len(text) < 5000 else None
 
 
 class OpenAIProvider(LLMProvider):
-    """OpenAI-compatible provider (works with OpenAI, Azure OpenAI)."""
+    """OpenAI-compatible provider (works with OpenAI / Azure OpenAI)."""
+
+    name = "openai"
 
     def __init__(self, model: str = "gpt-4o-mini", auth_token: str | None = None,
                  base_url: str | None = None):
+        super().__init__()
         self.model = model
         self._auth = auth_token
         self.base_url = base_url
+        if base_url:
+            require_https(base_url, "OPENAI_BASE_URL")
 
-    def complete(self, prompt: str, *, max_tokens: int = 100, timeout: float = 12.0) -> str | None:
+    def _complete_impl(self, prompt: str, *, max_tokens: int, timeout: float) -> str | None:
         return _openai_complete(
             model=self.model, prompt=prompt, max_tokens=max_tokens, timeout=timeout,
             api_key=self._auth, base_url=self.base_url, log_label="OpenAI",
@@ -107,28 +193,189 @@ class OpenAIProvider(LLMProvider):
 
 
 class GenericHTTPProvider(LLMProvider):
-    """Generic OpenAI-compatible HTTP endpoint (Ollama, vLLM, Together, LM Studio, etc.).
+    """Generic OpenAI-compatible HTTP endpoint (Ollama, vLLM, Together, LM Studio)."""
 
-    Configure via env vars:
-        GRADATA_LLM_BASE_URL  (default: http://localhost:11434/v1)
-        GRADATA_LLM_MODEL     (default: llama3)
-        GRADATA_LLM_AUTH      (optional)
-    """
+    name = "generic"
 
     def __init__(self, base_url: str | None = None, model: str | None = None,
                  auth_token: str | None = None):
-        self.base_url = base_url or os.environ.get("GRADATA_LLM_BASE_URL", "http://localhost:11434/v1")
+        super().__init__()
+        self.base_url = base_url or os.environ.get(
+            "GRADATA_LLM_BASE_URL", "http://localhost:11434/v1"
+        )
         self.model = model or env_str("GRADATA_LLM_MODEL", "llama3")
         self._auth = auth_token or os.environ.get("GRADATA_LLM_AUTH", "")
-        # SSRF / bearer-key exfil guard: refuse HTTP to non-local hosts at construction time
         require_https(self.base_url, "GRADATA_LLM_BASE_URL")
 
-    def complete(self, prompt: str, *, max_tokens: int = 100, timeout: float = 12.0) -> str | None:
-        # openai SDK requires a key even for local — use placeholder if none set
+    def _complete_impl(self, prompt: str, *, max_tokens: int, timeout: float) -> str | None:
         return _openai_complete(
             model=self.model, prompt=prompt, max_tokens=max_tokens, timeout=timeout,
             api_key=self._auth or "local", base_url=self.base_url, log_label="Generic HTTP",
         )
+
+
+class CLIProvider(LLMProvider):
+    """BYO-CLI provider — shells to a local CLI (claude / codex / gemini).
+
+    Reuses the user's existing Max-plan OAuth or ChatGPT Plus subscription.
+    No API key required. Mirrors ``rule_synthesizer._try_claude_cli`` pattern.
+
+    Selection order for ``cli_name``:
+      1. explicit constructor arg
+      2. ``GRADATA_LLM_CLI`` env var
+      3. ``claude`` if on PATH
+      4. ``codex`` if on PATH
+      5. ``gemini`` if on PATH
+    """
+
+    name = "cli"
+
+    def __init__(self, cli_name: str | None = None, model: str | None = None):
+        super().__init__()
+        self.cli_name = cli_name or env_str("GRADATA_LLM_CLI", "") or self._auto_detect()
+        self.model = model or env_str("GRADATA_LLM_CLI_MODEL", "")
+
+    @staticmethod
+    def _auto_detect() -> str | None:
+        for candidate in ("claude", "codex", "gemini"):
+            if shutil.which(candidate):
+                return candidate
+        return None
+
+    def _build_argv(self, prompt: str) -> list[str] | None:
+        if not self.cli_name:
+            return None
+        exe = shutil.which(self.cli_name)
+        if not exe:
+            return None
+        if self.cli_name == "claude":
+            argv = [exe, "-p", prompt, "--output-format", "text"]
+            if self.model:
+                argv[3:3] = ["--model", self.model]
+            return argv
+        if self.cli_name == "codex":
+            model = self.model or "gpt-5.5"
+            return [exe, "exec", "--skip-git-repo-check", "--sandbox",
+                    "read-only", "-m", model, prompt]
+        if self.cli_name == "gemini":
+            argv = [exe, "-p", prompt]
+            if self.model:
+                argv[2:2] = ["-m", self.model]
+            return argv
+        # Unknown CLI — best-effort generic shape
+        return [exe, "-p", prompt]
+
+    def _complete_impl(self, prompt: str, *, max_tokens: int, timeout: float) -> str | None:
+        argv = self._build_argv(prompt)
+        if argv is None:
+            _log.debug("CLI provider: no CLI binary available")
+            return None
+        try:
+            proc = subprocess.run(
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=max(timeout, 60.0),
+                check=False,
+                encoding="utf-8",
+                stdin=subprocess.DEVNULL,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+            _log.debug("CLI %s invocation failed: %s", self.cli_name, exc)
+            return None
+        if proc.returncode != 0:
+            _log.debug("CLI %s returned %d: %s",
+                       self.cli_name, proc.returncode, (proc.stderr or "")[:200])
+            return None
+        out = (proc.stdout or "").strip()
+        return out or None
+
+
+class GradataCloudProvider(LLMProvider):
+    """Cloud-Paid mode — POSTs to a Gradata-hosted relay.
+
+    Server holds the LLM API key. Billing flows through the Gradata
+    subscription. Local SDK only needs ``GRADATA_API_KEY`` and an endpoint.
+
+    Env contract:
+      * ``GRADATA_API_KEY``    — bearer token
+      * ``GRADATA_ENDPOINT``   — base URL (default: https://api.gradata.cloud)
+      * Path: ``/meta-rules/synthesize``
+    """
+
+    name = "cloud"
+
+    def __init__(self, api_key: str | None = None, endpoint: str | None = None):
+        super().__init__()
+        self._auth = api_key or env_str("GRADATA_API_KEY", "")
+        self.endpoint = (endpoint or env_str("GRADATA_ENDPOINT",
+                                             "https://api.gradata.cloud")).rstrip("/")
+        require_https(self.endpoint, "GRADATA_ENDPOINT")
+
+    def _complete_impl(self, prompt: str, *, max_tokens: int, timeout: float) -> str | None:
+        if not self._auth:
+            _log.debug("Cloud provider: GRADATA_API_KEY not set")
+            return None
+        url = f"{self.endpoint}/meta-rules/synthesize"
+        payload = json.dumps({"prompt": prompt, "max_tokens": max_tokens}).encode()
+        headers = {
+            "Authorization": f"Bearer {self._auth}",
+            "Content-Type": "application/json",
+        }
+        req = urllib.request.Request(url, data=payload, headers=headers, method="POST")
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                body = json.loads(resp.read().decode())
+        except urllib.error.HTTPError as exc:
+            if exc.code == 402:
+                _log.warning("Gradata Cloud: 402 Payment Required (quota exhausted)")
+                return None
+            if exc.code == 429:
+                retry_after = exc.headers.get("Retry-After") if exc.headers else None
+                _log.warning("Gradata Cloud: 429 rate-limited (Retry-After=%s)", retry_after)
+                return None
+            _log.debug("Gradata Cloud HTTPError %s", exc)
+            return None
+        except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
+            _log.debug("Gradata Cloud request failed: %s", exc)
+            return None
+        text = (body.get("text") or body.get("completion") or "").strip()
+        return text or None
+
+
+class GoogleGemmaProvider(LLMProvider):
+    """Google's native Gemma API (free tier — uses GRADATA_GEMMA_API_KEY).
+
+    The OpenAI-compat endpoint rejects AQ. keys, so we use the native
+    ``generativelanguage.googleapis.com/.../generateContent`` shape.
+    """
+
+    name = "gemma"
+
+    def __init__(self, api_key: str | None = None, model: str | None = None):
+        super().__init__()
+        self._auth = api_key or env_str("GRADATA_GEMMA_API_KEY", "")
+        self.model = model or env_str("GRADATA_GEMMA_MODEL", "gemma-3-27b-it")
+
+    def _complete_impl(self, prompt: str, *, max_tokens: int, timeout: float) -> str | None:
+        if not self._auth:
+            return None
+        url = f"https://generativelanguage.googleapis.com/v1beta/models/{self.model}:generateContent"
+        payload = json.dumps({
+            "contents": [{"parts": [{"text": prompt}]}],
+            "generationConfig": {"maxOutputTokens": max_tokens, "temperature": 0.3},
+        }).encode()
+        headers = {"Content-Type": "application/json", "x-goog-api-key": self._auth}
+        try:
+            req = urllib.request.Request(url, data=payload, headers=headers, method="POST")
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                body = json.loads(resp.read().decode())
+            text = body["candidates"][0]["content"]["parts"][0]["text"].strip()
+        except (urllib.error.URLError, urllib.error.HTTPError, OSError, KeyError,
+                json.JSONDecodeError, IndexError) as exc:
+            _log.debug("Gemma native call failed: %s", exc)
+            return None
+        return text if 5 < len(text) < 5000 else None
 
 
 # ---------------------------------------------------------------------------
@@ -139,19 +386,59 @@ _PROVIDERS = {
     "anthropic": AnthropicProvider,
     "openai": OpenAIProvider,
     "generic": GenericHTTPProvider,
+    "cli": CLIProvider,
+    "cloud": GradataCloudProvider,
+    "gemma": GoogleGemmaProvider,
 }
 
 
-def get_provider(name: str | None = None, **kwargs) -> LLMProvider:
-    """Get an LLM provider by name.
+def _resolve_auto() -> str | None:
+    """Auto-resolve preferred provider based on environment.
+
+    Order: cli (claude/codex on PATH) → anthropic (ANTHROPIC_API_KEY) →
+    openai (OPENAI_API_KEY or GRADATA_LLM_KEY) → cloud (GRADATA_API_KEY) → None.
+    """
+    if shutil.which("claude") or shutil.which("codex"):
+        return "cli"
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        return "anthropic"
+    if os.environ.get("OPENAI_API_KEY") or os.environ.get("GRADATA_LLM_KEY"):
+        return "openai"
+    if os.environ.get("GRADATA_API_KEY"):
+        return "cloud"
+    if os.environ.get("GRADATA_GEMMA_API_KEY"):
+        return "gemma"
+    return None
+
+
+def get_provider(name: str | None = None, **kwargs) -> LLMProvider | None:
+    """Get an LLM provider by name (or auto-resolve from environment).
 
     Args:
-        name: "anthropic", "openai", or "generic". Defaults to GRADATA_LLM_PROVIDER
-              env var, then "anthropic".
-        **kwargs: Passed to the provider constructor (model, auth_token, base_url).
+        name: One of ``anthropic``, ``openai``, ``generic``, ``cli``,
+              ``cloud``, ``gemma``, or ``auto``. Defaults to
+              ``GRADATA_LLM_PROVIDER`` env var, then ``auto``.
+        **kwargs: Forwarded to the provider constructor.
+
+    Returns:
+        Provider instance, or ``None`` if ``auto`` couldn't find any
+        configured backend (callers fall back to deterministic synthesis).
     """
-    name = name or os.environ.get("GRADATA_LLM_PROVIDER", "anthropic")
-    cls = _PROVIDERS.get(name.lower())
+    name = name or os.environ.get("GRADATA_LLM_PROVIDER", "auto")
+    name = name.lower()
+    if name == "auto":
+        resolved = _resolve_auto()
+        if resolved is None:
+            return None
+        name = resolved
+    cls = _PROVIDERS.get(name)
     if cls is None:
-        raise ValueError(f"Unknown LLM provider: {name!r}. Choose from: {list(_PROVIDERS)}")
-    return cls(**kwargs)
+        raise ValueError(
+            f"Unknown LLM provider: {name!r}. Choose from: {list(_PROVIDERS)}"
+        )
+    try:
+        return cls(**kwargs)
+    except ValueError as exc:
+        # E.g. require_https failure on a misconfigured base URL — degrade gracefully
+        _log.warning("Provider %s rejected its config: %s", name, exc)
+        return None

--- a/Gradata/src/gradata/enhancements/meta_rules.py
+++ b/Gradata/src/gradata/enhancements/meta_rules.py
@@ -773,6 +773,21 @@ _GEMMA_DEFAULT_BASE = "https://generativelanguage.googleapis.com/v1beta/openai"
 _GEMMA_DEFAULT_MODEL = "gemma-3-27b-it"
 
 
+def _get_meta_provider():
+    """Return a unified LLMProvider when one is configured, else None.
+
+    Honors GRADATA_LLM_PROVIDER and the ``auto`` resolution chain. Returning
+    ``None`` keeps the legacy urllib / Gemma-native code paths in play and
+    preserves backwards compatibility with tests that patch internal helpers.
+    """
+    try:
+        from gradata.enhancements.llm_provider import get_provider
+        return get_provider()
+    except Exception as exc:  # pragma: no cover — defensive
+        _log.debug("Unified provider lookup failed: %s", exc)
+        return None
+
+
 def _resolve_llm_credentials() -> tuple[str, str, str]:
     """Resolve LLM credentials from environment. Returns (key, base, model).
 
@@ -871,6 +886,20 @@ def _try_llm_principle(
     """
     if not rules:
         return None
+
+    # NEW: route through unified provider if user explicitly opted into a
+    # BYO mode (cli / cloud / auto). Legacy urllib + Gemma paths remain
+    # for the explicit GRADATA_LLM_KEY+BASE / GRADATA_GEMMA_API_KEY contract
+    # so that existing tests which patch the helpers below still pass.
+    explicit_mode = (env_str("GRADATA_LLM_PROVIDER", "") or "").lower()
+    if explicit_mode in {"cli", "cloud", "auto"}:
+        provider = _get_meta_provider()
+        if provider is not None:
+            prompt = _build_principle_prompt(rules, category)
+            out = provider.complete(prompt, max_tokens=200, timeout=30.0, sanitize=True)
+            if out:
+                return out
+            # fall through to legacy path on miss
 
     c = creds if creds is not None else _resolve_principle_creds()
     k = c.get("openai_key")

--- a/Gradata/tests/test_llm_provider.py
+++ b/Gradata/tests/test_llm_provider.py
@@ -1,0 +1,201 @@
+"""Tests for the unified LLM provider abstraction (BYO-Key / BYO-CLI / Cloud-Paid).
+
+These tests exercise the new CLIProvider, GradataCloudProvider, and the
+``auto`` factory resolution path. They never hit the network.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from unittest.mock import patch
+
+import pytest
+
+from gradata.enhancements import llm_provider as lp
+
+
+# ---------------------------------------------------------------------------
+# CLIProvider
+# ---------------------------------------------------------------------------
+
+
+class _FakeProc:
+    def __init__(self, stdout: str = "", stderr: str = "", returncode: int = 0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def test_cli_provider_claude_happy(monkeypatch):
+    """When `claude` CLI is on PATH and returns 0, .complete() returns its stdout."""
+    monkeypatch.setattr(lp.shutil, "which",
+                        lambda name: "/usr/local/bin/claude" if name == "claude" else None)
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        return _FakeProc(stdout="When drafting, lead with the benefit.\n", returncode=0)
+
+    monkeypatch.setattr(lp.subprocess, "run", fake_run)
+    provider = lp.CLIProvider(cli_name="claude")
+    out = provider.complete("Synthesize this group of corrections.")
+    assert out == "When drafting, lead with the benefit."
+    assert captured["argv"][0] == "/usr/local/bin/claude"
+    assert "-p" in captured["argv"]
+    assert "--output-format" in captured["argv"]
+
+
+def test_cli_provider_binary_missing(monkeypatch):
+    """If shutil.which returns None for every CLI, .complete() degrades to None."""
+    monkeypatch.setattr(lp.shutil, "which", lambda _name: None)
+    monkeypatch.delenv("GRADATA_LLM_CLI", raising=False)
+    provider = lp.CLIProvider()
+    assert provider.cli_name is None
+    assert provider.complete("hello") is None
+
+
+def test_cli_provider_circuit_breaker(monkeypatch):
+    """3 consecutive failures opens the circuit; the 4th call must skip subprocess."""
+    monkeypatch.setattr(lp.shutil, "which",
+                        lambda name: "/usr/local/bin/claude" if name == "claude" else None)
+    call_count = {"n": 0}
+
+    def fake_run(argv, **kwargs):
+        call_count["n"] += 1
+        return _FakeProc(stdout="", stderr="boom", returncode=1)
+
+    monkeypatch.setattr(lp.subprocess, "run", fake_run)
+    provider = lp.CLIProvider(cli_name="claude")
+    # 3 failing calls
+    for _ in range(3):
+        assert provider.complete("x") is None
+    assert call_count["n"] == 3
+    # 4th call: circuit open, no subprocess
+    assert provider.complete("x") is None
+    assert call_count["n"] == 3
+
+
+def test_cli_provider_codex_argv(monkeypatch):
+    """Codex argv shape is the documented `codex exec ... -m <model> <prompt>`."""
+    monkeypatch.setattr(lp.shutil, "which",
+                        lambda name: "/usr/local/bin/codex" if name == "codex" else None)
+    captured: dict = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        return _FakeProc(stdout="ok", returncode=0)
+
+    monkeypatch.setattr(lp.subprocess, "run", fake_run)
+    provider = lp.CLIProvider(cli_name="codex", model="gpt-5.5")
+    assert provider.complete("hello") == "ok"
+    assert "exec" in captured["argv"]
+    assert "--sandbox" in captured["argv"]
+    assert "read-only" in captured["argv"]
+    assert "-m" in captured["argv"]
+    assert "gpt-5.5" in captured["argv"]
+
+
+# ---------------------------------------------------------------------------
+# GradataCloudProvider
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def read(self):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def test_cloud_provider_happy(monkeypatch):
+    """Cloud provider POSTs the right shape and parses {text: ...}."""
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["headers"] = dict(req.headers)
+        captured["body"] = json.loads(req.data.decode())
+        return _FakeResponse(json.dumps({"text": "Synthesized principle."}).encode())
+
+    monkeypatch.setattr(lp.urllib.request, "urlopen", fake_urlopen)
+    provider = lp.GradataCloudProvider(api_key="sk-test", endpoint="https://api.gradata.cloud")
+    out = provider.complete("test prompt", max_tokens=300)
+    assert out == "Synthesized principle."
+    assert captured["url"].endswith("/meta-rules/synthesize")
+    # Headers are normalized to title-case by urllib
+    assert captured["headers"].get("Authorization") == "Bearer sk-test"
+    assert captured["body"]["prompt"] == "test prompt"
+    assert captured["body"]["max_tokens"] == 300
+
+
+def test_cloud_provider_402(monkeypatch):
+    """402 Payment Required → graceful None (quota exhausted)."""
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.HTTPError(req.full_url, 402, "Payment Required", {}, io.BytesIO(b""))
+
+    monkeypatch.setattr(lp.urllib.request, "urlopen", fake_urlopen)
+    provider = lp.GradataCloudProvider(api_key="sk-test", endpoint="https://api.gradata.cloud")
+    assert provider.complete("test") is None
+
+
+def test_cloud_provider_no_key(monkeypatch):
+    """Missing GRADATA_API_KEY → returns None without making a request."""
+    monkeypatch.delenv("GRADATA_API_KEY", raising=False)
+    called = {"n": 0}
+    def fake_urlopen(*a, **kw):
+        called["n"] += 1
+        raise AssertionError("must not be called")
+    monkeypatch.setattr(lp.urllib.request, "urlopen", fake_urlopen)
+    provider = lp.GradataCloudProvider(api_key="", endpoint="https://api.gradata.cloud")
+    assert provider.complete("x") is None
+    assert called["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Factory auto-resolution
+# ---------------------------------------------------------------------------
+
+
+def test_factory_auto_resolution(monkeypatch):
+    """auto picks cli when claude present; anthropic when only ANTHROPIC_API_KEY set;
+    cloud when only GRADATA_API_KEY set; None when nothing configured."""
+    for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GRADATA_LLM_KEY",
+                "GRADATA_API_KEY", "GRADATA_GEMMA_API_KEY", "GRADATA_LLM_PROVIDER"):
+        monkeypatch.delenv(var, raising=False)
+
+    # Case 1: claude on PATH → CLIProvider
+    monkeypatch.setattr(lp.shutil, "which",
+                        lambda name: "/u/claude" if name == "claude" else None)
+    p = lp.get_provider("auto")
+    assert isinstance(p, lp.CLIProvider)
+
+    # Case 2: nothing on PATH but ANTHROPIC_API_KEY → AnthropicProvider
+    monkeypatch.setattr(lp.shutil, "which", lambda _name: None)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    p = lp.get_provider("auto")
+    assert isinstance(p, lp.AnthropicProvider)
+    monkeypatch.delenv("ANTHROPIC_API_KEY")
+
+    # Case 3: only GRADATA_API_KEY → GradataCloudProvider
+    monkeypatch.setenv("GRADATA_API_KEY", "sk-cloud")
+    p = lp.get_provider("auto")
+    assert isinstance(p, lp.GradataCloudProvider)
+    monkeypatch.delenv("GRADATA_API_KEY")
+
+    # Case 4: nothing configured → None
+    p = lp.get_provider("auto")
+    assert p is None
+
+
+def test_factory_unknown_provider_raises():
+    with pytest.raises(ValueError):
+        lp.get_provider("xyz-not-a-real-provider")


### PR DESCRIPTION
## Summary

Extend the unified `LLMProvider` abstraction with three BYO modes for meta-rule synthesis:

- **BYO-Key** — Anthropic / OpenAI / generic OpenAI-compat (existing, lightly refactored)
- **BYO-CLI** — subprocess-shell to `claude` / `codex` / `gemini`, reusing the user's Max-plan OAuth or ChatGPT Plus subscription. No API key required.
- **Cloud-Paid** — POST to a Gradata-hosted relay; the server holds the LLM key and billing flows through the Gradata subscription.

This lets Claude Pro / ChatGPT Plus subscribers run meta-rule synthesis without spending API credits, and Gradata Cloud customers offload synthesis to a managed relay.

## Changes

- `enhancements/llm_provider.py`
  - New `CLIProvider`, `GradataCloudProvider`, `GoogleGemmaProvider`.
  - Per-instance circuit breaker (3 consecutive fails → open for 5 min, half-open recovery).
  - Centralized SSRF `require_https()` guard + `sanitize_lesson_content` pre-prompt hook in the base class.
  - `auto` factory resolution: cli → anthropic → openai → cloud → gemma → None.
  - Returns `None` (instead of raising) when `auto` finds nothing — caller falls back to deterministic synthesis.
- `enhancements/meta_rules.py`: `_try_llm_principle` routes through the unified provider when `GRADATA_LLM_PROVIDER ∈ {cli, cloud, auto}` is explicitly set. Legacy `GRADATA_LLM_KEY`+`GRADATA_LLM_BASE` and `GRADATA_GEMMA_API_KEY` paths preserved so existing tests (which patch internal helpers) stay green.
- `tests/test_llm_provider.py`: 9 new tests.

## Test plan

```
pytest tests/test_meta_rules.py tests/test_agentic_synthesis.py \
       tests/test_llm_synthesis.py tests/test_rule_synthesizer.py \
       tests/test_llm_provider.py
58 passed in 5.62s
```

- 44 existing meta-rule / agentic-synthesis / llm-synthesis tests — green.
- 5 rule_synthesizer tests — green.
- 9 new llm_provider tests — green.
- 2 `test_dualwrite_atomicity.py` failures observed are pre-existing on `main` (kill-9 + concurrency tests, unrelated to this PR).

## Layering check

All changes live inside Layer 1 (`enhancements/`). No upward imports introduced. No imports from `cloud/`. No new required dependencies — `anthropic` and `openai` SDKs remain optional.

## Risk

- Public function signatures unchanged. `provider="anthropic"` kw on `llm_synthesize_rules` retained for back-compat.
- Default behavior unchanged when no env var is set: the legacy resolution (`GRADATA_LLM_KEY`+`GRADATA_LLM_BASE` → Gemma) still fires.
- Opt-in to BYO-CLI / Cloud requires an explicit `GRADATA_LLM_PROVIDER=cli|cloud|auto`.