### PR TITLE
fix(daemon): allow disabling idle-shutdown via GRADATA_DAEMON_IDLE_TIMEOUT

### DIFF
--- a/Gradata/src/gradata/daemon.py
+++ b/Gradata/src/gradata/daemon.py
@@ -103,7 +103,12 @@ def _category_from_path(file_path: str) -> str:
 
 
 # ── Idle timeout ────────────────────────────────────────────────────────
-IDLE_TIMEOUT_SECONDS = 600  # 10 minutes
+# The daemon shuts itself down after this many seconds with no incoming
+# requests. Override via GRADATA_DAEMON_IDLE_TIMEOUT (seconds, integer).
+# Set to 0 to disable idle-shutdown entirely (recommended when the dashboard
+# Sync Now button is the only client — long stretches of no requests are
+# normal and shutting down breaks the button until the watchdog catches up).
+IDLE_TIMEOUT_SECONDS = int(os.environ.get("GRADATA_DAEMON_IDLE_TIMEOUT", "600"))
 
 
 # ── Cloud sync ──────────────────────────────────────────────────────────
@@ -1017,6 +1022,9 @@ class GradataDaemon:
     # ── Idle timer ──────────────────────────────────────────────────────
 
     def _reset_idle_timer(self) -> None:
+        # Idle-shutdown disabled (timeout <= 0): treat as long-running daemon.
+        if IDLE_TIMEOUT_SECONDS <= 0:
+            return
         if self._idle_timer is not None:
             self._idle_timer.cancel()
         self._idle_timer = threading.Timer(IDLE_TIMEOUT_SECONDS, self._idle_shutdown)


### PR DESCRIPTION
Bug: daemon self-terminates after 10min idle, breaking dashboard Sync Now until the watchdog cron catches up ~5min later. Users perceive intermittent 'Local Gradata daemon not running' errors.

Fix: make IDLE_TIMEOUT_SECONDS env-configurable. Setting GRADATA_DAEMON_IDLE_TIMEOUT=0 disables idle-shutdown entirely. Default unchanged (600s) for backwards compatibility.

Recommended config when daemon is only servicing Sync Now: GRADATA_DAEMON_IDLE_TIMEOUT=0.

Follow-up to #196/#197/#198.