### PR TITLE
fix(hooks): auto_correct matches Hermes payload shape (post_tool_call/patch/write_file)

### DIFF
--- a/Gradata/src/gradata/hooks/auto_correct.py
+++ b/Gradata/src/gradata/hooks/auto_correct.py
@@ -64,26 +64,54 @@ def _get_brain():
 
 
 def _extract_correction(
-    tool_input: dict, tool_output: dict | str | None = None
+    payload: dict, tool_output: dict | str | None = None
 ) -> tuple[str, str] | None:
-    """Extract before/after text from a tool call.
+    """Extract before/after text from a tool call payload.
 
-    Handles Edit (old_string/new_string) and Write (checks git diff).
+    Handles two stdin shapes:
+
+    1. **Claude Code** — `{"tool_name": "Edit", "input": {"old_string", "new_string"}}`
+       or `{"tool_name": "Write", "input": {"content"}}` with optional
+       `tool_output.old_content` for Write diffs.
+
+    2. **Hermes Agent** (and similar AGENTS.md hosts) —
+       `{"hook_event_name": "post_tool_call", "tool_name": "patch",
+         "tool_input": {"path", "old_string", "new_string"}, ...}`
+       or `{"tool_name": "write_file", "tool_input": {"path", "content"}}`.
+
+    Hermes nests tool args under ``tool_input`` (not ``input``) and uses
+    lowercase tool names (``patch``, ``write_file``, ``mcp_Patch``,
+    ``mcp_Write_file``) rather than ``Edit``/``Write``. Earlier versions
+    of this hook only matched the Claude-Code shape, so every Hermes
+    post_tool_call hook fired but silently captured zero corrections —
+    the canonical "hooks fire but events.jsonl stays idle for days"
+    failure mode. See Gradata/gradata#TBD.
+
     Returns (draft, final) or None if no meaningful correction.
     """
-    tool_name = tool_input.get("tool_name", "")
+    tool_name = payload.get("tool_name", "") or ""
+    # Hermes nests args under "tool_input"; Claude Code under "input".
+    args = payload.get("tool_input") or payload.get("input") or {}
+    if not isinstance(args, dict):
+        args = {}
 
-    if tool_name == "Edit":
-        old = tool_input.get("input", {}).get("old_string", "")
-        new = tool_input.get("input", {}).get("new_string", "")
+    # Normalize tool name for matching. Strip mcp_ prefix (e.g. "mcp_Patch" -> "Patch").
+    name_normalized = tool_name
+    if name_normalized.startswith("mcp_"):
+        name_normalized = name_normalized[4:]
+
+    # Edit-class tools: have old_string + new_string at the args top level.
+    EDIT_TOOLS = {"Edit", "edit", "patch", "Patch", "str_replace", "string_replace"}
+    if name_normalized in EDIT_TOOLS:
+        old = args.get("old_string", "") or ""
+        new = args.get("new_string", "") or ""
         if old and new and old != new:
             return (old, new)
 
-    elif tool_name == "Write":
-        # For Write, we need the previous file content
-        # The hook receives the tool output which may include the old content
-        new_content = tool_input.get("input", {}).get("content", "")
-
+    # Write-class tools: full-file replacement. Need previous content from tool_output.
+    WRITE_TOOLS = {"Write", "write", "write_file", "Write_file", "create_file"}
+    if name_normalized in WRITE_TOOLS:
+        new_content = args.get("content", "") or ""
         if isinstance(tool_output, dict) and tool_output.get("old_content"):
             old_content = tool_output["old_content"]
             if old_content != new_content and old_content and new_content:

--- a/Gradata/tests/test_auto_correct_payload_shapes.py
+++ b/Gradata/tests/test_auto_correct_payload_shapes.py
@@ -1,0 +1,133 @@
+"""Regression tests for auto_correct hook handling both Claude Code and Hermes payload shapes.
+
+History: pre-2026-05-19, ``_extract_correction`` only matched the Claude
+Code stdin shape (``tool_name`` in ``Edit``/``Write`` + args under
+``"input"``). Hermes Agent sends ``{"hook_event_name": "post_tool_call",
+"tool_name": "patch", "tool_input": {...}}`` instead, so every Hermes
+post_tool_call hook fired but captured zero corrections. The user's
+events.jsonl went idle for 43h+ while the fleet ran thousands of edits.
+
+This test pins both shapes so the regression cannot recur silently.
+"""
+
+from __future__ import annotations
+
+import json
+
+from gradata.hooks.auto_correct import _extract_correction, process_hook_input
+
+# ---- Pure unit tests for _extract_correction -------------------------------
+
+
+class TestExtractCorrectionClaudeCode:
+    """Pin the original Claude Code stdin shape."""
+
+    def test_edit_with_old_and_new_string(self) -> None:
+        payload = {
+            "tool_name": "Edit",
+            "input": {"old_string": "Dear Sir", "new_string": "Hey there"},
+        }
+        assert _extract_correction(payload) == ("Dear Sir", "Hey there")
+
+    def test_edit_unchanged_returns_none(self) -> None:
+        payload = {"tool_name": "Edit", "input": {"old_string": "same", "new_string": "same"}}
+        assert _extract_correction(payload) is None
+
+    def test_write_needs_tool_output_old_content(self) -> None:
+        payload = {"tool_name": "Write", "input": {"content": "new file body"}}
+        tool_output = {"old_content": "previous file body"}
+        result = _extract_correction(payload, tool_output)
+        assert result == ("previous file body", "new file body")
+
+
+class TestExtractCorrectionHermes:
+    """The regression these tests pin: Hermes-shape payloads must capture."""
+
+    def test_hermes_patch_tool_extracts_correction(self) -> None:
+        payload = {
+            "hook_event_name": "post_tool_call",
+            "tool_name": "patch",
+            "tool_input": {
+                "path": "/tmp/foo.txt",
+                "old_string": "Dear Sir",
+                "new_string": "Hey there",
+            },
+            "session_id": "test",
+            "cwd": "/tmp",
+            "extra": {},
+        }
+        assert _extract_correction(payload) == ("Dear Sir", "Hey there")
+
+    def test_hermes_mcp_patch_tool_extracts_correction(self) -> None:
+        """Tools dispatched via MCP get an mcp_ prefix; strip it for matching."""
+        payload = {
+            "hook_event_name": "post_tool_call",
+            "tool_name": "mcp_Patch",
+            "tool_input": {"old_string": "foo", "new_string": "bar"},
+        }
+        assert _extract_correction(payload) == ("foo", "bar")
+
+    def test_hermes_write_file_tool_needs_old_content(self) -> None:
+        payload = {
+            "hook_event_name": "post_tool_call",
+            "tool_name": "write_file",
+            "tool_input": {"path": "/tmp/foo.txt", "content": "new body"},
+        }
+        tool_output = {"old_content": "previous body"}
+        assert _extract_correction(payload, tool_output) == ("previous body", "new body")
+
+    def test_hermes_terminal_tool_returns_none(self) -> None:
+        """Non-edit tools must not produce false corrections."""
+        payload = {
+            "hook_event_name": "post_tool_call",
+            "tool_name": "terminal",
+            "tool_input": {"command": "ls /tmp"},
+        }
+        assert _extract_correction(payload) is None
+
+    def test_hermes_unchanged_strings_returns_none(self) -> None:
+        payload = {
+            "tool_name": "patch",
+            "tool_input": {"old_string": "same", "new_string": "same"},
+        }
+        assert _extract_correction(payload) is None
+
+
+class TestExtractCorrectionMalformedInput:
+    def test_missing_args_returns_none(self) -> None:
+        assert _extract_correction({"tool_name": "Edit"}) is None
+
+    def test_args_not_a_dict_returns_none(self) -> None:
+        assert _extract_correction({"tool_name": "Edit", "input": "not a dict"}) is None
+
+    def test_empty_payload_returns_none(self) -> None:
+        assert _extract_correction({}) is None
+
+
+# ---- Integration test: process_hook_input end-to-end ----------------------
+
+
+class TestProcessHookInputHermes:
+    """Exercise the full stdin → response flow with a real Brain.
+
+    These hit the brain at $BRAIN_DIR (set by conftest tmp_path fixture).
+    The point is: a Hermes-shape stdin must result in ``captured: true``.
+    """
+
+    def test_hermes_patch_produces_captured_true(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setenv("BRAIN_DIR", str(tmp_path / "brain"))
+        stdin = json.dumps(
+            {
+                "hook_event_name": "post_tool_call",
+                "tool_name": "patch",
+                "tool_input": {
+                    "old_string": "Dear Sir or Madam",
+                    "new_string": "Hey there",
+                },
+            }
+        )
+        result = process_hook_input(stdin)
+        assert result.get("captured") is True, f"expected capture, got {result}"
+        # Severity values vary by edit distance + content; the important
+        # assertion is captured=True. severity exists for diagnostic only.
+        assert "severity" in result


### PR DESCRIPTION
## Summary

`_extract_correction` only matched Claude Code stdin shape (`tool_name in {Edit, Write}` + args under `input`). Hermes Agent (and similar AGENTS.md hosts) sends `{hook_event_name: post_tool_call, tool_name: 'patch'|'write_file'|'mcp_Patch'|..., tool_input: {...}}`. Every Hermes post_tool_call hook fired but the extractor silently returned None — so events.jsonl never recorded a hook-driven correction.

Observed: oliver-admin brain went 43h with zero new corrections while a 27-agent Hermes fleet ran thousands of patch calls. system.db had 15 historical CORRECTION events all sourced `brain.correct` (manual), zero `hermes-hook`.

## Fix

Expand `_extract_correction` to accept both shapes:
- Args under either `input` (CC) or `tool_input` (Hermes)
- Map tool names to edit/write classes:
  - `EDIT_TOOLS = {Edit, edit, patch, Patch, str_replace, string_replace}`
  - `WRITE_TOOLS = {Write, write, write_file, Write_file, create_file}`
- Strip `mcp_` prefix so `mcp_Patch` matches `Patch`

## Test plan

```
pytest tests/test_auto_correct_payload_shapes.py tests/test_hooks_learning.py -xvs
=> 39 passed in 6.78s
```

12 new test cases pin both stdin shapes + malformed input + end-to-end `process_hook_input` integration with a real Brain.

## Verification on live system (oliver-admin)

Before fix:
- CORRECTION events: 15 (all source=brain.correct, zero hook-driven)
- events.jsonl mtime: 43h stale
- sync_queue: 1 row (May 17)

After fix:
- CORRECTION events: 20 (+5 from real Hermes post_tool_call hook firings)
- sync_queue: 6 rows total, drained by SyncWorker tick
- Cloud correction_count: 8851 → 8859 (+8 confirmed synced)
- Cloud brains.last_sync_at: advanced

## Layering check

Edit is internal to `gradata.hooks`; no Layer 0 → 2 import.

## Risk

Low — pure extractor with additive matching. Claude Code shape behavior unchanged (existing tests pass).