### PR TITLE
feat(install): add --systemd flag to gradata install for auto-start daemon

### DIFF
--- a/Gradata/pyproject.toml
+++ b/Gradata/pyproject.toml
@@ -71,6 +71,7 @@ exclude = ["**/__pycache__", "**/*.pyc", "**/*.db", "**/*( 1)*", "**/* (1)*"]
 artifacts = [
     "src/gradata/hooks/assets/**/*.js",
     "src/gradata/assets/**/*",
+    "src/gradata/templates/*",
 ]
 
 [tool.hatch.build.targets.wheel.force-include]
@@ -81,6 +82,7 @@ exclude = ["**/__pycache__", "**/*.pyc", "**/*.db", "**/*( 1)*", "**/* (1)*"]
 artifacts = [
     "src/gradata/hooks/assets/**/*.js",
     "src/gradata/assets/**/*",
+    "src/gradata/templates/*",
 ]
 
 [tool.hatch.build.targets.sdist.force-include]
@@ -96,6 +98,7 @@ gradata = [
     "assets/demo_brains/sdr/*.jsonl",
     "assets/demo_brains/sdr/*.json",
     "assets/demo_brains/sdr/*.db",
+    "templates/*.service",
 ]
 
 # --- Ruff (linter + formatter) ---

--- a/Gradata/src/gradata/_systemd_installer.py
+++ b/Gradata/src/gradata/_systemd_installer.py
@@ -1,0 +1,137 @@
+"""
+Gradata systemd user-unit installer.
+
+Writes a `gradata-daemon.service` user unit under
+``~/.config/systemd/user/`` so the HTTP daemon survives shell-session exit
+and is automatically restarted on failure.
+
+This module only WRITES the unit file and prints the post-install
+``systemctl --user`` commands the user should run. It deliberately does
+NOT shell out to ``systemctl`` itself — that keeps the function safe to
+unit-test in CI (which has no user systemd instance), and keeps the
+SDK's install path side-effect minimal.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+DEFAULT_UNIT_NAME = "gradata-daemon.service"
+DEFAULT_PORT = 8765
+
+# Template lives next to this module so it ships in the wheel.
+_TEMPLATE_PATH = Path(__file__).parent / "templates" / "gradata-daemon.service"
+
+
+def _read_token(brain_dir: Path) -> str:
+    """Resolve the cloud API token.
+
+    Precedence:
+      1. ``GRADATA_API_KEY`` env var
+      2. ``<brain_dir>/cloud-config.json`` ``token`` field
+    """
+    env_token = os.environ.get("GRADATA_API_KEY", "").strip()
+    if env_token:
+        return env_token
+
+    cfg = brain_dir / "cloud-config.json"
+    if cfg.exists():
+        try:
+            data = json.loads(cfg.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            data = {}
+        token = str(data.get("token", "")).strip()
+        if token:
+            return token
+
+    return ""
+
+
+def render_unit(
+    *,
+    brain_dir: Path,
+    token: str,
+    port: int = DEFAULT_PORT,
+    python: str | None = None,
+) -> str:
+    """Render the systemd user unit file as a string.
+
+    Pure function — does no filesystem writes — so it is trivial to test.
+    """
+    template = _TEMPLATE_PATH.read_text(encoding="utf-8")
+    return template.format(
+        python=python or sys.executable or "python3",
+        brain_dir=str(brain_dir),
+        port=port,
+        token=token,
+    )
+
+
+def unit_path(unit_name: str = DEFAULT_UNIT_NAME) -> Path:
+    """Return the canonical path the unit file is installed at.
+
+    Honors ``XDG_CONFIG_HOME`` so tests can sandbox via ``$HOME`` / XDG.
+    """
+    xdg = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / "systemd" / "user" / unit_name
+
+
+def install_systemd_unit(
+    *,
+    brain_dir: Path,
+    port: int = DEFAULT_PORT,
+    token: str | None = None,
+    unit_name: str = DEFAULT_UNIT_NAME,
+    python: str | None = None,
+) -> Path:
+    """Write ``gradata-daemon.service`` into the user's systemd config dir.
+
+    Returns the absolute path the unit was written to.
+
+    Note: this does NOT run ``systemctl daemon-reload`` / ``enable --now``
+    itself. The caller (CLI) prints those commands for the user to run.
+    """
+    brain_dir = Path(brain_dir).expanduser().resolve()
+    resolved_token = token if token is not None else _read_token(brain_dir)
+
+    if not resolved_token:
+        raise RuntimeError(
+            "No API token found. Set GRADATA_API_KEY or write "
+            f"{brain_dir / 'cloud-config.json'} with a 'token' field "
+            "before running `gradata install --systemd`."
+        )
+
+    rendered = render_unit(
+        brain_dir=brain_dir,
+        token=resolved_token,
+        port=port,
+        python=python,
+    )
+
+    target = unit_path(unit_name)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(rendered, encoding="utf-8")
+    try:
+        target.chmod(0o600)
+    except OSError:
+        # chmod can fail on tmpfs/WSL-mounted Windows paths — non-fatal,
+        # the file is still in the user's own config dir.
+        pass
+    return target
+
+
+def post_install_message(unit_path_: Path) -> str:
+    """Return the message printed after a successful install."""
+    return (
+        f"✓ Wrote systemd user unit: {unit_path_}\n"
+        "  To activate, run:\n"
+        "    systemctl --user daemon-reload\n"
+        "    systemctl --user enable --now gradata-daemon\n"
+        "  To check status:\n"
+        "    systemctl --user status gradata-daemon\n"
+        "    journalctl --user -u gradata-daemon -f"
+    )

--- a/Gradata/src/gradata/cli.py
+++ b/Gradata/src/gradata/cli.py
@@ -254,6 +254,10 @@ def cmd_doctor(args):
 
 
 def cmd_install(args):
+    if getattr(args, "systemd", False):
+        _cmd_install_systemd(args)
+        return
+
     if getattr(args, "agent", None):
         _cmd_install_agent(args)
         return
@@ -278,6 +282,24 @@ def cmd_install(args):
     report = install(Path(args.archive), target, dry_run=args.dry_run)
     if report["status"] == "failed":
         sys.exit(1)
+
+
+def _cmd_install_systemd(args) -> None:
+    """Write the gradata-daemon systemd user unit (see `--systemd` flag)."""
+    from gradata._systemd_installer import (
+        DEFAULT_PORT,
+        install_systemd_unit,
+        post_install_message,
+    )
+
+    brain_dir = _resolve_brain_root(args)
+    port = int(getattr(args, "port", None) or DEFAULT_PORT)
+    try:
+        target = install_systemd_unit(brain_dir=brain_dir, port=port)
+    except RuntimeError as exc:
+        print(f"✗ systemd install failed: {exc}")
+        sys.exit(1)
+    print(post_install_message(target))
 
 
 def _cmd_install_agent(args) -> None:
@@ -1492,6 +1514,21 @@ def main():
         type=str,
         default=None,
         help="Brain directory for agent hook config (default: BRAIN_DIR or ./brain)",
+    )
+    p_install.add_argument(
+        "--systemd",
+        action="store_true",
+        help=(
+            "Install a systemd --user unit (~/.config/systemd/user/"
+            "gradata-daemon.service) so the daemon survives shell exit "
+            "and restarts on failure."
+        ),
+    )
+    p_install.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help="Port for the daemon when used with --systemd (default: 8765)",
     )
 
     # health

--- a/Gradata/src/gradata/templates/gradata-daemon.service
+++ b/Gradata/src/gradata/templates/gradata-daemon.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Gradata daemon (HTTP transport for AI memory brain)
+After=network.target
+
+[Service]
+Type=simple
+ExecStart={python} -m gradata.daemon --brain-dir {brain_dir} --port {port}
+Environment=GRADATA_API_KEY={token}
+Environment=GRADATA_DAEMON_IDLE_TIMEOUT=0
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target

--- a/Gradata/tests/test_systemd_installer.py
+++ b/Gradata/tests/test_systemd_installer.py
@@ -1,0 +1,173 @@
+"""Tests for `gradata install --systemd` user-unit installation."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from gradata._systemd_installer import (
+    DEFAULT_PORT,
+    install_systemd_unit,
+    render_unit,
+    unit_path,
+)
+
+
+def test_render_unit_contains_all_required_fields(tmp_path: Path) -> None:
+    brain = tmp_path / "brain"
+    brain.mkdir()
+
+    rendered = render_unit(
+        brain_dir=brain,
+        token="tok-abc123",
+        port=8765,
+        python="/usr/bin/python3",
+    )
+
+    # ExecStart with module + brain-dir + port
+    assert (
+        f"ExecStart=/usr/bin/python3 -m gradata.daemon --brain-dir {brain} --port 8765"
+        in rendered
+    )
+    # Environment lines
+    assert "Environment=GRADATA_API_KEY=tok-abc123" in rendered
+    assert "Environment=GRADATA_DAEMON_IDLE_TIMEOUT=0" in rendered
+    # Service hardening / restart
+    assert "Restart=on-failure" in rendered
+    assert "RestartSec=10" in rendered
+    # Install target
+    assert "WantedBy=default.target" in rendered
+
+
+def test_install_systemd_unit_writes_file_with_token_from_cloud_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Sandbox HOME / XDG so no global state is touched.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    monkeypatch.delenv("GRADATA_API_KEY", raising=False)
+
+    brain = tmp_path / "brain"
+    brain.mkdir()
+    (brain / "cloud-config.json").write_text(
+        json.dumps({"token": "from-cloud-config"}), encoding="utf-8"
+    )
+
+    written = install_systemd_unit(brain_dir=brain, port=8765)
+
+    # File exists at the right location
+    expected = tmp_path / ".config" / "systemd" / "user" / "gradata-daemon.service"
+    assert written == expected
+    assert written.exists()
+
+    contents = written.read_text(encoding="utf-8")
+    # Token came from cloud-config.json
+    assert "Environment=GRADATA_API_KEY=from-cloud-config" in contents
+    # And the brain-dir + port made it into ExecStart
+    assert "-m gradata.daemon --brain-dir" in contents
+    assert str(brain.resolve()) in contents
+    assert "--port 8765" in contents
+    # Idle timeout disabled so the daemon doesn't self-shutdown
+    assert "Environment=GRADATA_DAEMON_IDLE_TIMEOUT=0" in contents
+    # Restart policy
+    assert "Restart=on-failure" in contents
+    assert "RestartSec=10" in contents
+    # Install section
+    assert "WantedBy=default.target" in contents
+
+
+def test_install_systemd_unit_prefers_env_token_over_cloud_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    monkeypatch.setenv("GRADATA_API_KEY", "from-env-var")
+
+    brain = tmp_path / "brain"
+    brain.mkdir()
+    (brain / "cloud-config.json").write_text(
+        json.dumps({"token": "from-cloud-config"}), encoding="utf-8"
+    )
+
+    written = install_systemd_unit(brain_dir=brain)
+    contents = written.read_text(encoding="utf-8")
+    assert "Environment=GRADATA_API_KEY=from-env-var" in contents
+    assert "from-cloud-config" not in contents
+
+
+def test_install_systemd_unit_raises_when_no_token_available(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    monkeypatch.delenv("GRADATA_API_KEY", raising=False)
+
+    brain = tmp_path / "brain"
+    brain.mkdir()
+    # No cloud-config.json, no env var → should fail loudly.
+
+    with pytest.raises(RuntimeError, match="No API token"):
+        install_systemd_unit(brain_dir=brain)
+
+
+def test_unit_path_honors_xdg_config_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "custom-xdg"))
+    p = unit_path()
+    assert p == tmp_path / "custom-xdg" / "systemd" / "user" / "gradata-daemon.service"
+
+
+def test_default_port_constant() -> None:
+    assert DEFAULT_PORT == 8765
+
+
+def _run_cli(
+    tmp_path: Path, *args: str, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    base_env = os.environ.copy()
+    for key in list(base_env):
+        if key.startswith("GRADATA_"):
+            base_env.pop(key, None)
+    base_env["HOME"] = str(tmp_path)
+    base_env["USERPROFILE"] = str(tmp_path)
+    base_env["XDG_CONFIG_HOME"] = str(tmp_path / ".config")
+    base_env["PYTHONPATH"] = str(Path.cwd() / "src")
+    if env:
+        base_env.update(env)
+    return subprocess.run(
+        [sys.executable, "-m", "gradata.cli", *args],
+        cwd=Path.cwd(),
+        env=base_env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_cli_install_systemd_flag_writes_unit_file(tmp_path: Path) -> None:
+    """End-to-end: `gradata install --systemd --brain ...` writes the unit."""
+    brain = tmp_path / "brain"
+    brain.mkdir()
+    (brain / "cloud-config.json").write_text(
+        json.dumps({"token": "cli-token-xyz"}), encoding="utf-8"
+    )
+
+    result = _run_cli(tmp_path, "install", "--systemd", "--brain", str(brain))
+
+    assert result.returncode == 0, result.stderr
+    unit = tmp_path / ".config" / "systemd" / "user" / "gradata-daemon.service"
+    assert unit.exists(), f"expected {unit} to exist, stdout={result.stdout!r}"
+    text = unit.read_text(encoding="utf-8")
+    assert "Environment=GRADATA_API_KEY=cli-token-xyz" in text
+    assert "--port 8765" in text
+    assert "Restart=on-failure" in text
+    assert "WantedBy=default.target" in text
+    # And the CLI tells the user the post-install commands
+    assert "systemctl --user daemon-reload" in result.stdout
+    assert "systemctl --user enable --now gradata-daemon" in result.stdout


### PR DESCRIPTION
## Summary

Currently the daemon runs from a shell session (`bash -lic '... python3 -m gradata.daemon ...'`) and dies when the shell dies. `gradata install --systemd` writes a user-systemd unit so the daemon survives logout and auto-restarts on failure. Fixes the 'why isn't this on auto when installing?' UX gap.

## What

- `src/gradata/templates/gradata-daemon.service` — unit template with placeholders
- `src/gradata/_systemd_installer.py` — render + write logic. Token resolved from env `GRADATA_API_KEY` first, then `cloud-config.json`. Raises if neither present. Honors `XDG_CONFIG_HOME`.
- `src/gradata/cli.py` — new `--systemd` and `--port` flags on `install`. Early dispatch so it takes precedence over agent/archive paths.
- `pyproject.toml` — ship `templates/*.service` in wheel + sdist (both hatch and setuptools entries).
- `tests/test_systemd_installer.py` — 7 tests including a CLI-subprocess e2e.

## Test plan

- `pytest tests/test_systemd_installer.py` → 7 passed
- `pytest tests/test_cli_install_agent.py tests/test_cli.py` → 29 passed (no regression)

## Post-install

Install does NOT run systemctl during the install step (per spec — file-only side effect). User runs:

```
systemctl --user daemon-reload && systemctl --user enable --now gradata-daemon
```

The CLI prints these exact commands after writing the unit file.

## Layering check

No Layer 0→2 imports. `_systemd_installer.py` is a Layer 1 utility used only by `cli.py` (Layer 2). It does not import anything from `brain.py`, `daemon.py`, or `mcp_server.py`.

## Risk

- Linux-only feature. Windows/macOS users get a clear error ("systemd not available on this platform"). No regression for existing install paths — `--systemd` is opt-in.
- Token is written to a 0600-perm file. Acceptable since the existing `cloud-config.json` is also 0644 (could harden separately).