### PR TITLE
fix(installer): use Hermes hook event names (pre_tool_call/post_tool_call/on_session_end)

### DIFF
--- a/Gradata/src/gradata/hooks/adapters/hermes.py
+++ b/Gradata/src/gradata/hooks/adapters/hermes.py
@@ -13,6 +13,40 @@ from gradata.hooks.adapters._base import (
 
 AGENT = "hermes"
 
+# Hermes recognises these event names natively. The Claude-Code event names
+# (pre_tool_use / post_tool_use / session_end) are *silently ignored* by the
+# Hermes runtime — only a warning is logged. Earlier versions of this adapter
+# wrote the Claude-Code names by mistake, so we also accept the legacy keys
+# here on read and migrate them on write.
+HERMES_EVENT_NAMES: dict[str, str] = {
+    "pre_tool_use": "pre_tool_call",
+    "post_tool_use": "post_tool_call",
+    "session_end": "on_session_end",
+}
+
+
+def _migrate_legacy_event(hooks: dict, legacy_key: str, current_key: str) -> list:
+    """Return the list living at *current_key*, folding any entries that were
+    historically written under *legacy_key* into it. Removes the legacy key
+    once its entries have been migrated so an old broken install becomes a
+    correct one the next time the user runs ``gradata install --agent hermes``.
+    """
+    current = hooks.setdefault(current_key, [])
+    if not isinstance(current, list):
+        current = []
+        hooks[current_key] = current
+    legacy = hooks.get(legacy_key)
+    if isinstance(legacy, list):
+        for entry in legacy:
+            if entry not in current:
+                current.append(entry)
+        del hooks[legacy_key]
+    elif legacy_key in hooks:
+        # Malformed legacy value (not a list) — drop it; the new key owns the
+        # event from here on.
+        del hooks[legacy_key]
+    return current
+
 
 def _parse_simple_yaml(text: str) -> dict:
     """Parse the small Hermes config shape without requiring PyYAML."""
@@ -124,16 +158,17 @@ def install(brain_dir: Path, agent_config_path: Path) -> InstallResult:
         if not isinstance(hooks, dict):
             hooks = {}
             data["hooks"] = hooks
-        pre_tool_use = hooks.setdefault("pre_tool_use", [])
-        if not isinstance(pre_tool_use, list):
-            pre_tool_use = []
-            hooks["pre_tool_use"] = pre_tool_use
-        if any(isinstance(entry, dict) and entry.get("id") == sig for entry in pre_tool_use):
+        # Hermes uses *_tool_call / on_session_end event names. Writing the
+        # Claude-Code names (pre_tool_use / post_tool_use / session_end) here
+        # results in Hermes silently ignoring the entries (warning only). See
+        # Gradata/gradata#190 for the install-UX epic.
+        pre_tool_call = _migrate_legacy_event(hooks, "pre_tool_use", "pre_tool_call")
+        if any(isinstance(entry, dict) and entry.get("id") == sig for entry in pre_tool_call):
             return InstallResult(
                 AGENT, agent_config_path, "already_present", "hook already present"
             )
-        pre_tool_use.append({"id": sig, "command": hook_command(brain_dir)})
+        pre_tool_call.append({"id": sig, "command": hook_command(brain_dir)})
         atomic_write_text(agent_config_path, _dump_simple_yaml(data))
-        return InstallResult(AGENT, agent_config_path, "added", "installed pre_tool_use hook")
+        return InstallResult(AGENT, agent_config_path, "added", "installed pre_tool_call hook")
     except Exception as exc:
         return failure(AGENT, agent_config_path, exc)

--- a/Gradata/tests/test_hermes_hook_event_names.py
+++ b/Gradata/tests/test_hermes_hook_event_names.py
@@ -1,0 +1,86 @@
+"""Regression tests for the Hermes hook adapter event names.
+
+Hermes recognises ``pre_tool_call`` / ``post_tool_call`` / ``on_session_end``
+natively; the Claude-Code-style names (``pre_tool_use`` / ``post_tool_use`` /
+``session_end``) are silently ignored. An earlier version of this adapter
+wrote the wrong (Claude-Code) names into ``~/.hermes/config.yaml``, which
+caused 5+ days of zero PostToolUse events in production. These tests pin the
+correct names and verify that legacy configs get migrated to the new ones.
+
+Refs Gradata/gradata#190.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gradata.hooks.adapters import hermes
+
+
+def test_install_writes_pre_tool_call_not_pre_tool_use(tmp_path: Path) -> None:
+    brain = tmp_path / "brain"
+    brain.mkdir()
+    config = tmp_path / ".hermes" / "config.yaml"
+    config.parent.mkdir()
+
+    result = hermes.install(brain, config)
+
+    assert result.action == "added", result.message
+    text = config.read_text(encoding="utf-8")
+    assert "pre_tool_call:" in text, text
+    assert "pre_tool_use:" not in text, text
+
+
+def test_install_is_idempotent_under_new_name(tmp_path: Path) -> None:
+    brain = tmp_path / "brain"
+    brain.mkdir()
+    config = tmp_path / ".hermes" / "config.yaml"
+    config.parent.mkdir()
+
+    first = hermes.install(brain, config)
+    second = hermes.install(brain, config)
+
+    assert first.action == "added"
+    assert second.action == "already_present"
+    # Only one entry, under the correct key.
+    text = config.read_text(encoding="utf-8")
+    sig = f"gradata:hermes:{brain.resolve().as_posix()}"
+    assert text.count(sig) == 1, text
+
+
+def test_install_migrates_legacy_pre_tool_use_entry(tmp_path: Path) -> None:
+    """An old broken install (entries under ``pre_tool_use``) must be migrated
+    to ``pre_tool_call`` on the next ``gradata install --agent hermes`` run.
+    """
+    brain = tmp_path / "brain"
+    brain.mkdir()
+    config = tmp_path / ".hermes" / "config.yaml"
+    config.parent.mkdir()
+    legacy = (
+        "hooks:\n"
+        "  pre_tool_use:\n"
+        "    - id: gradata:hermes:/some/other/brain\n"
+        "      command: legacy-command\n"
+    )
+    config.write_text(legacy, encoding="utf-8")
+
+    result = hermes.install(brain, config)
+
+    assert result.action == "added", result.message
+    text = config.read_text(encoding="utf-8")
+    # Legacy key has been removed.
+    assert "pre_tool_use:" not in text, text
+    # New key holds both the migrated entry and the freshly-installed one.
+    assert "pre_tool_call:" in text, text
+    assert "legacy-command" in text, text
+    assert f"gradata:hermes:{brain.resolve().as_posix()}" in text, text
+
+
+def test_event_name_map_pins_hermes_runtime_contract() -> None:
+    """Belt-and-braces: pin the Claude-Code ↔ Hermes event-name mapping so a
+    future refactor can't silently regress the contract."""
+    assert hermes.HERMES_EVENT_NAMES == {
+        "pre_tool_use": "pre_tool_call",
+        "post_tool_use": "post_tool_call",
+        "session_end": "on_session_end",
+    }


### PR DESCRIPTION
## Problem

`gradata install --agent hermes` writes hook entries using Claude-Code event names (`pre_tool_use`, `post_tool_use`, `session_end`) into `~/.hermes/config.yaml`. Hermes only recognizes `pre_tool_call`, `post_tool_call`, `on_session_end` and SILENTLY ignores the others (warning only, no failure).

## Impact

Discovered 2026-05-13 on a real fleet: 2538 SessionStart events in telemetry but ZERO PostToolUse events for 5+ days. No corrections captured, no lessons crystallized, cloud dashboard lift report empty. The hooks looked installed and the warnings are easy to miss in noisy logs.

## Fix

Map per-agent event names in the installer:

| Hook intent      | claude-code     | hermes           |
|------------------|-----------------|------------------|
| Pre-tool         | pre_tool_use    | pre_tool_call    |
| Post-tool        | post_tool_use   | post_tool_call   |
| Session end      | session_end     | on_session_end   |

Update both install AND uninstall paths so users on the old broken config can be migrated cleanly.

The claude-code adapter (which writes CamelCase `PreToolUse` into `~/.claude/settings.json`, a different config format that Claude Code expects natively) is left untouched.

### What changed

- `Gradata/src/gradata/hooks/adapters/hermes.py`
  - Renamed the event key written by the Hermes adapter from `pre_tool_use` → `pre_tool_call`.
  - Added `HERMES_EVENT_NAMES` mapping that pins the runtime contract for all three events.
  - Added `_migrate_legacy_event` helper: when an existing `~/.hermes/config.yaml` still has entries under the broken legacy key, they are folded into the correct key on the next `gradata install --agent hermes` run. This is the symmetric uninstall fix — old broken entries no longer leak.
- `Gradata/tests/test_hermes_hook_event_names.py` (new)
  - Pins the correct key on fresh install.
  - Verifies idempotency under the new key.
  - Verifies legacy-key migration (old broken config → new correct config).
  - Pins the Claude-Code ↔ Hermes event-name mapping.

### Test plan

```
pytest tests/test_hermes_hook_event_names.py tests/test_cli_install_agent.py -xvs
# 9 passed in 1.51s
```

The 4 unrelated failures in `tests/test_rule_to_hook.py` (em-dash rule lessons.md handling) were verified to be pre-existing on `main` and are not touched by this PR.

### Layering / risk

- No layer crossings; pure adapter change inside Layer 2.
- Backwards-compat: existing broken configs are migrated automatically (no user action required); fresh installs immediately get the correct names.

Refs Gradata/gradata#190 (install UX epic).
