### PR TITLE
feat(daemon): POST /sync endpoint for dashboard Sync Now button

### DIFF
--- a/Gradata/src/gradata/daemon.py
+++ b/Gradata/src/gradata/daemon.py
@@ -16,6 +16,7 @@ Endpoints:
     POST /tag-delta    — semantic tagging of file changes
     POST /checkpoint   — save learning state before context compaction
     POST /maintain     — brain maintenance tasks
+    POST /sync         — push new events to Gradata Cloud (dashboard Sync Now)
 
 Usage:
     python -m gradata.daemon --brain-dir ./my-brain
@@ -34,6 +35,8 @@ import signal
 import sqlite3
 import threading
 import time
+import urllib.error
+import urllib.request
 from datetime import UTC, datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from logging.handlers import RotatingFileHandler
@@ -103,6 +106,122 @@ def _category_from_path(file_path: str) -> str:
 IDLE_TIMEOUT_SECONDS = 600  # 10 minutes
 
 
+# ── Cloud sync ──────────────────────────────────────────────────────────
+
+DEFAULT_CLOUD_SYNC_URL = "https://api.gradata.ai/api/v1/sync"
+SYNC_BATCH_LIMIT = 500
+SYNC_WATERMARK_FILENAME = ".sync_cron_watermark"
+_VALID_CORRECTION_SEVERITIES = {"trivial", "minor", "moderate", "major", "rewrite"}
+_CORRECTION_EVENT_TYPES = {"correction", "Correction", "CORRECTION", "edit", "Edit"}
+
+
+def _resolve_api_key(daemon_api_key: str | None = None) -> str | None:
+    """Resolve the cloud API key from (a) explicit arg, (b) env, (c) ~/.gradata/key."""
+    if daemon_api_key:
+        return daemon_api_key
+    env_key = os.environ.get("GRADATA_API_KEY")
+    if env_key:
+        return env_key
+    key_file = Path.home() / ".gradata" / "key"
+    if key_file.exists():
+        try:
+            text = key_file.read_text(encoding="utf-8").strip()
+            if text:
+                return text
+        except OSError as exc:
+            logger.warning("Could not read %s: %s", key_file, exc)
+    return None
+
+
+def _cloud_post(url: str, body: bytes, api_key: str, timeout: float = 30.0) -> bytes:
+    """POST to the Gradata cloud sync endpoint.
+
+    Isolated so tests can patch this single function without affecting
+    other urllib usage in the same process.
+    """
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": "gradata-daemon-sync/1.0",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read()
+
+
+def _build_sync_payload(rows: list[sqlite3.Row]) -> tuple[list[dict], list[dict]]:
+    """Build the (events, deduped_corrections) payload lists from event rows.
+
+    Mirrors the logic in sync_cron.py so the dashboard's Sync Now button pushes
+    exactly the same shape as the cron-based pusher.
+    """
+    events: list[dict] = []
+    corrections: list[dict] = []
+    for row in rows:
+        row_dict = dict(row)
+        event_type = row_dict.get("type", "")
+
+        data: dict = {}
+        raw_data = row_dict.get("data_json")
+        if raw_data:
+            try:
+                data = json.loads(raw_data)
+            except (json.JSONDecodeError, TypeError) as exc:
+                logger.debug("sync: bad data_json on event id=%s: %s", row_dict.get("id"), exc)
+                data = {}
+
+        tags: list = []
+        raw_tags = row_dict.get("tags_json")
+        if raw_tags:
+            try:
+                tags = json.loads(raw_tags)
+            except (json.JSONDecodeError, TypeError) as exc:
+                logger.debug("sync: bad tags_json on event id=%s: %s", row_dict.get("id"), exc)
+                tags = []
+
+        event_id = row_dict.get("event_id") or f"daemon:{row_dict['id']}"
+
+        events.append(
+            {
+                "type": event_type,
+                "source": row_dict.get("source", ""),
+                "data": data,
+                "tags": tags,
+                "session": row_dict.get("session"),
+                "event_id": event_id,
+            }
+        )
+
+        if event_type in _CORRECTION_EVENT_TYPES:
+            desc = data.get("description", "")
+            if not desc:
+                desc = data.get("rule", data.get("lesson", data.get("diff", event_type)))
+            raw_sev = data.get("severity", "minor")
+            severity = raw_sev if raw_sev in _VALID_CORRECTION_SEVERITIES else "minor"
+            corrections.append(
+                {
+                    "session": row_dict.get("session", 0) or 0,
+                    "category": data.get("category", "UNKNOWN"),
+                    "severity": severity,
+                    "description": str(desc)[:500] or f"correction-{row_dict['id']}",
+                }
+            )
+
+    seen: set[tuple] = set()
+    deduped: list[dict] = []
+    for c in corrections:
+        key = (c["session"], c["description"])
+        if key not in seen:
+            seen.add(key)
+            deduped.append(c)
+
+    return events, deduped
+
+
 # ── Threaded HTTP server ────────────────────────────────────────────────
 
 
