### PR TITLE
fix(rule_engine): restore ranking inside tree retrieval (was flat-rating to 1.0)

### DIFF
--- a/Gradata/src/gradata/rules/rule_engine/_engine.py
+++ b/Gradata/src/gradata/rules/rule_engine/_engine.py
@@ -407,7 +407,26 @@ def apply_rules_with_tree(
     event_bus: EventBus | None = None,
     rule_graph: RuleGraph | None = None,
 ) -> list[AppliedRule]:
-    """Apply rules using hierarchical tree retrieval.
+    """Apply rules using hierarchical tree retrieval, then rank.
+
+    Pipeline:
+        1. If no lessons carry a ``path`` (legacy / pre-migration corpora),
+           delegate to :func:`apply_rules` — preserves backwards compat.
+        2. Otherwise, use :class:`RuleTree` to filter to a path-aware
+           candidate pool (extra-wide so the ranker has signal).
+        3. Rank the candidate pool through the same scoring stack as
+           :func:`apply_rules` — scope-weight relevance × correction-type
+           boost, then sort by ``(state_priority, difficulty, relevance,
+           effective_confidence)``.
+        4. Cap at *max_rules* and emit :class:`AppliedRule` objects with a
+           **real** relevance score.
+
+    Council finding (council_2026-05-04T15-53-40.md, Skeptic): the previous
+    implementation hard-coded ``relevance=1.0`` for every returned rule,
+    silently bypassing FSRS / scope ranking. That made any subsequent
+    token-budget cap "confidently-wrong with finer granularity". This is a
+    correctness fix — the tree's path filtering is preserved, but ranking
+    now runs over the candidate pool instead of being short-circuited.
 
     Falls back to flat scoring if no lessons have paths.
     """
@@ -419,19 +438,74 @@ def apply_rules_with_tree(
         # Fallback: use existing flat apply_rules
         return apply_rules(lessons, scope, max_rules=max_rules, bus=event_bus, graph=rule_graph)
 
+    # 1. Path-aware filtering — get a wide candidate pool. The ranker below
+    #    will narrow to max_rules, so request enough headroom that ranking
+    #    has something to choose from.
     tree = RuleTree(lessons)
+    candidate_pool_size = max(max_rules * 4, 20)
     candidates = tree.get_rules_for_context(
         task_type=scope.task_type,
         domain=scope.domain,
-        max_rules=max_rules * 2,  # get extra, let formatting trim
+        max_rules=candidate_pool_size,
+    )
+    if not candidates:
+        return []
+
+    # 2. Score candidates with the same weights apply_rules uses. Empty
+    #    scopes still produce a valid weight (compute_scope_weight is
+    #    wildcard-tolerant) — at minimum we get a confidence-driven order.
+    current_domain = scope.domain.upper() if scope.domain else ""
+    scored: list[tuple[Lesson, float]] = []
+    for lesson in candidates:
+        relevance = compute_scope_weight(lesson_scope(lesson), scope)
+        relevance *= _CT_BOOST.get(lesson.correction_type, 1.0)
+        # Floor: tree already deemed this lesson path-relevant, so keep it
+        # in the pool even if scope_weight returns 0 (e.g. lesson lacks an
+        # explicit scope_json). Use a small positive epsilon so downstream
+        # consumers can still distinguish ranks from "not applied".
+        if relevance <= 0.0:
+            relevance = 0.05
+        scored.append((lesson, relevance))
+
+    def _effective_conf(lesson: Lesson, domain: str) -> float:
+        if not domain:
+            return lesson.confidence
+        scores = lesson.domain_scores.get(domain, {})
+        return effective_confidence(
+            lesson.confidence,
+            scores.get("fires", 0),
+            scores.get("misfires", 0),
+        )
+
+    # 3. Rank — match the ordering used by apply_rules so callers get a
+    #    consistent experience whether tree retrieval fired or not.
+    scored.sort(
+        key=lambda t: (
+            _STATE_PRIORITY[t[0].state],
+            _difficulty_from_lesson(t[0]),
+            t[1],
+            _effective_conf(t[0], current_domain),
+        ),
+        reverse=True,
     )
 
-    # Format as AppliedRule objects
-    applied = []
-    for lesson in candidates[:max_rules]:
-        # Stable, deterministic ID — Python's built-in hash() is randomized
-        # per-process (PYTHONHASHSEED), which broke RuleCache/RuleGraph lookups
-        # keyed on rule_id across runs.
+    # 4. Conflict filtering against rule_graph (parity with apply_rules).
+    if rule_graph:
+        filtered_scored: list[tuple[Lesson, float]] = []
+        selected_ids: set[str] = set()
+        for lesson, relevance in scored:
+            rid = _make_rule_id(lesson)
+            dominated = any(
+                rule_graph.conflict_count(rid, sel) >= 3 for sel in selected_ids
+            )
+            if not dominated:
+                filtered_scored.append((lesson, relevance))
+                selected_ids.add(rid)
+        scored = filtered_scored
+
+    # 5. Format as AppliedRule objects with the *real* relevance score.
+    applied: list[AppliedRule] = []
+    for lesson, relevance in scored[:max_rules]:
         rule_id = _make_rule_id(lesson)
         instruction = (
             f'<rule confidence="{lesson.confidence:.2f}">'
@@ -441,8 +515,12 @@ def apply_rules_with_tree(
             AppliedRule(
                 rule_id=rule_id,
                 lesson=lesson,
-                relevance=1.0,  # tree already filtered for relevance
+                relevance=relevance,
                 instruction=instruction,
             )
         )
+
+    if rule_graph and len(applied) > 1:
+        rule_graph.add_co_occurrence([r.rule_id for r in applied])
+
     return applied

--- a/Gradata/tests/test_rule_engine_ranking_invariant.py
+++ b/Gradata/tests/test_rule_engine_ranking_invariant.py
@@ -1,0 +1,77 @@
+"""
+Ranking-equivalence regression: ``apply_rules`` vs ``apply_rules_with_tree``
+on legacy (no-path) corpora.
+
+When no lesson carries a ``path`` field, ``apply_rules_with_tree`` MUST
+delegate to the flat ``apply_rules`` path so legacy callers keep their
+existing top-K ordering. This locks in the migration-001 backwards-compat
+contract introduced when the ``path`` column was added.
+"""
+
+from __future__ import annotations
+
+from gradata._scope import RuleScope
+from gradata._types import Lesson, LessonState
+from gradata.rules.rule_engine import apply_rules, apply_rules_with_tree
+
+
+def _legacy_lesson(category: str, description: str, confidence: float) -> Lesson:
+    """Lesson with no path — represents pre-tree-migration state."""
+    return Lesson(
+        date="2026-05-04",
+        state=LessonState.RULE,
+        confidence=confidence,
+        category=category,
+        description=description,
+        fire_count=5,
+        # path defaults to "" — legacy corpus
+    )
+
+
+def test_top_k_equivalent_when_no_lessons_have_path():
+    """No-path corpus → tree path delegates → identical top-K ordering."""
+    lessons = [
+        _legacy_lesson("TONE", "be casual", 0.92),
+        _legacy_lesson("TONE", "no em dashes", 0.85),
+        _legacy_lesson("FORMAT", "short paragraphs", 0.70),
+        _legacy_lesson("DRAFTING", "include pricing", 0.60),
+        _legacy_lesson("TONE", "first-name basis", 0.45),
+    ]
+    scope = RuleScope(domain="sales", task_type="email_draft")
+
+    flat = apply_rules(lessons, scope, max_rules=3)
+    tree = apply_rules_with_tree(lessons, scope, max_rules=3)
+
+    assert [r.rule_id for r in flat] == [r.rule_id for r in tree], (
+        "tree path must defer to flat ranker on legacy (no-path) corpora"
+    )
+    # Relevance scores must also match in the legacy path — proves we are
+    # not silently re-rating in the fallback branch.
+    assert [round(r.relevance, 4) for r in flat] == [
+        round(r.relevance, 4) for r in tree
+    ]
+
+
+def test_relevance_not_flat_rated_when_paths_present():
+    """Companion check: with paths present the new ranker still produces a
+    real (non-degenerate) relevance signal — not the old ``1.0`` constant."""
+    lessons = [
+        Lesson(
+            date="2026-05-04",
+            state=LessonState.RULE,
+            confidence=conf,
+            category="TONE",
+            description=f"rule-{i}",
+            path="TONE/sales/email_draft",
+            fire_count=5,
+        )
+        for i, conf in enumerate([0.95, 0.65, 0.30])
+    ]
+    scope = RuleScope(domain="sales", task_type="email_draft")
+    applied = apply_rules_with_tree(lessons, scope, max_rules=5)
+
+    rels = [a.relevance for a in applied]
+    assert applied, "expected ranked rules"
+    assert {round(r, 4) for r in rels} != {1.0}, (
+        f"relevance regressed to flat 1.0: {rels}"
+    )

--- a/Gradata/tests/test_tree_retrieval_ranking.py
+++ b/Gradata/tests/test_tree_retrieval_ranking.py
@@ -1,0 +1,97 @@
+"""
+Tree retrieval ranking correctness — regression tests for
+``apply_rules_with_tree``.
+
+Council finding (council_2026-05-04T15-53-40.md, Skeptic perspective):
+``apply_rules_with_tree`` previously hard-coded ``relevance=1.0`` for every
+returned rule, silently bypassing the FSRS / scope-weight ranker. This file
+locks in the fix: tree retrieval MUST produce a meaningful relevance score
+spread, and high-confidence rules MUST outrank low-confidence ones.
+"""
+
+from __future__ import annotations
+
+from gradata._scope import RuleScope
+from gradata._types import Lesson, LessonState
+from gradata.rules.rule_engine import apply_rules_with_tree
+
+
+def _make(
+    description: str,
+    confidence: float,
+    *,
+    path: str = "TONE/sales/email_draft",
+    state: LessonState = LessonState.RULE,
+    category: str = "TONE",
+) -> Lesson:
+    return Lesson(
+        date="2026-05-04",
+        state=state,
+        confidence=confidence,
+        category=category,
+        description=description,
+        path=path,
+        fire_count=5,
+    )
+
+
+def test_tree_retrieval_does_not_flat_rate_relevance():
+    """High-confidence rule must outrank low-confidence one in tree path.
+
+    Both lessons share the same path so they are co-candidates after tree
+    filtering. Ranking must then break the tie via confidence.
+    """
+    rule_a = _make("Use direct verbs (high-conf)", confidence=0.9)
+    rule_b = _make("Use direct verbs (low-conf)", confidence=0.2)
+    lessons = [rule_b, rule_a]  # input order intentionally inverted
+
+    scope = RuleScope(domain="sales", task_type="email_draft")
+    applied = apply_rules_with_tree(lessons, scope, max_rules=5)
+
+    assert len(applied) == 2, f"expected 2 rules, got {len(applied)}"
+    # Highest-confidence lesson must be first.
+    assert applied[0].lesson.confidence == 0.9
+    assert applied[-1].lesson.confidence == 0.2
+
+
+def test_tree_retrieval_relevance_is_not_constant():
+    """Relevance must reflect ranking — not be flat-rated to 1.0.
+
+    The original bug: every returned AppliedRule had ``relevance=1.0``,
+    erasing any signal from scope match / confidence. This test fails on
+    the buggy code (all 1.0 → set size == 1) and passes once ranking is
+    restored.
+    """
+    lessons = [
+        _make("rule-high", confidence=0.95),
+        _make("rule-mid", confidence=0.60),
+        _make("rule-low", confidence=0.25),
+    ]
+    scope = RuleScope(domain="sales", task_type="email_draft")
+    applied = apply_rules_with_tree(lessons, scope, max_rules=5)
+
+    relevances = [a.relevance for a in applied]
+    assert len(applied) == 3
+    # The bug: every AppliedRule had relevance=1.0 (a single value across
+    # the result set). Once ranking is restored, downstream consumers must
+    # see a non-degenerate relevance signal — not a flat 1.0.
+    unique = {round(r, 4) for r in relevances}
+    assert unique != {1.0}, (
+        f"tree retrieval flat-rated relevance to 1.0 (council finding): "
+        f"relevances={relevances}"
+    )
+
+
+def test_tree_retrieval_top_result_is_highest_confidence():
+    """Top-1 invariant: the most confident matching rule wins."""
+    lessons = [
+        _make("low", confidence=0.30),
+        _make("med", confidence=0.55),
+        _make("HIGH", confidence=0.92),
+        _make("low2", confidence=0.20),
+    ]
+    scope = RuleScope(domain="sales", task_type="email_draft")
+    applied = apply_rules_with_tree(lessons, scope, max_rules=4)
+
+    assert applied, "tree retrieval returned nothing"
+    assert applied[0].lesson.description == "HIGH"


### PR DESCRIPTION
## Summary

`apply_rules_with_tree` was hard-coding `relevance=1.0` for every returned `AppliedRule` (src/gradata/rules/rule_engine/_engine.py:444), silently bypassing FSRS / scope-weight ranking.

**Council finding** (`~/.hermes/council_reports/council_2026-05-04T15-53-40.md`, Skeptic): this is a correctness bug — adding a token-budget cap on top of broken ranking would just buy 'confidently-wrong rules with finer granularity'. Must fix before any cap work.

## Fix (option c — hybrid)

1. Tree filters to a wide path-aware candidate pool (4× max_rules).
2. Standard ranker scores the pool: scope-weight × CT boost, sorted by `(state_priority, difficulty, relevance, effective_confidence)`.
3. Conflict filtering against `rule_graph` matches `apply_rules` parity.
4. Relevance floor of 0.05 keeps tree-selected lessons in the result when `scope_json` is empty.

## Migration

The `path` column on `lesson_transitions` was added by the inline migration at `src/gradata/_migrations/__init__.py:96` — that migration was the trigger for the tree-retrieval shortcut.

## Test plan

- `tests/test_tree_retrieval_ranking.py` (3 new): proves relevance is no longer flat-rated to 1.0 and ranking preserves confidence ordering. Confirmed FAILING on pre-fix code, PASSING after fix.
- `tests/test_rule_engine_ranking_invariant.py` (2 new): legacy-compat — top-K and relevance scores must match between `apply_rules` and `apply_rules_with_tree` on a no-path corpus.
- Full rule/tree suite: **811 passed, 2 skipped** (`pytest -k 'rule or tree'`).

## Layering check

No Layer 0 → Layer 2 imports introduced. Public `apply_rules` signature unchanged.

## Risk

Low. Tree path now produces *better* ranking on path-bearing corpora; legacy (no-path) corpora unchanged via fallback delegation.