### PR TITLE
feat(sync): write-through Brain.correct() → /api/v1/ingest (day 3 of #194)

### DIFF
--- a/Gradata/src/gradata/_migrations/__init__.py
+++ b/Gradata/src/gradata/_migrations/__init__.py
@@ -72,6 +72,17 @@ _BASE_TABLES: list[str] = [
         timestamp TEXT NOT NULL,
         user_context TEXT
     )""",
+    # Write-through sync queue (cloud upload buffer, #194). Idempotent:
+    # if PR #195 lands first this block is a no-op via CREATE IF NOT EXISTS.
+    """CREATE TABLE IF NOT EXISTS sync_queue (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        payload_json TEXT NOT NULL,
+        kind TEXT NOT NULL CHECK(kind IN ('correction','lesson','event')),
+        enqueued_at REAL NOT NULL,
+        synced_at REAL,
+        attempts INTEGER DEFAULT 0,
+        last_error TEXT
+    )""",
 ]
 
 _MIGRATIONS: list[str] = [
@@ -97,6 +108,7 @@ _MIGRATIONS: list[str] = [
     "ALTER TABLE super_meta_rules ADD COLUMN applies_when TEXT",
     "ALTER TABLE super_meta_rules ADD COLUMN never_when TEXT",
     "ALTER TABLE super_meta_rules ADD COLUMN transfer_scope TEXT DEFAULT 'personal'",
+    "CREATE INDEX IF NOT EXISTS idx_sync_queue_pending ON sync_queue(synced_at) WHERE synced_at IS NULL",
 ]
 
 

--- a/Gradata/src/gradata/_sync_queue.py
+++ b/Gradata/src/gradata/_sync_queue.py
@@ -1,0 +1,155 @@
+"""Sync queue primitives — local SQLite buffer for write-through cloud sync.
+
+Day 1 of #194 (write-through sync). Provides CRUD over the ``sync_queue``
+table that is created as part of the standard Brain schema (see
+``_migrations/__init__.py``). The queue stores serialized payloads that
+need to be flushed to the cloud ingest endpoint; the actual flush
+worker is implemented in :mod:`gradata._sync_worker`.
+
+All public functions take an explicit ``sqlite3.Connection`` as the first
+argument — there are no implicit globals or module-level state.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+
+__all__ = [
+    "enqueue",
+    "enqueue_correction",
+    "mark_failed",
+    "mark_synced",
+    "peek_pending",
+]
+
+_VALID_KINDS = ("correction", "lesson", "event")
+_MAX_ERROR_LEN = 500
+
+
+def enqueue(conn: sqlite3.Connection, kind: str, payload: dict) -> int:
+    """Insert a new row into ``sync_queue`` and return its row id.
+
+    Args:
+        conn: Active SQLite connection to a brain database.
+        kind: One of ``'correction'``, ``'lesson'``, ``'event'``. The
+            CHECK constraint on the column will reject anything else
+            with :class:`sqlite3.IntegrityError`.
+        payload: Arbitrary JSON-serializable dict; stored via
+            ``json.dumps`` into ``payload_json``.
+
+    Returns:
+        The autoincrement ``id`` of the newly inserted row.
+    """
+    payload_json = json.dumps(payload, ensure_ascii=False)
+    cur = conn.execute(
+        "INSERT INTO sync_queue (payload_json, kind, enqueued_at) VALUES (?, ?, ?)",
+        (payload_json, kind, time.time()),
+    )
+    conn.commit()
+    rowid = cur.lastrowid
+    if rowid is None:
+        raise RuntimeError("sync_queue insert did not return a lastrowid")
+    return int(rowid)
+
+
+def enqueue_correction(
+    conn: sqlite3.Connection,
+    brain_id: str,
+    correction: dict,
+    event_id: str | None = None,
+) -> int:
+    """Convenience: enqueue a correction in the shape the cloud /ingest expects.
+
+    Wraps :func:`enqueue` with ``kind='correction'`` and the
+    ``IngestRequest`` payload shape::
+
+        {"brain_id": <brain_id>, "correction": <correction>, "event_id": <event_id>}
+
+    The cloud receiver (``POST /api/v1/ingest``) deduplicates on
+    ``event_id`` — pass a deterministic id (e.g. derived from
+    session/timestamp/content hash) to get idempotent retries.
+    """
+    payload: dict = {
+        "brain_id": brain_id,
+        "correction": correction,
+        "event_id": event_id,
+    }
+    return enqueue(conn, "correction", payload)
+
+
+def peek_pending(conn: sqlite3.Connection, limit: int = 100) -> list[dict]:
+    """Return up to ``limit`` pending rows ordered by id (FIFO).
+
+    Pending == ``synced_at IS NULL``. Each returned dict has keys:
+    ``id`` (int), ``kind`` (str), ``payload`` (decoded dict),
+    ``enqueued_at`` (float), and ``attempts`` (int).
+    """
+    rows = conn.execute(
+        "SELECT id, kind, payload_json, enqueued_at, attempts "
+        "FROM sync_queue "
+        "WHERE synced_at IS NULL "
+        "ORDER BY id ASC "
+        "LIMIT ?",
+        (int(limit),),
+    ).fetchall()
+
+    out: list[dict] = []
+    for r in rows:
+        # Support both sqlite3.Row (named) and tuple rows.
+        try:
+            rid = r["id"]
+            kind = r["kind"]
+            payload_json = r["payload_json"]
+            enqueued_at = r["enqueued_at"]
+            attempts = r["attempts"]
+        except (TypeError, IndexError):
+            rid, kind, payload_json, enqueued_at, attempts = r
+        try:
+            payload = json.loads(payload_json) if payload_json else {}
+        except json.JSONDecodeError:
+            payload = {"_raw": payload_json}
+        out.append(
+            {
+                "id": int(rid),
+                "kind": kind,
+                "payload": payload,
+                "enqueued_at": float(enqueued_at) if enqueued_at is not None else None,
+                "attempts": int(attempts) if attempts is not None else 0,
+            }
+        )
+    return out
+
+
+def mark_synced(conn: sqlite3.Connection, ids: list[int]) -> None:
+    """Mark the given row ids as successfully synced (sets ``synced_at``)."""
+    if not ids:
+        return
+    now = time.time()
+    placeholders = ",".join("?" for _ in ids)
+    conn.execute(
+        f"UPDATE sync_queue SET synced_at = ? WHERE id IN ({placeholders})",
+        (now, *[int(i) for i in ids]),
+    )
+    conn.commit()
+
+
+def mark_failed(conn: sqlite3.Connection, ids: list[int], error: str) -> None:
+    """Record a failed sync attempt for the given rows.
+
+    Increments ``attempts`` and stores the (truncated) error message on
+    every targeted row. The rows remain pending (``synced_at`` stays
+    NULL) so they will be retried.
+    """
+    if not ids:
+        return
+    truncated = (error or "")[:_MAX_ERROR_LEN]
+    placeholders = ",".join("?" for _ in ids)
+    conn.execute(
+        f"UPDATE sync_queue "
+        f"SET attempts = COALESCE(attempts, 0) + 1, last_error = ? "
+        f"WHERE id IN ({placeholders})",
+        (truncated, *[int(i) for i in ids]),
+    )
+    conn.commit()

--- a/Gradata/src/gradata/_sync_worker.py
+++ b/Gradata/src/gradata/_sync_worker.py
@@ -1,0 +1,234 @@
+"""Background sync worker — drains the local ``sync_queue`` to the cloud.
+
+Day 3 of #194. A :class:`SyncWorker` runs as a daemon thread inside the
+Brain process. On each tick (default 30s) it:
+
+1. Opens a fresh sqlite connection to ``<brain>/system.db``.
+2. Reads up to 50 pending rows via :func:`gradata._sync_queue.peek_pending`.
+3. POSTs each payload to the cloud ingest endpoint
+   (``GRADATA_CLOUD_INGEST_URL`` or ``https://api.gradata.ai/api/v1/ingest``).
+4. On 2xx (including ``deduplicated=true``) → ``mark_synced``.
+5. On 4xx other than 429 → ``mark_failed`` (permanent; treated as
+   not-pending by re-marking; payload kept for forensics but not retried).
+6. On 5xx / network errors → ``mark_failed`` (transient, retried next tick).
+7. On 429 → ``mark_failed`` and bail out of the tick (back off until next).
+
+Concurrency rules:
+* Daemon thread; never blocks process exit.
+* Never holds the brain's locks — owns its own connection-per-call.
+* :meth:`stop(drain=True)` runs one final synchronous tick before returning,
+  so :meth:`gradata.brain.Brain.close` can flush pending corrections on exit.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from gradata import _sync_queue
+
+__all__ = ["SyncWorker"]
+
+logger = logging.getLogger("gradata.sync_worker")
+
+_DEFAULT_INGEST_URL = "https://api.gradata.ai/api/v1/ingest"
+_TICK_BATCH = 50
+_HTTP_TIMEOUT = 30.0
+# 4xx status codes that mean "don't retry, this row is poison".
+_PERMANENT_4XX = {400, 401, 403, 404, 410, 422}
+
+
+class SyncWorker:
+    """Drain ``sync_queue`` to the cloud ``/api/v1/ingest`` endpoint.
+
+    Args:
+        brain_dir: Path to the brain directory (contains ``system.db``).
+        api_key: Bearer token for the cloud API.
+        ingest_url: Full URL of the cloud ingest endpoint.
+        tick_sec: Interval between drain attempts.
+    """
+
+    def __init__(
+        self,
+        brain_dir: Path,
+        api_key: str,
+        ingest_url: str = _DEFAULT_INGEST_URL,
+        tick_sec: float = 30.0,
+    ) -> None:
+        self.brain_dir = Path(brain_dir)
+        self.api_key = api_key
+        self.ingest_url = ingest_url
+        self.tick_sec = float(tick_sec)
+
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._started = False
+
+    # ── lifecycle ────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        """Spawn the daemon thread. Idempotent."""
+        if self._started:
+            return
+        self._started = True
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="gradata-sync-worker",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self, drain: bool = True) -> None:
+        """Signal shutdown and (optionally) run one final synchronous tick.
+
+        Safe to call multiple times.
+        """
+        self._stop_event.set()
+        if drain:
+            try:
+                self._tick()
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.debug("final drain tick failed: %s", exc)
+        if self._thread is not None:
+            self._thread.join(timeout=max(1.0, self.tick_sec))
+            self._thread = None
+        self._started = False
+
+    # ── thread loop ──────────────────────────────────────────────────
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                self._tick()
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.warning("sync tick failed: %s", exc, exc_info=True)
+            # Wait tick_sec OR until shutdown — wake immediately on stop().
+            self._stop_event.wait(self.tick_sec)
+
+    # ── single tick ──────────────────────────────────────────────────
+
+    def _tick(self) -> None:
+        db_path = self.brain_dir / "system.db"
+        if not db_path.exists():
+            return
+
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = _sync_queue.peek_pending(conn, limit=_TICK_BATCH)
+            if not rows:
+                return
+
+            for row in rows:
+                if self._stop_event.is_set():
+                    # On shutdown, only finish work if we're inside the
+                    # explicit drain path (stop calls _tick directly).
+                    # Otherwise bail early — main thread already set the
+                    # event and any in-flight POST would just delay exit.
+                    if threading.current_thread() is not self._thread:
+                        # we are inside stop(drain=True) → keep going
+                        pass
+                    else:
+                        return
+
+                row_id = int(row["id"])
+                payload = row.get("payload") or {}
+                try:
+                    status, _resp = self._post_one(payload)
+                except urllib.error.HTTPError as exc:
+                    status = int(exc.code)
+                    body_preview = _safe_body_preview(exc)
+                    if status == 429:
+                        _sync_queue.mark_failed(conn, [row_id], f"http 429: {body_preview}")
+                        # Back off — stop this tick entirely.
+                        return
+                    if status in _PERMANENT_4XX:
+                        # Mark synced so we don't retry forever. The row
+                        # remains in the table for forensics. last_error
+                        # is set via a preceding mark_failed for context.
+                        _sync_queue.mark_failed(
+                            conn, [row_id], f"http {status} (permanent): {body_preview}"
+                        )
+                        _sync_queue.mark_synced(conn, [row_id])
+                        continue
+                    # 5xx and anything else → transient, retry next tick.
+                    _sync_queue.mark_failed(conn, [row_id], f"http {status}: {body_preview}")
+                    continue
+                except (urllib.error.URLError, TimeoutError, OSError) as exc:
+                    _sync_queue.mark_failed(conn, [row_id], f"network: {exc}")
+                    continue
+                except Exception as exc:  # pragma: no cover — defensive
+                    _sync_queue.mark_failed(conn, [row_id], f"unexpected: {exc}")
+                    continue
+
+                # 2xx happy path (including deduplicated=true)
+                if 200 <= status < 300:
+                    try:
+                        _sync_queue.mark_synced(conn, [row_id])
+                    except Exception as exc:
+                        # At-least-once: don't lose the row if the DB
+                        # write fails. It will retry next tick (the cloud
+                        # is idempotent on event_id).
+                        logger.warning(
+                            "mark_synced failed for row %s: %s",
+                            row_id,
+                            exc,
+                            exc_info=True,
+                        )
+                        # Re-raise so the parent retry path sees it.
+                        raise
+                else:
+                    _sync_queue.mark_failed(conn, [row_id], f"unexpected status {status}")
+        finally:
+            conn.close()
+
+    # ── http ─────────────────────────────────────────────────────────
+
+    def _post_one(self, payload: dict) -> tuple[int, dict]:
+        """POST a single payload to the ingest endpoint.
+
+        Returns ``(status, response_dict)``. Raises
+        :class:`urllib.error.HTTPError` on non-2xx (urllib's default).
+        """
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        req = urllib.request.Request(
+            self.ingest_url,
+            data=body,
+            headers={
+                "Authorization": f"Bearer {self.api_key}",
+                "Content-Type": "application/json",
+                "User-Agent": "gradata-sync-worker/1.0",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=_HTTP_TIMEOUT) as resp:  # noqa: S310
+            raw = resp.read()
+            status = int(resp.status)
+        try:
+            parsed: Any = json.loads(raw) if raw else {}
+        except json.JSONDecodeError:
+            parsed = {"_raw": raw[:500].decode("utf-8", errors="replace")}
+        if not isinstance(parsed, dict):
+            parsed = {"_value": parsed}
+        return status, parsed
+
+
+def _safe_body_preview(exc: urllib.error.HTTPError) -> str:
+    """Best-effort short string of an HTTPError body for log/error storage."""
+    try:
+        raw = exc.read() or b""
+    except Exception:
+        return ""
+    try:
+        text = raw.decode("utf-8", errors="replace")
+    except Exception:
+        return ""
+    return text[:200]

--- a/Gradata/src/gradata/brain.py
+++ b/Gradata/src/gradata/brain.py
@@ -55,6 +55,33 @@ from gradata._env import env_str
 from gradata.brain_inspection import BrainInspectionMixin
 
 
+def _resolve_sync_api_key() -> str | None:
+    """Resolve cloud API key for the write-through sync worker.
+
+    Order matches ``gradata.daemon._resolve_api_key``:
+    ``GRADATA_API_KEY`` env var, then ``~/.gradata/key`` file.
+    Returns ``None`` when neither is set — write-through is silently
+    disabled (the local correct() path still works normally).
+    """
+    import os
+
+    env_key = os.environ.get("GRADATA_API_KEY")
+    if env_key:
+        return env_key
+    try:
+        key_file = Path.home() / ".gradata" / "key"
+    except (RuntimeError, OSError):
+        return None
+    if key_file.exists():
+        try:
+            text = key_file.read_text(encoding="utf-8").strip()
+            if text:
+                return text
+        except OSError as exc:
+            logger.debug("Could not read %s: %s", key_file, exc)
+    return None
+
+
 class Brain(BrainInspectionMixin):
     """A personal AI brain backed by a directory of knowledge files."""
 
@@ -230,6 +257,51 @@ class Brain(BrainInspectionMixin):
 
         self._brain_salt = load_or_create_salt(self.dir)
 
+        # Write-through sync worker (#194). Drains sync_queue to cloud.
+        # Activated only when an API key is resolvable AND the user has
+        # not opted out via GRADATA_DISABLE_WRITE_THROUGH=1.
+        self._sync_worker = None
+        try:
+            self._maybe_start_sync_worker()
+        except Exception as exc:
+            logger.debug("sync worker start skipped: %s", exc)
+
+    def _maybe_start_sync_worker(self) -> None:
+        """Resolve API key + start :class:`SyncWorker` if configured.
+
+        Resolution order matches ``gradata.daemon._resolve_api_key``:
+        ``GRADATA_API_KEY`` env > ``~/.gradata/key`` file. Opt-out via
+        ``GRADATA_DISABLE_WRITE_THROUGH=1``. Endpoint can be overridden
+        via ``GRADATA_CLOUD_INGEST_URL``. Tick cadence via
+        ``GRADATA_SYNC_TICK_SEC`` (float seconds, default 30).
+        """
+        import os
+
+        if os.environ.get("GRADATA_DISABLE_WRITE_THROUGH") == "1":
+            return
+        api_key = _resolve_sync_api_key()
+        if not api_key:
+            return
+
+        from gradata._sync_worker import SyncWorker
+
+        ingest_url = os.environ.get(
+            "GRADATA_CLOUD_INGEST_URL", "https://api.gradata.ai/api/v1/ingest"
+        )
+        try:
+            tick_sec = float(os.environ.get("GRADATA_SYNC_TICK_SEC", "30"))
+        except (TypeError, ValueError):
+            tick_sec = 30.0
+
+        worker = SyncWorker(
+            brain_dir=self.dir,
+            api_key=api_key,
+            ingest_url=ingest_url,
+            tick_sec=tick_sec,
+        )
+        worker.start()
+        self._sync_worker = worker
+
     @property
     def session(self) -> int:
         """Current session number (from event log)."""
@@ -380,7 +452,14 @@ class Brain(BrainInspectionMixin):
         return self._memory_manager
 
     def close(self):
-        """Cleanup: re-encrypt database if encryption is enabled."""
+        """Cleanup: stop sync worker (drain), re-encrypt database if needed."""
+        worker = getattr(self, "_sync_worker", None)
+        if worker is not None:
+            try:
+                worker.stop(drain=True)
+            except Exception as exc:
+                logger.debug("sync worker stop failed: %s", exc)
+            self._sync_worker = None
         if self._encryption_key:
             from gradata._encryption import close_encrypted_db
 
@@ -462,7 +541,140 @@ class Brain(BrainInspectionMixin):
         except Exception as e:
             logger.debug("telemetry send_once failed: %s", e)
 
+        # Write-through cloud sync (#194). Enqueue the correction into
+        # sync_queue so the background worker can POST it to /api/v1/ingest.
+        # NEVER allow this to break the local correct() return value —
+        # write-through is best-effort and additive to existing paths.
+        if not dry_run:
+            try:
+                self._write_through_enqueue(
+                    draft=draft,
+                    final=final,
+                    category=category,
+                    session_arg=session,
+                    result=result,
+                )
+            except Exception as exc:
+                logger.debug("write-through enqueue failed: %s", exc)
+
         return result
+
+    def _write_through_enqueue(
+        self,
+        *,
+        draft: str,
+        final: str,
+        category: str | None,
+        session_arg: int | None,
+        result: dict | None,
+    ) -> None:
+        """Enqueue this correction into the local sync_queue.
+
+        Builds a payload matching the cloud ``IngestRequest`` shape and
+        the existing daemon ``/sync`` correction sub-shape:
+        ``{session, category, severity, description}``. The cloud
+        receiver dedupes on ``event_id`` so a deterministic id keeps
+        retries idempotent.
+
+        This is a no-op when no sync worker is active (no API key, or
+        ``GRADATA_DISABLE_WRITE_THROUGH=1``). The worker is the only
+        thing that actually flushes the queue — but enqueueing while
+        the worker is offline is still useful: a future Brain open with
+        a key will drain whatever piled up.
+        """
+        import os
+
+        if os.environ.get("GRADATA_DISABLE_WRITE_THROUGH") == "1":
+            return
+        if not getattr(self, "_sync_worker", None):
+            # No API key at construction → no worker → don't accumulate
+            # queue rows that will never drain. Hooks/cron still cover
+            # the no-key case via the events table.
+            return
+
+        import hashlib
+        import sqlite3
+        import time as _time
+
+        # brain_id: use tenant_id if available (matches the cloud schema),
+        # otherwise fall back to the brain directory name.
+        brain_id = self._resolve_brain_id_for_sync()
+
+        # Session: prefer explicit, else current.
+        try:
+            sess = session_arg if session_arg is not None else int(self.session or 0)
+        except Exception:
+            sess = 0
+
+        # Severity + description: pull from the brain_correct result when
+        # available (richer than re-deriving). Fall back to the diff.
+        severity = "minor"
+        description = ""
+        if isinstance(result, dict):
+            sev = result.get("severity")
+            if isinstance(sev, str) and sev:
+                severity = sev
+            desc = result.get("description") or result.get("rule") or result.get("lesson") or ""
+            if isinstance(desc, str):
+                description = desc
+        if not description:
+            description = (final or "")[:500] or "(empty correction)"
+
+        cat = (
+            category
+            or ((result or {}).get("category") if isinstance(result, dict) else None)
+            or "UNKNOWN"
+        )
+
+        correction: dict = {
+            "session": int(sess),
+            "category": str(cat),
+            "severity": str(severity),
+            "description": description[:500],
+        }
+        # Pass draft/final through so the cloud receiver can store full
+        # text if its schema accepts it (the local correction dict only
+        # carries description for the legacy /sync shape).
+        correction["draft"] = (draft or "")[:8000]
+        correction["final"] = (final or "")[:8000]
+
+        # Deterministic event_id: stable across retries.
+        digest = hashlib.sha1(
+            f"{draft}\x00{final}".encode("utf-8"),
+            usedforsecurity=False,
+        ).hexdigest()[:16]
+        ts_ms = int(_time.time() * 1000)
+        event_id = f"correct:{sess}:{ts_ms}:{digest}"
+
+        # Open a FRESH sqlite connection — do not reuse any brain-owned
+        # connection. The worker is on another thread and SQLite
+        # connections are not safely shareable across threads.
+        from gradata._sync_queue import enqueue_correction
+
+        conn = sqlite3.connect(str(self.db_path))
+        try:
+            enqueue_correction(conn, brain_id, correction, event_id=event_id)
+        finally:
+            conn.close()
+
+    def _resolve_brain_id_for_sync(self) -> str:
+        """Best-effort stable brain identifier for cloud /ingest payloads.
+
+        Prefers the tenant UUID (written by the migrations runner). Falls
+        back to the brain directory basename. Never raises.
+        """
+        try:
+            from gradata._migrations.tenant_uuid import get_or_create_tenant_id
+
+            tid = get_or_create_tenant_id(self.dir)
+            if tid:
+                return str(tid)
+        except Exception as exc:
+            logger.debug("tenant_id resolution failed: %s", exc)
+        try:
+            return self.dir.name
+        except Exception:
+            return "unknown-brain"
 
     def record_correction(
         self,

--- a/Gradata/src/gradata/onboard.py
+++ b/Gradata/src/gradata/onboard.py
@@ -103,6 +103,18 @@ _TABLES_SQL = [
         mention_count INTEGER DEFAULT 1
     )
     """,
+    # Write-through sync queue (cloud upload buffer, #194)
+    """
+    CREATE TABLE IF NOT EXISTS sync_queue (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        payload_json TEXT NOT NULL,
+        kind TEXT NOT NULL CHECK(kind IN ('correction','lesson','event')),
+        enqueued_at REAL NOT NULL,
+        synced_at REAL,
+        attempts INTEGER DEFAULT 0,
+        last_error TEXT
+    )
+    """,
 ]
 
 _INDEXES_SQL = [
@@ -113,6 +125,7 @@ _INDEXES_SQL = [
     "CREATE INDEX IF NOT EXISTS idx_lesson_apps_lesson ON lesson_applications(lesson_id)",
     "CREATE INDEX IF NOT EXISTS idx_lesson_transitions_cat ON lesson_transitions(category)",
     "CREATE INDEX IF NOT EXISTS idx_lesson_transitions_desc ON lesson_transitions(lesson_desc)",
+    "CREATE INDEX IF NOT EXISTS idx_sync_queue_pending ON sync_queue(synced_at) WHERE synced_at IS NULL",
 ]
 
 # ── Subdirectories ────────────────────────────────────────────────────

--- a/Gradata/tests/test_brain_write_through.py
+++ b/Gradata/tests/test_brain_write_through.py
@@ -1,0 +1,145 @@
+"""Integration tests for Brain.correct() write-through path (#194 day 3).
+
+Verify that:
+* When GRADATA_API_KEY is set, Brain.__init__ starts a SyncWorker.
+* When GRADATA_DISABLE_WRITE_THROUGH=1, no worker starts.
+* When no API key is resolvable, no worker starts (silent skip).
+* Brain.correct() enqueues a row in sync_queue regardless of cloud reachability.
+* Brain.close() drains the queue cleanly.
+
+These tests don't hit the network — they assert on sync_queue rows directly.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from gradata import Brain
+
+
+def _count_pending(brain_dir: Path) -> int:
+    conn = sqlite3.connect(brain_dir / "system.db")
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM sync_queue WHERE synced_at IS NULL").fetchone()[0]
+    finally:
+        conn.close()
+    return n
+
+
+def _all_rows(brain_dir: Path) -> list[dict]:
+    conn = sqlite3.connect(brain_dir / "system.db")
+    conn.row_factory = sqlite3.Row
+    try:
+        return [dict(r) for r in conn.execute("SELECT * FROM sync_queue").fetchall()]
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def brain_dir(tmp_path, monkeypatch):
+    d = tmp_path / "brain"
+    # Brain.init() creates the directory and schema; don't pre-create.
+    monkeypatch.setenv("BRAIN_DIR", str(d))
+    # Default: no API key, no worker. Tests opt in.
+    monkeypatch.delenv("GRADATA_API_KEY", raising=False)
+    monkeypatch.delenv("GRADATA_DISABLE_WRITE_THROUGH", raising=False)
+    monkeypatch.setenv("GRADATA_SYNC_TICK_SEC", "300")  # don't tick during tests
+    # Point the worker at a definitely-unreachable URL so accidental network
+    # calls hard-fail fast instead of hanging.
+    monkeypatch.setenv("GRADATA_CLOUD_INGEST_URL", "http://127.0.0.1:1/api/v1/ingest")
+    return d
+
+
+def _open_brain(brain_dir):
+    """Use Brain.init() so the schema is created (including sync_queue)."""
+    return Brain.init(brain_dir)
+
+
+def test_brain_correct_enqueues_when_api_key_present(brain_dir, monkeypatch):
+    monkeypatch.setenv("GRADATA_API_KEY", "gd_live_test")
+    brain = _open_brain(brain_dir)
+    try:
+        assert brain._sync_worker is not None, "worker should start when API key set"
+        before = _count_pending(brain_dir)
+        brain.correct(draft="hello world", final="hi")
+        after = _count_pending(brain_dir)
+        assert after == before + 1, (
+            f"Brain.correct() should enqueue exactly one row (before={before} after={after})"
+        )
+        rows = _all_rows(brain_dir)
+        assert rows[-1]["kind"] == "correction"
+    finally:
+        brain.close()
+
+
+def test_brain_correct_no_worker_when_disabled(brain_dir, monkeypatch):
+    monkeypatch.setenv("GRADATA_API_KEY", "gd_live_test")
+    monkeypatch.setenv("GRADATA_DISABLE_WRITE_THROUGH", "1")
+    brain = _open_brain(brain_dir)
+    try:
+        assert brain._sync_worker is None, (
+            "worker must NOT start when GRADATA_DISABLE_WRITE_THROUGH=1"
+        )
+        before = _count_pending(brain_dir)
+        brain.correct(draft="hello", final="hi")
+        after = _count_pending(brain_dir)
+        assert after == before, "Brain.correct() must not enqueue when write-through is disabled"
+    finally:
+        brain.close()
+
+
+def test_brain_correct_no_worker_when_no_api_key(brain_dir, monkeypatch):
+    # brain_dir fixture already deletes GRADATA_API_KEY. Make sure ~/.gradata/key
+    # is also unreadable.
+    monkeypatch.setenv("HOME", str(brain_dir.parent))  # no ~/.gradata/key under here
+    brain = _open_brain(brain_dir)
+    try:
+        assert brain._sync_worker is None, "worker must NOT start without an API key"
+        before = _count_pending(brain_dir)
+        brain.correct(draft="hello", final="hi")
+        after = _count_pending(brain_dir)
+        assert after == before, "Brain.correct() must not enqueue when no API key is resolvable"
+    finally:
+        brain.close()
+
+
+def test_brain_correct_enqueues_even_when_cloud_unreachable(brain_dir, monkeypatch):
+    # GRADATA_CLOUD_INGEST_URL is already pointed at port 1 (unreachable).
+    # The point is that correct() must NOT block on cloud reachability —
+    # the row should land in sync_queue regardless.
+    monkeypatch.setenv("GRADATA_API_KEY", "gd_live_test")
+    brain = _open_brain(brain_dir)
+    try:
+        before = _count_pending(brain_dir)
+        # If the enqueue path were doing inline network calls this would hang
+        # for seconds. Asserting it returns quickly + the row is queued is
+        # the actual contract.
+        brain.correct(draft="hello", final="hi")
+        after = _count_pending(brain_dir)
+        assert after == before + 1
+    finally:
+        brain.close()
+
+
+def test_brain_correct_local_path_unaffected_by_worker_failure(brain_dir, monkeypatch):
+    """If _write_through_enqueue raises, correct() must still succeed locally.
+
+    The local correct() path is the user's source of truth — write-through
+    can never break it.
+    """
+    monkeypatch.setenv("GRADATA_API_KEY", "gd_live_test")
+    brain = _open_brain(brain_dir)
+    try:
+        # Sabotage the enqueue helper to raise.
+        def boom(*a, **kw):
+            raise RuntimeError("simulated sync_queue failure")
+
+        monkeypatch.setattr(brain, "_write_through_enqueue", boom)
+        # correct() must still return successfully (no exception propagated).
+        brain.correct(draft="hello", final="hi")
+    finally:
+        brain.close()

--- a/Gradata/tests/test_daemon_sync.py
+++ b/Gradata/tests/test_daemon_sync.py
@@ -169,7 +169,13 @@ def test_sync_pushes_events_and_advances_watermark(daemon_with_events) -> None:
 
 
 def test_sync_with_no_events_returns_zero(brain_dir: Path) -> None:
-    """POST /sync with empty brain returns pushed=0 and does NOT call cloud."""
+    """POST /sync with empty brain returns pushed=0 and sends a heartbeat.
+
+    PR #198 changed the empty-payload behavior: the daemon now POSTs an
+    empty heartbeat to the cloud so brains.last_sync_at advances even
+    when there's nothing new to push. Cloud failures during the
+    heartbeat are non-fatal (logged at info, not surfaced to caller).
+    """
     from gradata._events import _ensure_table
 
     db_path = brain_dir / "system.db"
@@ -193,13 +199,17 @@ def test_sync_with_no_events_returns_zero(brain_dir: Path) -> None:
 
     try:
         with patch("gradata.daemon._cloud_post") as mock_post:
+            mock_post.return_value = b'{"events_synced":0,"corrections_synced":0}'
             status, body = _post(base, "/sync")
         assert status == 200
         assert body["status"] == "ok"
         assert body["pushed"] == 0
         assert "last_sync_at" in body
-        # No cloud call when nothing to push
-        mock_post.assert_not_called()
+        # PR #198 heartbeat: empty payload still POSTs to cloud so
+        # brains.last_sync_at advances. Exactly one call expected.
+        assert mock_post.call_count == 1, (
+            f"empty-sync should POST one heartbeat, got {mock_post.call_count}"
+        )
     finally:
         d._server.shutdown()
 

--- a/Gradata/tests/test_sync_queue.py
+++ b/Gradata/tests/test_sync_queue.py
@@ -1,0 +1,154 @@
+"""Unit tests for sync_queue primitives (#194, day 1) + the new
+:func:`gradata._sync_queue.enqueue_correction` convenience (day 3).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+
+import pytest
+
+from gradata import _sync_queue
+from gradata._migrations import _BASE_TABLES, _MIGRATIONS
+
+
+def _make_conn() -> sqlite3.Connection:
+    """In-memory SQLite connection with the sync_queue schema applied."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    for sql in _BASE_TABLES:
+        if "sync_queue" in sql:
+            conn.execute(sql)
+    for sql in _MIGRATIONS:
+        if "sync_queue" in sql:
+            conn.execute(sql)
+    conn.commit()
+    return conn
+
+
+def test_sync_queue_enqueue_returns_int_and_peek_finds_row():
+    conn = _make_conn()
+    payload = {"draft": "hello", "final": "Hello.", "meta": {"n": 1}}
+
+    row_id = _sync_queue.enqueue(conn, "correction", payload)
+
+    assert isinstance(row_id, int)
+    assert row_id > 0
+
+    pending = _sync_queue.peek_pending(conn)
+    assert len(pending) == 1
+    row = pending[0]
+    assert row["id"] == row_id
+    assert row["kind"] == "correction"
+    assert row["payload"] == payload
+    assert row["attempts"] == 0
+    assert isinstance(row["enqueued_at"], float)
+
+
+def test_sync_queue_peek_pending_respects_limit_and_fifo_order():
+    conn = _make_conn()
+    ids = [_sync_queue.enqueue(conn, "event", {"i": i}) for i in range(5)]
+
+    pending = _sync_queue.peek_pending(conn, limit=3)
+    assert [r["id"] for r in pending] == ids[:3]
+
+
+def test_sync_queue_mark_synced_removes_from_peek_pending():
+    conn = _make_conn()
+    id_a = _sync_queue.enqueue(conn, "correction", {"x": 1})
+    id_b = _sync_queue.enqueue(conn, "lesson", {"x": 2})
+
+    _sync_queue.mark_synced(conn, [id_a])
+
+    pending_ids = [r["id"] for r in _sync_queue.peek_pending(conn)]
+    assert id_a not in pending_ids
+    assert id_b in pending_ids
+
+    row = conn.execute("SELECT synced_at FROM sync_queue WHERE id = ?", (id_a,)).fetchone()
+    assert row["synced_at"] is not None
+    assert float(row["synced_at"]) <= time.time() + 1.0
+
+
+def test_sync_queue_mark_failed_increments_attempts_and_keeps_row_pending():
+    conn = _make_conn()
+    row_id = _sync_queue.enqueue(conn, "event", {"k": "v"})
+
+    _sync_queue.mark_failed(conn, [row_id], "boom: network unreachable")
+    _sync_queue.mark_failed(conn, [row_id], "boom again")
+
+    pending = _sync_queue.peek_pending(conn)
+    assert len(pending) == 1
+    assert pending[0]["id"] == row_id
+    assert pending[0]["attempts"] == 2
+
+    row = conn.execute(
+        "SELECT last_error, synced_at FROM sync_queue WHERE id = ?", (row_id,)
+    ).fetchone()
+    assert row["last_error"] == "boom again"
+    assert row["synced_at"] is None
+
+
+def test_sync_queue_mark_failed_truncates_long_error_to_500_chars():
+    conn = _make_conn()
+    row_id = _sync_queue.enqueue(conn, "event", {})
+    long_err = "x" * 5000
+
+    _sync_queue.mark_failed(conn, [row_id], long_err)
+
+    row = conn.execute("SELECT last_error FROM sync_queue WHERE id = ?", (row_id,)).fetchone()
+    assert len(row["last_error"]) == 500
+    assert row["last_error"] == "x" * 500
+
+
+def test_sync_queue_kind_constraint_rejects_invalid_value():
+    conn = _make_conn()
+    with pytest.raises(sqlite3.IntegrityError):
+        _sync_queue.enqueue(conn, "foo", {"bad": True})
+
+
+def test_sync_queue_empty_id_lists_are_noops():
+    conn = _make_conn()
+    _sync_queue.mark_synced(conn, [])
+    _sync_queue.mark_failed(conn, [], "nope")
+
+    pending = _sync_queue.peek_pending(conn)
+    assert pending == []
+
+
+# ── enqueue_correction convenience (day 3) ────────────────────────────
+
+
+def test_enqueue_correction_uses_ingest_request_shape():
+    conn = _make_conn()
+    correction = {
+        "session": 7,
+        "category": "TONE",
+        "severity": "minor",
+        "description": "use commas not em dashes",
+    }
+
+    row_id = _sync_queue.enqueue_correction(
+        conn,
+        brain_id="brain-abc",
+        correction=correction,
+        event_id="correct:7:1700000000000:deadbeef",
+    )
+
+    assert isinstance(row_id, int)
+    pending = _sync_queue.peek_pending(conn)
+    assert len(pending) == 1
+    row = pending[0]
+    assert row["kind"] == "correction"
+    assert row["payload"] == {
+        "brain_id": "brain-abc",
+        "correction": correction,
+        "event_id": "correct:7:1700000000000:deadbeef",
+    }
+
+
+def test_enqueue_correction_defaults_event_id_to_none():
+    conn = _make_conn()
+    _sync_queue.enqueue_correction(conn, brain_id="b", correction={"x": 1})
+    row = _sync_queue.peek_pending(conn)[0]
+    assert row["payload"]["event_id"] is None

--- a/Gradata/tests/test_sync_worker.py
+++ b/Gradata/tests/test_sync_worker.py
@@ -1,0 +1,389 @@
+"""Tests for :class:`gradata._sync_worker.SyncWorker` (#194 day 3).
+
+The worker drains rows from the local ``sync_queue`` table by POSTing
+each payload to the cloud ``/api/v1/ingest`` endpoint. These tests
+spin up a tiny stub HTTP server (same pattern as ``test_daemon_sync``)
+to assert on the exact requests and exercise the failure modes:
+
+* 200 → mark_synced (queue empties)
+* 200 + ``deduplicated=true`` body → still mark_synced
+* 500 → mark_failed, row stays pending for next tick
+* 429 → mark_failed and bail (don't process the rest of the batch)
+* permanent 4xx (e.g. 422) → mark_synced (poison row, no infinite retry)
+* network error → mark_failed, retry next tick
+* stop(drain=True) flushes pending in one final synchronous tick
+* at-least-once: mark_synced failure → row remains pending → next tick retries
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from gradata import _sync_queue
+from gradata._migrations import _BASE_TABLES, _MIGRATIONS
+from gradata._sync_worker import SyncWorker
+
+
+# ── shared helpers ────────────────────────────────────────────────────
+
+
+def _seed_db(db_path) -> None:
+    """Create a system.db with only the sync_queue schema applied."""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        for sql in _BASE_TABLES:
+            if "sync_queue" in sql:
+                conn.execute(sql)
+        for sql in _MIGRATIONS:
+            if "sync_queue" in sql:
+                conn.execute(sql)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _open(db_path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+# ── stub /ingest HTTP server ──────────────────────────────────────────
+
+
+class _StubIngestServer:
+    """Tiny in-process HTTP server that records POSTs to /api/v1/ingest."""
+
+    def __init__(self, response_fn) -> None:
+        self.response_fn = response_fn
+        self.requests: list[dict[str, Any]] = []
+        self._server: HTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> str:
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *_args, **_kwargs) -> None:  # silence
+                return
+
+            def do_POST(self) -> None:  # noqa: N802 — stdlib API
+                length = int(self.headers.get("Content-Length", "0"))
+                body = self.rfile.read(length) if length else b""
+                try:
+                    payload = json.loads(body) if body else {}
+                except json.JSONDecodeError:
+                    payload = {"_raw": body.decode("utf-8", errors="replace")}
+                outer.requests.append(
+                    {
+                        "path": self.path,
+                        "auth": self.headers.get("Authorization", ""),
+                        "payload": payload,
+                    }
+                )
+                status, resp = outer.response_fn(payload, len(outer.requests))
+                resp_body = json.dumps(resp).encode("utf-8")
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(resp_body)))
+                self.end_headers()
+                self.wfile.write(resp_body)
+
+        self._server = HTTPServer(("127.0.0.1", 0), Handler)
+        port = self._server.server_address[1]
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return f"http://127.0.0.1:{port}/api/v1/ingest"
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+
+
+@pytest.fixture
+def stub_ingest():
+    """Yield a factory that starts a stub /ingest server with a custom responder."""
+    started: list[_StubIngestServer] = []
+
+    def _factory(response_fn):
+        s = _StubIngestServer(response_fn)
+        url = s.start()
+        started.append(s)
+        return s, url
+
+    yield _factory
+
+    for s in started:
+        s.stop()
+
+
+# ── happy path ────────────────────────────────────────────────────────
+
+
+def test_worker_drains_queue_on_200(tmp_path, stub_ingest):
+    db_path = tmp_path / "system.db"
+    _seed_db(db_path)
+    conn = _open(db_path)
+    try:
+        for i in range(3):
+            _sync_queue.enqueue_correction(
+                conn,
+                brain_id="brain-x",
+                correction={"session": 1, "description": f"row {i}"},
+                event_id=f"e-{i}",
+            )
+    finally:
+        conn.close()
+
+    server, url = stub_ingest(lambda _p, _n: (200, {"ok": True}))
+
+    worker = SyncWorker(tmp_path, api_key="test-key", ingest_url=url, tick_sec=999)
+    worker._tick()
+
+    conn = _open(db_path)
+    try:
+        pending = _sync_queue.peek_pending(conn)
+    finally:
+        conn.close()
+    assert pending == []
+
+    assert len(server.requests) == 3
+    # All requests carry the bearer token and the IngestRequest shape.
+    for req in server.requests:
+        assert req["path"].endswith("/api/v1/ingest")
+        assert req["auth"] == "Bearer test-key"
+        assert req["payload"]["brain_id"] == "brain-x"
+        assert "correction" in req["payload"]
+        assert req["payload"]["event_id"] in {"e-0", "e-1", "e-2"}
+
+
+def test_worker_marks_synced_on_deduplicated_response(tmp_path, stub_ingest):
+    db_path = tmp_path / "system.db"
+    _seed_db(db_path)
+    conn = _open(db_path)
+    try:
+        _sync_queue.enqueue_correction(conn, brain_id="b", correction={"x": 1}, event_id="dup")
+    finally:
+        conn.close()
+
+    _server, url = stub_ingest(lambda _p, _n: (200, {"status": "ok", "deduplicated": True}))
+
+    worker = SyncWorker(tmp_path, api_key="k", ingest_url=url, tick_sec=999)
+    worker._tick()
+
+    conn = _open(db_path)
+    try:
+        assert _sync_queue.peek_pending(conn) == []
+    finally:
+        conn.close()
+
+
+# ── failure modes ────────────────────────────────────────────────────
+
+
+def test_worker_marks_failed_on_500_and_row_stays_pending(tmp_path, stub_ingest):
+    db_path = tmp_path / "system.db"
+    _seed_db(db_path)
+    conn = _open(db_path)
+    try:
+        _sync_queue.enqueue_correction(conn, brain_id="b", correction={"x": 1}, event_id="e1")
+    finally:
+        conn.close()
+
+    _server, url = stub_ingest(lambda _p, _n: (500, {"error": "db down"}))
+
+    worker = SyncWorker(tmp_path, api_key="k", ingest_url=url, tick_sec=999)
+    worker._tick()
+
+    conn = _open(db_path)
+    try:
+        pending = _sync_queue.peek_pending(conn)
+    finally:
+        conn.close()
+    assert len(pending) == 1
+    assert pending[0]["attempts"] == 1
+    # A second tick retries (still pending after failure).
+    worker._tick()
+    conn = _open(db_path)
+    try:
+        pending = _sync_queue.peek_pending(conn)
+    finally:
+        conn.close()
+    assert len(pending) == 1
+    assert pending[0]["attempts"] == 2
+
+
+def test_worker_429_stops_tick_and_marks_failed(tmp_path, stub_ingest):
+    db_path = tmp_path / "system.db"
+    _seed_db(db_path)
+    conn = _open(db_path)
+    try:
+        for i in range(3):
+            _sync_queue.enqueue_correction(
+                conn, brain_id="b", correction={"i": i}, event_id=f"e{i}"
+            )
+    finally:
+        conn.close()
+
+    _server, url = stub_ingest(lambda _p, _n: (429, {"error": "rate limited"}))
+
+    worker = SyncWorker(tmp_path, api_key="k", ingest_url=url, tick_sec=999)
+    worker._tick()
+
+    conn = _open(db_path)
+    try:
+        pending = _sync_queue.peek_pending(conn)
+    finally:
+        conn.close()
+    # All three still pending — 429 bails on the first row.
+    assert len(pending) == 3
+    # First row recorded the 429 failure, the rest are untouched.
+    attempts = sorted(r["attempts"] for r in pending)
+    assert attempts == [0, 0, 1]
+
+
+def test_worker_422_is_permanent_and_marks_synced(tmp_path, stub_ingest):
+    """422 means the payload is rejected — don't retry forever."""
+    db_path = tmp_path / "system.db"
+    _seed_db(db_path)
+    conn = _open(db_path)
+    try:
+        _sync_queue.enqueue_correction(conn, brain_id="b", correction={"bad": True}, event_id="e1")
+    finally:
+        conn.close()
+
+    _server, url = stub_ingest(lambda _p, _n: (422, {"error": "validation"}))
+
+    worker = SyncWorker(tmp_path, api_key="k", ingest_url=url, tick_sec=999)
+    worker._tick()
+
+    conn = _open(db_path)
+    try:
+        pending = _sync_queue.peek_pending(conn)
+        row = conn.execute("SELECT synced_at, last_error FROM sync_queue").fetchone()
+    finally:
+        conn.close()
+    assert pending == []  # not pending — won't retry
+    assert row["synced_at"] is not None
+    assert "permanent" in (row["last_error"] or "")
+
+
+def test_worker_network_error_marks_failed(tmp_path):
+    """Unreachable URL → mark_failed (transient, retry next tick)."""
+    db_path = tmp_path / "system.db"
+    _seed_db(db_path)
+    conn = _open(db_path)
+    try:
+        _sync_queue.enqueue_correction(conn, brain_id="b", correction={"x": 1}, event_id="e1")
+    finally:
+        conn.close()
+
+    # Port 1 is reserved → connection refused.
+    bogus = "http://127.0.0.1:1/api/v1/ingest"
+    worker = SyncWorker(tmp_path, api_key="k", ingest_url=bogus, tick_sec=999)
+    worker._tick()
+
+    conn = _open(db_path)
+    try:
+        pending = _sync_queue.peek_pending(conn)
+    finally:
+        conn.close()
+    assert len(pending) == 1
+    assert pending[0]["attempts"] == 1
+
+
+# ── lifecycle ────────────────────────────────────────────────────────
+
+
+def test_stop_with_drain_flushes_pending(tmp_path, stub_ingest):
+    db_path = tmp_path / "system.db"
+    _seed_db(db_path)
+    conn = _open(db_path)
+    try:
+        _sync_queue.enqueue_correction(conn, brain_id="b", correction={"x": 1}, event_id="e1")
+    finally:
+        conn.close()
+
+    _server, url = stub_ingest(lambda _p, _n: (200, {"ok": True}))
+
+    # Long tick — the worker would not naturally drain in time.
+    worker = SyncWorker(tmp_path, api_key="k", ingest_url=url, tick_sec=999)
+    worker.start()
+    try:
+        worker.stop(drain=True)
+    finally:
+        # idempotent — calling again must not throw
+        worker.stop(drain=False)
+
+    conn = _open(db_path)
+    try:
+        pending = _sync_queue.peek_pending(conn)
+    finally:
+        conn.close()
+    assert pending == []
+
+
+def test_worker_noop_when_db_missing(tmp_path):
+    """If system.db doesn't exist (no Brain there), _tick is a no-op."""
+    worker = SyncWorker(tmp_path / "nope", api_key="k", ingest_url="http://x")
+    # Should not raise.
+    worker._tick()
+
+
+# ── at-least-once ────────────────────────────────────────────────────
+
+
+def test_at_least_once_when_mark_synced_fails(tmp_path, stub_ingest):
+    """If /ingest returns 200 but mark_synced raises, the row stays pending."""
+    db_path = tmp_path / "system.db"
+    _seed_db(db_path)
+    conn = _open(db_path)
+    try:
+        _sync_queue.enqueue_correction(conn, brain_id="b", correction={"x": 1}, event_id="e1")
+    finally:
+        conn.close()
+
+    _server, url = stub_ingest(lambda _p, _n: (200, {"ok": True}))
+
+    worker = SyncWorker(tmp_path, api_key="k", ingest_url=url, tick_sec=999)
+
+    real_mark_synced = _sync_queue.mark_synced
+    call_count = {"n": 0}
+
+    def flaky_mark_synced(conn, ids):  # type: ignore[no-untyped-def]
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise sqlite3.OperationalError("simulated db lock")
+        return real_mark_synced(conn, ids)
+
+    with patch("gradata._sync_worker._sync_queue.mark_synced", side_effect=flaky_mark_synced):
+        with pytest.raises(sqlite3.OperationalError):
+            worker._tick()
+
+        # Still pending — at-least-once guarantee preserved.
+        conn = _open(db_path)
+        try:
+            pending = _sync_queue.peek_pending(conn)
+        finally:
+            conn.close()
+        assert len(pending) == 1
+
+        # Next tick: cloud returns 200 again, mark_synced succeeds → drained.
+        worker._tick()
+
+    conn = _open(db_path)
+    try:
+        pending = _sync_queue.peek_pending(conn)
+    finally:
+        conn.close()
+    assert pending == []


### PR DESCRIPTION
Day 3 of #194 — wire Brain.correct() to write-through cloud sync.

## What
Every Brain.correct(draft, final) now enqueues into local sync_queue + a background daemon thread POSTs each row to api.gradata.ai/api/v1/ingest.

## Why
Removes the dependency on session-end hooks (which barely fire for long-running agents on hermes --continue) and the cron sync band-aid. See /home/olive/gradata-office-hours-memo.md for the full architectural rationale.

## Env vars
- GRADATA_API_KEY required to start worker
- GRADATA_DISABLE_WRITE_THROUGH=1: opt-out
- GRADATA_CLOUD_INGEST_URL (default https://api.gradata.ai/api/v1/ingest)
- GRADATA_SYNC_TICK_SEC (default 30)

## Failure modes
- Cloud unreachable: row stays pending, retried next tick
- 422 permanent: poison row marked synced+failed
- 429: backoff, bail batch
- No API key: worker doesn't start, local correct() unaffected
- enqueue exception: caught, local correct() always succeeds

## Tests
38 passed (test_sync_queue × 9, test_sync_worker × 9, test_brain_write_through × 5, test_brain × 15 regression).

## Series
- #195 (day 1, draft): SDK sync_queue primitives  
- Gradata/gradata-cloud#58 (day 2, merged): cloud /ingest receiver
- This PR (day 3): SDK wire-up