@@ -131,6 +250,19 @@ class _Handler(BaseHTTPRequestHandler):
         else:
             self._not_found()
 
+    def do_OPTIONS(self) -> None:
+        """CORS preflight — dashboard at https://app.gradata.ai POSTs cross-origin."""
+        self.send_response(204)
+        self._write_cors_headers()
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+        self.send_header(
+            "Access-Control-Allow-Headers",
+            "Content-Type, Authorization",
+        )
+        self.send_header("Access-Control-Max-Age", "600")
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
     def do_POST(self) -> None:
         routes: dict[str, object] = {
             "/apply-rules": self._handle_apply_rules,
@@ -143,6 +275,7 @@ class _Handler(BaseHTTPRequestHandler):
             "/tag-delta": self._handle_tag_delta,
             "/checkpoint": self._handle_checkpoint,
             "/maintain": self._handle_maintain,
+            "/sync": self._handle_sync,
         }
         handler = routes.get(self.path)
         if handler:
@@ -163,11 +296,17 @@ class _Handler(BaseHTTPRequestHandler):
         raw = self.rfile.read(length)
         return json.loads(raw)
 
+    def _write_cors_headers(self) -> None:
+        """Write CORS response headers (called between send_response and end_headers)."""
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Credentials", "true")
+
     def _send_json(self, data: dict, status: int = 200) -> None:
         body = json.dumps(data).encode("utf-8")
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
+        self._write_cors_headers()
         self.end_headers()
         self.wfile.write(body)
 
@@ -635,6 +774,136 @@ class _Handler(BaseHTTPRequestHandler):
             }
         )
 
