### PR TITLE
fix(daemon): add Access-Control-Allow-Private-Network for Chrome PNA

### DIFF
--- a/Gradata/src/gradata/daemon.py
+++ b/Gradata/src/gradata/daemon.py
@@ -251,7 +251,14 @@ class _Handler(BaseHTTPRequestHandler):
             self._not_found()
 
     def do_OPTIONS(self) -> None:
-        """CORS preflight — dashboard at https://app.gradata.ai POSTs cross-origin."""
+        """CORS preflight — dashboard at https://app.gradata.ai POSTs cross-origin.
+
+        Chrome's Private Network Access (PNA) requires the
+        Access-Control-Allow-Private-Network response header on preflights
+        from public origins (HTTPS pages) to private IPs (127.0.0.1).
+        Without it the preflight fails silently and the real request is
+        never sent — the "Sync Now" button looks like a no-op.
+        """
         self.send_response(204)
         self._write_cors_headers()
         self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
@@ -259,6 +266,7 @@ class _Handler(BaseHTTPRequestHandler):
             "Access-Control-Allow-Headers",
             "Content-Type, Authorization",
         )
+        self.send_header("Access-Control-Allow-Private-Network", "true")
         self.send_header("Access-Control-Max-Age", "600")
         self.send_header("Content-Length", "0")
         self.end_headers()


### PR DESCRIPTION
Bug: dashboard Sync Now button silently failed in Chrome/Edge because the daemon CORS preflight did not include Access-Control-Allow-Private-Network. Chrome PNA blocks requests from https:// public origins to private IPs (127.0.0.1) unless this header is on the preflight. The fetch fails with 'TypeError: Failed to fetch' before the real POST is sent.

Fix: add the header to do_OPTIONS in daemon.py.

Verify:
curl -X OPTIONS http://127.0.0.1:8765/sync -H 'Origin: https://app.gradata.ai' -H 'Access-Control-Request-Private-Network: true' -i

Response now includes: Access-Control-Allow-Private-Network: true

Follow-up to #196.