### PR TITLE
fix(daemon): heartbeat empty /sync to cloud so brains.last_sync_at advances

### DIFF
--- a/Gradata/src/gradata/daemon.py
+++ b/Gradata/src/gradata/daemon.py
@@ -824,6 +824,27 @@ class _Handler(BaseHTTPRequestHandler):
                     conn.close()
 
             if not rows:
+                # Heartbeat: still POST an empty payload so the cloud can bump
+                # `brains.last_sync_at`. Without this the dashboard's
+                # "last sync Nh ago" stays stale even though the button worked.
+                api_key = _resolve_api_key(d._api_key)
+                if not api_key:
+                    self._send_json(
+                        {
+                            "status": "ok",
+                            "pushed": 0,
+                            "last_sync_at": datetime.now(UTC).isoformat(),
+                        }
+                    )
+                    return
+                api_url = os.environ.get("GRADATA_CLOUD_API_URL", DEFAULT_CLOUD_SYNC_URL)
+                heartbeat = json.dumps(
+                    {"corrections": [], "events": [], "lessons": [], "meta_rules": []}
+                ).encode("utf-8")
+                try:
+                    _cloud_post(api_url, heartbeat, api_key)
+                except (urllib.error.HTTPError, urllib.error.URLError) as exc:
+                    logger.info("sync: cloud heartbeat failed (non-fatal): %s", exc)
                 self._send_json(
                     {
                         "status": "ok",


### PR DESCRIPTION
## Bug

Dashboard 'Sync Now' returned 'Synced 0 events' (success) but 'last sync' stayed at e.g. 15h ago because the daemon short-circuited the empty-payload case and never hit the cloud. brains.last_sync_at therefore stayed stale.

## Fix

When no new local events past the watermark, still POST an empty payload to api.gradata.ai/api/v1/sync as a heartbeat. The cloud /sync endpoint already updates brains.last_sync_at to now() in this path. Failures are logged at info level (non-fatal).

## Verify

Before:
  3b49e9c6 last_sync= 2026-05-15T08:25:36+00:00

After one POST /sync with watermark=329 (no new events):
  3b49e9c6 last_sync= 2026-05-15T23:43:58+00:00

Follow-up to #196 and #197.