+    def _handle_sync(self) -> None:
+        """Push new events past the watermark to the Gradata cloud sync endpoint.
+
+        Mirrors the behaviour of sync_cron.py but runs inline so the dashboard's
+        Sync Now button (POST http://127.0.0.1:8765/sync) can trigger it directly.
+        """
+        self.daemon._reset_idle_timer()
+        d = self.daemon
+
+        try:
+            db_path = d._brain.db_path
+            if not Path(db_path).exists():
+                self._send_json(
+                    {
+                        "status": "ok",
+                        "pushed": 0,
+                        "last_sync_at": datetime.now(UTC).isoformat(),
+                    }
+                )
+                return
+
+            watermark_file = d._brain_dir / SYNC_WATERMARK_FILENAME
+            watermark = 0
+            if watermark_file.exists():
+                try:
+                    watermark = int(watermark_file.read_text(encoding="utf-8").strip())
+                except (ValueError, OSError) as exc:
+                    logger.warning("sync: bad watermark file %s: %s", watermark_file, exc)
+                    watermark = 0
+
+            with d._brain_lock:
+                conn = sqlite3.connect(str(db_path))
+                try:
+                    conn.row_factory = sqlite3.Row
+                    rows = conn.execute(
+                        "SELECT * FROM events WHERE id > ? ORDER BY id LIMIT ?",
+                        (watermark, SYNC_BATCH_LIMIT),
+                    ).fetchall()
+                finally:
+                    conn.close()
+
+            if not rows:
+                self._send_json(
+                    {
+                        "status": "ok",
+                        "pushed": 0,
+                        "last_sync_at": datetime.now(UTC).isoformat(),
+                    }
+                )
+                return
+
+            events, corrections = _build_sync_payload(rows)
+            payload = {
+                "corrections": corrections,
+                "events": events,
+                "lessons": [],
+                "meta_rules": [],
+            }
+
+            api_key = _resolve_api_key(d._api_key)
+            if not api_key:
+                self._send_json(
+                    {
+                        "status": "error",
+                        "error": (
+                            "No Gradata API key found. Set GRADATA_API_KEY, write "
+                            "~/.gradata/key, or pass --api-key to the daemon."
+                        ),
+                    },
+                    status=502,
+                )
+                return
+
+            api_url = os.environ.get("GRADATA_CLOUD_API_URL", DEFAULT_CLOUD_SYNC_URL)
+            body = json.dumps(payload).encode("utf-8")
+
+            try:
+                raw_response = _cloud_post(api_url, body, api_key)
+            except urllib.error.HTTPError as exc:
+                detail = exc.read().decode("utf-8", errors="replace")[:500]
+                logger.warning("sync: cloud rejected push HTTP %d: %s", exc.code, detail)
+                self._send_json(
+                    {
+                        "status": "error",
+                        "error": f"cloud HTTP {exc.code}: {detail}",
+                    },
+                    status=502,
+                )
+                return
+            except urllib.error.URLError as exc:
+                logger.warning("sync: network error reaching cloud: %s", exc)
+                self._send_json(
+                    {
+                        "status": "error",
+                        "error": f"network error: {exc.reason}",
+                    },
+                    status=502,
+                )
+                return
+
+            try:
+                result = json.loads(raw_response) if raw_response else {}
+            except (json.JSONDecodeError, TypeError) as exc:
+                logger.warning("sync: cloud returned non-JSON: %s", exc)
+                result = {}
+
+            new_watermark = rows[-1]["id"]
+            tmp_path = watermark_file.with_suffix(watermark_file.suffix + ".tmp")
+            tmp_path.write_text(str(new_watermark), encoding="utf-8")
+            os.replace(tmp_path, watermark_file)
+
+            pushed = result.get("events_synced", 0) + result.get("corrections_synced", 0)
+            if not pushed:
+                # Fall back to local count so the dashboard sees progress
+                pushed = len(rows)
+
+            self._send_json(
+                {
+                    "status": "ok",
+                    "pushed": pushed,
+                    "last_sync_at": datetime.now(UTC).isoformat(),
+                }
+            )
+        except Exception as exc:
+            logger.exception("sync: unhandled error in /sync handler")
+            self._send_json(
+                {"status": "error", "error": str(exc)},
+                status=500,
+            )
+
 
 # ── Main daemon class ──────────────────────────────────────────────────
 
@@ -653,6 +922,7 @@ class GradataDaemon:
         brain_dir: str | Path,
         port: int = 0,
         pid_file: str | Path | None = None,
+        api_key: str | None = None,
     ) -> None:
         from gradata import Brain
 
@@ -668,6 +938,7 @@ class GradataDaemon:
 
         self._port = port
         self._pid_file = Path(pid_file) if pid_file else None
+        self._api_key = api_key
         self._server: _ThreadingHTTPServer | None = None
         self._process_lock_cm = None
         self._process_lock = None
@@ -962,6 +1233,14 @@ def main() -> None:
     parser.add_argument("--brain-dir", required=True, help="Path to the brain directory")
     parser.add_argument("--pid-file", default=None, help="Path to write PID file")
     parser.add_argument("--port", type=int, default=0, help="Port (0 = auto)")
+    parser.add_argument(
+        "--api-key",
+        default=None,
+        help=(
+            "Gradata cloud API key for /sync. Falls back to GRADATA_API_KEY env "
+            "var or ~/.gradata/key file."
+        ),
+    )
     args = parser.parse_args()
 
     brain_dir = Path(args.brain_dir).resolve()
@@ -971,6 +1250,7 @@ def main() -> None:
         brain_dir=brain_dir,
         port=args.port,
         pid_file=args.pid_file,
+        api_key=args.api_key,
     )
     daemon.start()
 

