### PR TITLE
fix: remove ghost references to nonexistent gradata_cloud namespace

### DIFF
--- a/Gradata/docs/architecture/multi-tenant-future-proofing.md
+++ b/Gradata/docs/architecture/multi-tenant-future-proofing.md
@@ -13,7 +13,7 @@
 - Embeddings stored as BLOB (`brain_embeddings`); FTS5 via `brain_fts`.
 - `events.scope` column exists (default 'local') — partial seed for tenant scoping, not used.
 - `sync_state` table exists per source but not cloud-bound.
-- Proprietary dashboard / team-sharing code in `gradata_cloud_backup/`. Graduation runs locally in the OSS SDK.
+<!-- TODO: re-document team-sharing/dashboard surface once gradata_cloud_backup namespace actually exists. Prior copy claimed proprietary dashboard code in `gradata_cloud_backup/` — that path does not exist on disk. -->
 - Open SDK is Apache-2.0 — cannot require cloud to run.
 
 ## Architectural Decisions (Lock In Now)

--- a/Gradata/src/gradata/enhancements/contradiction_detector.py
+++ b/Gradata/src/gradata/enhancements/contradiction_detector.py
@@ -15,9 +15,6 @@ Contradiction types detected:
 
 If contradictions are found with confidence > 0.7, the lesson is flagged
 as PENDING_REVIEW instead of graduating automatically.
-
-OPEN SOURCE: Detection heuristics are open. Embedding-based semantic
-similarity is proprietary cloud-side (medium-term).
 """
 
 from __future__ import annotations

--- a/Gradata/src/gradata/enhancements/meta_rules.py
+++ b/Gradata/src/gradata/enhancements/meta_rules.py
@@ -652,8 +652,8 @@ def refresh_meta_rules(
     """Re-discover meta-rules, keeping valid existing ones.
 
     In the open-source build, this validates and returns existing
-    meta-rules but does not discover new ones.  New discovery
-    requires Gradata Cloud.
+    meta-rules but does not discover new ones. New discovery is not
+    yet implemented locally; cloud sync is optional.
 
     Args:
         lessons: All lessons (active + archived).
@@ -666,7 +666,7 @@ def refresh_meta_rules(
     Returns:
         Validated subset of *existing_metas*.
     """
-    _log.info("Meta-rule discovery requires Gradata Cloud")
+    _log.info("Meta-rule discovery not implemented in open-source build; validating existing meta-rules only")
     corrections = recent_corrections or []
 
     # Validate existing meta-rules (invalidation still works locally).

--- a/Gradata/src/gradata/enhancements/rule_integrity.py
+++ b/Gradata/src/gradata/enhancements/rule_integrity.py
@@ -10,9 +10,6 @@ a WARNING log.
 
 Backward compatible: when no secret key is configured (solo use),
 rules pass through unsigned and unverified.
-
-OPEN SOURCE: Signing algorithm is open. Key management and
-multi-tenant signing are proprietary cloud-side.
 """
 
 from __future__ import annotations

--- a/Gradata/src/gradata/enhancements/self_improvement/__init__.py
+++ b/Gradata/src/gradata/enhancements/self_improvement/__init__.py
@@ -9,9 +9,6 @@ This is the open-source graduation engine. Corrections become procedural
 memory: confidence scoring, lesson parsing, FSRS-inspired graduation,
 adversarial validation, and formatting.
 
-The proprietary cloud version (gradata_cloud.graduation.self_improvement)
-adds FSRS-based scheduling and multi-brain optimization on top.
-
 Package layout
 --------------
 _confidence.py  — constants, FSRS math, parse/format, update_confidence

--- a/Gradata/tests/test_severity_weighting.py
+++ b/Gradata/tests/test_severity_weighting.py
@@ -5,7 +5,6 @@ Verifies that edit distance severity labels scale confidence
 updates instead of applying flat-rate penalties/bonuses.
 
 Tests work against whichever self_improvement module is available:
-- gradata_cloud.graduation.self_improvement (proprietary, CI)
 - gradata.enhancements.self_improvement (packaged engine)
 - gradata._self_improvement stubs (open source, constants only)
 """


### PR DESCRIPTION
## Summary

Removes ghost references in source comments + docs that claim features
as "proprietary cloud-side", "requires Gradata Cloud", or live in the
nonexistent `gradata_cloud.*` / `gradata_cloud_backup/` namespace.
None of those modules exist on disk or in the Gradata GitHub org —
they were aspirational copy that became a diligence trap.

Council verdict: 5/7 lenses agreed in
`council_2026-05-04T15-53-40.md` that these references must be
deleted.

## Changes

| File | Change |
|------|--------|
| `src/gradata/enhancements/contradiction_detector.py` | Drop docstring claim that semantic similarity is "proprietary cloud-side" |
| `src/gradata/enhancements/rule_integrity.py` | Drop docstring claim that key management / multi-tenant signing are "proprietary cloud-side" |
| `src/gradata/enhancements/self_improvement/__init__.py` | Drop reference to `gradata_cloud.graduation.self_improvement` |
| `src/gradata/enhancements/meta_rules.py` | Rewrite "requires Gradata Cloud" docstring + log line to factual "not implemented in open-source build; cloud sync optional" |
| `tests/test_severity_weighting.py` | Drop comment line listing `gradata_cloud.graduation.self_improvement` as a test target |
| `docs/architecture/multi-tenant-future-proofing.md` | Replace claim about proprietary dashboard in `gradata_cloud_backup/` with a TODO comment (per task: delete-only, no new claims) |

## Flagged but NOT modified

These are real runtime guards (`try / except ImportError` with OSS
fallback). Per task spec they are left in place — they are not bugs:

- `src/gradata/cli.py:286` — `from gradata_cloud.scoring.reports import ...` inside `try/except ImportError`
- `src/gradata/cli.py:309` — same pattern
- `src/gradata/enhancements/reporting.py:170` — same pattern
- `tests/test_brain_events.py` — explicitly parametrizes the absence of `gradata_cloud` modules via `monkeypatch.setitem(sys.modules, "gradata_cloud", None)`
- `tests/test_severity_weighting.py:42` — same try/except fallback

These are functionally safe (no install break) but do leak the
proprietary module layout in import statements. Deciding whether to
strip them belongs in a separate PR (touches code paths, not just
comments) — flagged here for follow-up.

## Test plan

- `pytest -x --tb=short tests/test_severity_weighting.py tests/test_brain_events.py tests/test_pattern_extractor.py` — 99 passed
- Full suite: 4158 passed, 6 skipped, 2 pre-existing failures in `tests/test_dualwrite_atomicity.py` confirmed present on `main` before my changes (unrelated, fs-race in test fixture)
- Changes are docstring/comment/log-string only — no behavioral diff

## Layering check

No imports added or moved. Comment-only edits to Layer 1 + tests + docs.

## Risk

None — pure copy edits. The single log-line change in `meta_rules.py`
is a string-literal swap inside an `_log.info(...)` call.