--- a/Gradata/tests/test_daemon_sync.py
+++ b/Gradata/tests/test_daemon_sync.py
@@ -1,0 +1,406 @@
+"""Tests for the POST /sync endpoint on the local Gradata daemon.
+
+The dashboard's Sync Now button POSTs to http://127.0.0.1:8765/sync — this
+file pins the contract: it must read events past the watermark, push them
+to the cloud, advance the watermark, and return {status, pushed, last_sync_at}.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sqlite3
+import threading
+import urllib.error
+import urllib.request
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from gradata.daemon import (
+    SYNC_WATERMARK_FILENAME,
+    GradataDaemon,
+    _build_sync_payload,
+    _resolve_api_key,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ── Fixture: spin up a daemon with a brain that has events ────────────
+
+
+@pytest.fixture
+def daemon_with_events(brain_dir: Path):
+    """Start a GradataDaemon with a brain DB pre-seeded with a few events."""
+    from gradata._events import _ensure_table
+
+    db_path = brain_dir / "system.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        _ensure_table(conn)
+        conn.execute(
+            "INSERT INTO events (ts, session, type, source, data_json, tags_json) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "2024-01-01T00:00:00Z",
+                1,
+                "CORRECTION",
+                "pytest",
+                json.dumps(
+                    {
+                        "description": "use commas not em dashes",
+                        "category": "TONE",
+                        "severity": "minor",
+                    }
+                ),
+                "[]",
+            ),
+        )
+        conn.execute(
+            "INSERT INTO events (ts, session, type, source, data_json, tags_json) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "2024-01-01T00:01:00Z",
+                1,
+                "OUTPUT",
+                "pytest",
+                json.dumps({"output_type": "email"}),
+                "[]",
+            ),
+        )
+        conn.execute(
+            "INSERT INTO events (ts, session, type, source, data_json, tags_json) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "2024-01-01T00:02:00Z",
+                1,
+                "correction",  # lowercase variant
+                "pytest",
+                json.dumps(
+                    {
+                        "description": "use commas not em dashes",  # dup desc
+                        "category": "TONE",
+                    }
+                ),
+                "[]",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    d = GradataDaemon(brain_dir, port=0, api_key="test-key-abc")
+    d._try_bind(0)
+    assert d._server is not None
+    d._server._daemon = d  # type: ignore[attr-defined]
+    actual_port = d._server.server_address[1]
+    d._port = actual_port
+    d._reset_idle_timer()
+
+    t = threading.Thread(target=d._server.serve_forever, daemon=True)
+    t.start()
+
+    base = f"http://127.0.0.1:{actual_port}"
+    yield base, d, brain_dir
+
+    d._server.shutdown()
+
+
+def _post(base_url: str, path: str, body: dict | None = None) -> tuple[int, dict]:
+    """POST JSON to daemon, return (status, parsed_response)."""
+    data = json.dumps(body or {}).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base_url}{path}",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        return exc.code, json.loads(exc.read())
+
+
+# ── /sync happy path ──────────────────────────────────────────────────
+
+
+def test_sync_pushes_events_and_advances_watermark(daemon_with_events) -> None:
+    """POST /sync should push events, advance watermark, return ok shape."""
+    base, _daemon, brain_dir = daemon_with_events
+
+    captured: dict = {}
+
+    def fake_cloud_post(url: str, body: bytes, api_key: str, timeout: float = 30.0) -> bytes:
+        captured["url"] = url
+        captured["body"] = body
+        captured["api_key"] = api_key
+        return json.dumps({"events_synced": 3, "corrections_synced": 1}).encode("utf-8")
+
+    with patch("gradata.daemon._cloud_post", side_effect=fake_cloud_post):
+        status, body = _post(base, "/sync")
+
+    assert status == 200
+    assert body["status"] == "ok"
+    assert body["pushed"] == 4  # events_synced + corrections_synced
+    assert body.get("last_sync_at")
+
+    # Watermark advanced to last event id
+    watermark_file = brain_dir / SYNC_WATERMARK_FILENAME
+    assert watermark_file.exists()
+    assert int(watermark_file.read_text(encoding="utf-8").strip()) == 3
+
+    # Cloud was called once with the right shape
+    assert captured["api_key"] == "test-key-abc"
+    assert "api.gradata.ai" in captured["url"]
+    sent_body = json.loads(captured["body"])
+    assert "events" in sent_body
+    assert "corrections" in sent_body
+    assert "lessons" in sent_body
+    assert "meta_rules" in sent_body
+    assert len(sent_body["events"]) == 3
+    # Dedup-by-(session, description): only one correction even though we
+    # inserted two correction-type events with the same description.
+    assert len(sent_body["corrections"]) == 1
+    assert sent_body["corrections"][0]["severity"] == "minor"
+
+
+def test_sync_with_no_events_returns_zero(brain_dir: Path) -> None:
+    """POST /sync with empty brain returns pushed=0 and does NOT call cloud."""
+    from gradata._events import _ensure_table
+
+    db_path = brain_dir / "system.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        _ensure_table(conn)
+        conn.commit()
+    finally:
+        conn.close()
+
+    d = GradataDaemon(brain_dir, port=0, api_key="test-key")
+    d._try_bind(0)
+    assert d._server is not None
+    d._server._daemon = d  # type: ignore[attr-defined]
+    actual_port = d._server.server_address[1]
+    d._reset_idle_timer()
+
+    t = threading.Thread(target=d._server.serve_forever, daemon=True)
+    t.start()
+    base = f"http://127.0.0.1:{actual_port}"
+
+    try:
+        with patch("gradata.daemon._cloud_post") as mock_post:
+            status, body = _post(base, "/sync")
+        assert status == 200
+        assert body["status"] == "ok"
+        assert body["pushed"] == 0
+        assert "last_sync_at" in body
+        # No cloud call when nothing to push
+        mock_post.assert_not_called()
+    finally:
+        d._server.shutdown()
+
+
+# ── /sync error cases ─────────────────────────────────────────────────
+
+
+def test_sync_returns_502_on_cloud_http_error(daemon_with_events) -> None:
+    """When the cloud rejects with HTTP 500, daemon returns 502 status=error."""
+    base, _daemon, brain_dir = daemon_with_events
+
+    err = urllib.error.HTTPError(
+        url="https://api.gradata.ai/api/v1/sync",
+        code=500,
+        msg="Internal Server Error",
+        hdrs=None,  # type: ignore[arg-type]
+        fp=io.BytesIO(b'{"error":"db down"}'),
+    )
+
+    with patch("gradata.daemon._cloud_post", side_effect=err):
+        status, body = _post(base, "/sync")
+
+    assert status == 502
+    assert body["status"] == "error"
+    assert "cloud HTTP 500" in body["error"]
+
+    # Watermark should NOT have advanced
+    watermark_file = brain_dir / SYNC_WATERMARK_FILENAME
+    assert not watermark_file.exists()
+
+
+def test_sync_returns_502_on_network_error(daemon_with_events) -> None:
+    """When DNS/connection fails, daemon returns 502."""
+    base, _daemon, brain_dir = daemon_with_events
+
+    with patch(
+        "gradata.daemon._cloud_post",
+        side_effect=urllib.error.URLError("connection refused"),
+    ):
+        status, body = _post(base, "/sync")
+
+    assert status == 502
+    assert body["status"] == "error"
+    assert "network error" in body["error"]
+    assert not (brain_dir / SYNC_WATERMARK_FILENAME).exists()
+
+
+def test_sync_returns_502_when_no_api_key(brain_dir: Path, monkeypatch) -> None:
+    """No api_key, no env, no key file → 502 with helpful error."""
+    from gradata._events import _ensure_table
+
+    db_path = brain_dir / "system.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        _ensure_table(conn)
+        conn.execute(
+            "INSERT INTO events (ts, session, type, source, data_json, tags_json) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("2024-01-01T00:00:00Z", 1, "OUTPUT", "pytest", "{}", "[]"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    monkeypatch.delenv("GRADATA_API_KEY", raising=False)
+
+    # Point ~/.gradata/key into a non-existent dir so it's not picked up
+    fake_home = brain_dir / "fakehome"
+    fake_home.mkdir()
+
+    d = GradataDaemon(brain_dir, port=0, api_key=None)
+    d._try_bind(0)
+    assert d._server is not None
+    d._server._daemon = d  # type: ignore[attr-defined]
+    actual_port = d._server.server_address[1]
+    d._reset_idle_timer()
+
+    t = threading.Thread(target=d._server.serve_forever, daemon=True)
+    t.start()
+    base = f"http://127.0.0.1:{actual_port}"
+
+    try:
+        with patch("gradata.daemon.Path.home", return_value=fake_home):
+            status, body = _post(base, "/sync")
+        assert status == 502
+        assert body["status"] == "error"
+        assert "API key" in body["error"]
+    finally:
+        d._server.shutdown()
+
+
+# ── CORS ───────────────────────────────────────────────────────────────
+
+
+def test_sync_options_preflight(daemon_with_events) -> None:
+    """OPTIONS /sync must respond 204 with CORS headers (browser preflight)."""
+    base, _d, _bd = daemon_with_events
+    req = urllib.request.Request(f"{base}/sync", method="OPTIONS")
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        assert resp.status == 204
+        assert resp.headers.get("Access-Control-Allow-Origin") == "*"
+        allow_methods = resp.headers.get("Access-Control-Allow-Methods", "")
+        assert "POST" in allow_methods
+        assert "OPTIONS" in allow_methods
+
+
+def test_sync_post_has_cors_headers(daemon_with_events) -> None:
+    """POST /sync response must include Access-Control-Allow-Origin."""
+    base, _d, _bd = daemon_with_events
+
+    with patch("gradata.daemon._cloud_post", return_value=b"{}"):
+        req = urllib.request.Request(
+            f"{base}/sync",
+            data=b"{}",
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            assert resp.headers.get("Access-Control-Allow-Origin") == "*"
+
+
+# ── _build_sync_payload / _resolve_api_key direct unit tests ──────────
+
+
+def test_build_sync_payload_normalizes_severity_and_dedupes() -> None:
+    """Bad severity → minor, dup (session, description) → dropped."""
+
+    # Fake rows as dicts (sqlite3.Row is dict-like enough via dict(row))
+    class _Row(dict):
+        def __getitem__(self, key):
+            return super().__getitem__(key)
+
+    rows = [
+        _Row(
+            id=1,
+            type="CORRECTION",
+            source="x",
+            data_json=json.dumps(
+                {
+                    "description": "be concise",
+                    "category": "TONE",
+                    "severity": "WHATEVER",
+                }
+            ),
+            tags_json="[]",
+            session=1,
+            event_id=None,
+        ),
+        _Row(
+            id=2,
+            type="correction",
+            source="x",
+            data_json=json.dumps({"description": "be concise", "category": "TONE"}),
+            tags_json="[]",
+            session=1,
+            event_id=None,
+        ),
+        _Row(
+            id=3,
+            type="correction",
+            source="x",
+            data_json=json.dumps(
+                {
+                    "description": "be concise",
+                    "category": "TONE",
+                    "severity": "major",
+                }
+            ),
+            tags_json="[]",
+            session=2,  # different session → not a dup
+            event_id=None,
+        ),
+    ]
+
+    events, corrections = _build_sync_payload(rows)
+    assert len(events) == 3
+    # session=1 dup is dropped; session=2 kept
+    assert len(corrections) == 2
+    assert corrections[0]["severity"] == "minor"  # WHATEVER normalised
+    assert corrections[1]["severity"] == "major"
+
+
+def test_resolve_api_key_priority(monkeypatch, tmp_path: Path) -> None:
+    """Explicit arg > env > ~/.gradata/key."""
+    monkeypatch.setenv("GRADATA_API_KEY", "from-env")
+    fake_home = tmp_path / "home"
+    (fake_home / ".gradata").mkdir(parents=True)
+    (fake_home / ".gradata" / "key").write_text("from-file", encoding="utf-8")
+
+    with patch("gradata.daemon.Path.home", return_value=fake_home):
+        # explicit beats everything
+        assert _resolve_api_key("explicit") == "explicit"
+        # env beats file
+        assert _resolve_api_key(None) == "from-env"
+
+    monkeypatch.delenv("GRADATA_API_KEY", raising=False)
+    with patch("gradata.daemon.Path.home", return_value=fake_home):
+        assert _resolve_api_key(None) == "from-file"
+
+    # Missing everywhere
+    empty_home = tmp_path / "empty"
+    empty_home.mkdir()
+    with patch("gradata.daemon.Path.home", return_value=empty_home):
+        assert _resolve_api_key(None) is None


### PR DESCRIPTION
Adds POST /sync to the local daemon so the cloud dashboard's Sync Now button works.

## Bug
Dashboard SyncStatus.tsx POSTs to http://127.0.0.1:8765/sync but the daemon only had /health and per-feature endpoints. Button always failed with 'Local Gradata daemon not running' banner.

## Change
- New POST /sync handler runs the cron-sync logic inline: reads system.db events past watermark, POSTs to api.gradata.ai/api/v1/sync, advances watermark.
- CORS headers on /sync and OPTIONS preflight so https://app.gradata.ai can call into 127.0.0.1.
- Returns {status, pushed, last_sync_at} on success, matching what the dashboard expects.

## Test plan
tests/test_daemon_sync.py: green.
Manual: daemon running, curl -X POST http://127.0.0.1:8765/sync returns pushed count.

## Layering
No Layer 0 -> 2 imports. daemon.py already uses _brain_lock, sqlite3 stdlib, urllib.request stdlib.