### PR TITLE
refactor(hooks): host adapters own runtime extraction (clean fix on top of #204)

### DIFF
--- a/Gradata/src/gradata/hooks/adapters/_base.py
+++ b/Gradata/src/gradata/hooks/adapters/_base.py
@@ -1,4 +1,39 @@
-"""Shared helpers for Gradata hook adapter installers."""
+"""Shared helpers for Gradata hook adapter installers + runtime extraction.
+
+Adapters are the bridge between Gradata and a specific AI-coding-agent
+host (Claude Code, Codex, Cursor, Gemini, Hermes, OpenCode). Each adapter
+owns TWO concerns for its host:
+
+1. **Install** — write the right hook/MCP wire-up into the host's config
+   file (settings.json, config.toml, etc.). This is the only concern
+   pre-2026-05-19.
+
+2. **Runtime extraction** — given a stdin payload that the host pipes
+   into ``python -m gradata.hooks.auto_correct``, decide whether the
+   payload represents a "correction" (file edit) and return the
+   ``(draft, final)`` tuple. Hosts disagree on stdin shape, tool names,
+   and where the tool args live; centralising this per-adapter prevents
+   the "extractor only works for one host" regression that bit oliver-
+   admin for 43h in May 2026 (Gradata/gradata#TBD).
+
+Each adapter is a module exposing:
+
+- ``AGENT: str`` — canonical agent name (e.g. ``"hermes"``)
+- ``install(brain_dir, agent_config_path) -> InstallResult``
+- ``detect(payload: dict) -> bool`` — does this stdin look like this host?
+- ``extract_correction(payload, tool_output=None) -> tuple[str, str] | None``
+
+The dispatcher in ``auto_correct._extract_correction`` calls ``detect``
+on each registered adapter in priority order, then routes to the first
+match's ``extract_correction``. If no adapter claims the payload, the
+generic ``extract_generic`` falls back to a duck-typed best-effort.
+
+Contract test: ``tests/test_adapter_extraction_contracts.py`` runs a
+fixed corpus of payloads through every registered adapter and asserts
+each adapter's ``detect``/``extract_correction`` is honest (no false-
+positive captures across hosts, no silent drops on its own host's
+canonical shape).
+"""
 
 from __future__ import annotations
 
@@ -10,7 +45,7 @@ import shlex
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Protocol, runtime_checkable
 
 from gradata._atomic import atomic_write_text
 
@@ -33,7 +68,26 @@ _CONFIGS = {
     "hermes": Path(".hermes/config.yaml"),
     "opencode": Path(".config/opencode/config.json"),
 }
+# Detection priority — most-specific hosts first. Hermes carries an
+# unmistakable ``hook_event_name`` envelope; Claude Code has the original
+# ``Edit``/``Write`` capitalised tool names; the others use generic
+# lowercase tool names so they fall through to detection-by-elimination.
+_DETECT_PRIORITY = ("hermes", "claude-code", "codex", "opencode", "gemini", "cursor")
+
 logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class HostAdapter(Protocol):
+    """Structural protocol every adapter module must satisfy."""
+
+    AGENT: str
+
+    def install(self, brain_dir: Path, agent_config_path: Path) -> InstallResult: ...
+    def detect(self, payload: dict) -> bool: ...
+    def extract_correction(
+        self, payload: dict, tool_output: dict | str | None = None
+    ) -> tuple[str, str] | None: ...
 
 
 @dataclass(frozen=True)
@@ -59,6 +113,16 @@ def get_adapter(agent: str):
     if agent not in _MODULES:
         raise ValueError(f"unknown agent: {agent}")
     return importlib.import_module(f"gradata.hooks.adapters.{_MODULES[agent]}")
+
+
+def iter_adapters_in_priority_order():
+    """Yield adapter modules in detection priority order.
+
+    The dispatcher walks this in order and routes the payload to the
+    first adapter whose ``detect()`` returns True.
+    """
+    for agent in _DETECT_PRIORITY:
+        yield agent, get_adapter(agent)
 
 
 def hook_signature(agent: str, brain_dir: Path) -> str:
@@ -99,3 +163,82 @@ def contains_signature(path: Path, signature: str) -> bool:
 
 def failure(agent: str, config_path: Path, exc: Exception) -> InstallResult:
     return InstallResult(agent, config_path, "failed", str(exc))
+
+
+# --------------------------------------------------------------------------
+# Shared extraction utilities — used by individual adapters.
+# --------------------------------------------------------------------------
+
+
+def _coerce_dict(value) -> dict:
+    """Return value if it's a non-empty dict, else {}."""
+    return value if isinstance(value, dict) else {}
+
+
+def _normalize_tool_name(raw: str) -> str:
+    """Strip framework-specific prefixes for matching.
+
+    - Hermes MCP tools arrive as ``mcp_<RawName>`` — strip ``mcp_``.
+    - Some hosts include namespacing like ``builtin:Edit`` — strip prefix up to ``:``.
+    """
+    name = raw or ""
+    if name.startswith("mcp_"):
+        name = name[4:]
+    if ":" in name:
+        name = name.rsplit(":", 1)[-1]
+    return name
+
+
+# Tool-name allowlists at the adapter layer below. Adapter modules import
+# these as the canonical "what counts as an edit/write" enumeration and
+# extend per host where the host's tool surface is documented to include
+# additional aliases.
+
+EDIT_TOOL_ALIASES = frozenset(
+    {
+        "Edit",
+        "edit",
+        "MultiEdit",
+        "patch",
+        "Patch",
+        "str_replace",
+        "string_replace",
+        "string_replace_editor",
+        "apply_patch",
+    }
+)
+
+WRITE_TOOL_ALIASES = frozenset(
+    {
+        "Write",
+        "write",
+        "write_file",
+        "Write_file",
+        "create_file",
+        "createFile",
+        "NewFile",
+    }
+)
+
+
+def extract_from_edit_args(args: dict) -> tuple[str, str] | None:
+    """Edit-class tools: pull ``old_string`` and ``new_string`` from args."""
+    old = args.get("old_string") or args.get("oldString") or ""
+    new = args.get("new_string") or args.get("newString") or ""
+    if old and new and old != new:
+        return (old, new)
+    return None
+
+
+def extract_from_write_args(args: dict, tool_output) -> tuple[str, str] | None:
+    """Write-class tools: full-file replacement requires the host to supply
+    the previous file content via ``tool_output.old_content``. Hosts that
+    don't surface old_content produce no correction (we can't fabricate
+    one from thin air without reading the filesystem, which the hook
+    should not do)."""
+    new_content = args.get("content") or args.get("file_text") or ""
+    out = _coerce_dict(tool_output)
+    old_content = out.get("old_content") or out.get("oldContent") or ""
+    if old_content and new_content and old_content != new_content:
+        return (old_content[:5000], new_content[:5000])
+    return None

--- a/Gradata/src/gradata/hooks/adapters/claude_code.py
+++ b/Gradata/src/gradata/hooks/adapters/claude_code.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 
 from gradata.hooks.adapters._base import (
+    EDIT_TOOL_ALIASES,
+    WRITE_TOOL_ALIASES,
     InstallResult,
+    _normalize_tool_name,
+    extract_from_edit_args,
+    extract_from_write_args,
     failure,
     hook_command,
     hook_signature,
@@ -12,6 +17,39 @@ from gradata.hooks.adapters._base import (
 )
 
 AGENT = "claude-code"
+
+# Claude Code's canonical tool names (capitalised, no prefix).
+EDIT_TOOLS: frozenset[str] = frozenset({"Edit", "MultiEdit"}) | (EDIT_TOOL_ALIASES & {"Edit"})
+WRITE_TOOLS: frozenset[str] = frozenset({"Write"}) | (WRITE_TOOL_ALIASES & {"Write"})
+
+
+def detect(payload: dict) -> bool:
+    """Claude Code stdin signature: capitalised tool name + args at ``input``.
+
+    The Claude Code hook protocol pipes JSON with ``{"tool_name": "Edit",
+    "input": {...}}``. The capitalised tool name and the ``input`` key
+    (not ``tool_input``) are the disambiguating features.
+    """
+    if not isinstance(payload, dict):
+        return False
+    tool_name = _normalize_tool_name(payload.get("tool_name") or "")
+    return tool_name in EDIT_TOOLS or tool_name in WRITE_TOOLS
+
+
+def extract_correction(
+    payload: dict, tool_output: dict | str | None = None
+) -> tuple[str, str] | None:
+    """Extract (draft, final) from a Claude Code post-tool-use payload."""
+    tool_name = _normalize_tool_name(payload.get("tool_name") or "")
+    args = payload.get("input")
+    if not isinstance(args, dict):
+        return None
+
+    if tool_name in EDIT_TOOLS:
+        return extract_from_edit_args(args)
+    if tool_name in WRITE_TOOLS:
+        return extract_from_write_args(args, tool_output)
+    return None
 
 
 def install(brain_dir: Path, agent_config_path: Path) -> InstallResult:

--- a/Gradata/src/gradata/hooks/adapters/codex.py
+++ b/Gradata/src/gradata/hooks/adapters/codex.py
@@ -5,14 +5,65 @@ from pathlib import Path
 
 from gradata._atomic import atomic_write_text
 from gradata.hooks.adapters._base import (
+    EDIT_TOOL_ALIASES,
+    WRITE_TOOL_ALIASES,
     InstallResult,
+    _normalize_tool_name,
     contains_signature,
+    extract_from_edit_args,
+    extract_from_write_args,
     failure,
     hook_command,
     hook_signature,
 )
 
 AGENT = "codex"
+
+# Codex's edit/write tool surface (OpenAI Codex CLI documented tool names).
+CODEX_EDIT_TOOLS = EDIT_TOOL_ALIASES | frozenset({"apply_patch", "str_replace_editor"})
+CODEX_WRITE_TOOLS = WRITE_TOOL_ALIASES
+
+
+def detect(payload: dict) -> bool:
+    """Codex stdin: ``{"tool": "apply_patch", "input": {...}}``.
+
+    Distinguishing features:
+    - ``tool`` field present (not ``tool_name``) — rules out Claude Code
+    - ``input`` field present (not ``args``)         — rules out Gemini
+    - ``event`` field absent                          — rules out OpenCode
+    - ``hook_event_name`` absent                      — rules out Hermes
+    - tool name in Codex's edit/write surface
+    """
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("hook_event_name"):
+        return False
+    if payload.get("event") in {"preTool", "postTool"}:
+        return False
+    if "tool" not in payload:
+        return False
+    if "input" not in payload:
+        return False
+    if "args" in payload:
+        return False
+    tool_name = _normalize_tool_name(payload.get("tool") or "")
+    return tool_name in CODEX_EDIT_TOOLS or tool_name in CODEX_WRITE_TOOLS
+
+
+def extract_correction(
+    payload: dict, tool_output: dict | str | None = None
+) -> tuple[str, str] | None:
+    # Codex uses the lowercase ``tool`` field only.
+    tool_name = _normalize_tool_name(payload.get("tool") or "")
+    args = payload.get("input")
+    if not isinstance(args, dict):
+        return None
+
+    if tool_name in CODEX_EDIT_TOOLS:
+        return extract_from_edit_args(args)
+    if tool_name in CODEX_WRITE_TOOLS:
+        return extract_from_write_args(args, tool_output)
+    return None
 
 
 def _toml_string(value: str) -> str:

--- a/Gradata/src/gradata/hooks/adapters/cursor.py
+++ b/Gradata/src/gradata/hooks/adapters/cursor.py
@@ -7,6 +7,24 @@ from gradata.hooks.adapters._base import InstallResult, failure, mcp_command, re
 AGENT = "cursor"
 
 
+def detect(payload: dict) -> bool:
+    """Cursor integrates via MCP, not via stdin hooks.
+
+    Corrections are captured through the gradata MCP server's tool
+    surface (``brain_correct`` tool callable from Cursor's chat), not
+    through a stdin pipe to this script. So no stdin payload should be
+    routed to this adapter — detect always returns False.
+    """
+    return False
+
+
+def extract_correction(
+    payload: dict, tool_output: dict | str | None = None
+) -> tuple[str, str] | None:
+    """Cursor doesn't emit auto_correct stdin payloads; nothing to extract."""
+    return None
+
+
 def install(brain_dir: Path, agent_config_path: Path) -> InstallResult:
     try:
         data = read_json(agent_config_path)

--- a/Gradata/src/gradata/hooks/adapters/gemini.py
+++ b/Gradata/src/gradata/hooks/adapters/gemini.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 
 from gradata.hooks.adapters._base import (
+    EDIT_TOOL_ALIASES,
+    WRITE_TOOL_ALIASES,
     InstallResult,
+    _normalize_tool_name,
+    extract_from_edit_args,
+    extract_from_write_args,
     failure,
     hook_command,
     hook_signature,
@@ -12,6 +17,41 @@ from gradata.hooks.adapters._base import (
 )
 
 AGENT = "gemini"
+
+# Gemini CLI surfaces tools via the Gemini SDK; canonical tool names use
+# CamelCase or lowercase depending on version. The shared allowlists cover
+# both shapes.
+GEMINI_EDIT_TOOLS = EDIT_TOOL_ALIASES
+GEMINI_WRITE_TOOLS = WRITE_TOOL_ALIASES
+
+
+def detect(payload: dict) -> bool:
+    """Gemini stdin: ``{"tool": "...", "args": {...}}``.
+
+    Distinct from Claude Code (``input`` not ``args``) and Hermes
+    (``hook_event_name`` envelope absent).
+    """
+    if not isinstance(payload, dict):
+        return False
+    if "args" not in payload or "hook_event_name" in payload:
+        return False
+    tool_name = _normalize_tool_name(payload.get("tool") or payload.get("tool_name") or "")
+    return tool_name in GEMINI_EDIT_TOOLS or tool_name in GEMINI_WRITE_TOOLS
+
+
+def extract_correction(
+    payload: dict, tool_output: dict | str | None = None
+) -> tuple[str, str] | None:
+    tool_name = _normalize_tool_name(payload.get("tool") or payload.get("tool_name") or "")
+    args = payload.get("args")
+    if not isinstance(args, dict):
+        return None
+
+    if tool_name in GEMINI_EDIT_TOOLS:
+        return extract_from_edit_args(args)
+    if tool_name in GEMINI_WRITE_TOOLS:
+        return extract_from_write_args(args, tool_output)
+    return None
 
 
 def install(brain_dir: Path, agent_config_path: Path) -> InstallResult:

--- a/Gradata/src/gradata/hooks/adapters/hermes.py
+++ b/Gradata/src/gradata/hooks/adapters/hermes.py
@@ -4,8 +4,13 @@ from pathlib import Path
 
 from gradata._atomic import atomic_write_text
 from gradata.hooks.adapters._base import (
+    EDIT_TOOL_ALIASES,
+    WRITE_TOOL_ALIASES,
     InstallResult,
+    _normalize_tool_name,
     contains_signature,
+    extract_from_edit_args,
+    extract_from_write_args,
     failure,
     hook_command,
     hook_signature,
@@ -172,3 +177,55 @@ def install(brain_dir: Path, agent_config_path: Path) -> InstallResult:
         return InstallResult(AGENT, agent_config_path, "added", "installed pre_tool_call hook")
     except Exception as exc:
         return failure(AGENT, agent_config_path, exc)
+
+
+# Hermes-specific tool name aliases (in addition to the universal allowlist).
+# Hermes ships ``patch``/``write_file``/``mcp_*`` natively; MCP-dispatched
+# tools arrive as ``mcp_<RawName>`` and need the prefix stripped (done by
+# ``_normalize_tool_name``). See agent/shell_hooks.py::_serialize_payload
+# in the Hermes runtime for the canonical wire shape.
+HERMES_EDIT_TOOLS = EDIT_TOOL_ALIASES | frozenset({"patch", "Patch"})
+HERMES_WRITE_TOOLS = WRITE_TOOL_ALIASES | frozenset({"write_file", "Write_file"})
+
+
+def detect(payload: dict) -> bool:
+    """Hermes stdin signature: top-level ``hook_event_name`` envelope.
+
+    Hermes is the only host that wraps its payload with
+    ``{"hook_event_name": "pre_tool_call" | "post_tool_call" | ...}``
+    AND nests the tool args under ``tool_input``. Both signals are
+    checked because some legacy migrations may emit only one.
+    """
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("hook_event_name") in {
+        "pre_tool_call",
+        "post_tool_call",
+        "on_session_end",
+        "pre_llm_call",
+    }:
+        return True
+    # Fallback: payload uses ``tool_input`` (not ``input``) AND has lowercase
+    # tool name. This catches old Hermes versions before hook_event_name
+    # was added, plus any Hermes-shape relay that strips the envelope.
+    if "tool_input" in payload and "input" not in payload:
+        tool_name = _normalize_tool_name(payload.get("tool_name") or "")
+        if tool_name in HERMES_EDIT_TOOLS or tool_name in HERMES_WRITE_TOOLS:
+            return True
+    return False
+
+
+def extract_correction(
+    payload: dict, tool_output: dict | str | None = None
+) -> tuple[str, str] | None:
+    """Extract (draft, final) from a Hermes post_tool_call payload."""
+    tool_name = _normalize_tool_name(payload.get("tool_name") or "")
+    args = payload.get("tool_input")
+    if not isinstance(args, dict):
+        return None
+
+    if tool_name in HERMES_EDIT_TOOLS:
+        return extract_from_edit_args(args)
+    if tool_name in HERMES_WRITE_TOOLS:
+        return extract_from_write_args(args, tool_output)
+    return None

--- a/Gradata/src/gradata/hooks/adapters/opencode.py
+++ b/Gradata/src/gradata/hooks/adapters/opencode.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 
 from gradata.hooks.adapters._base import (
+    EDIT_TOOL_ALIASES,
+    WRITE_TOOL_ALIASES,
     InstallResult,
+    _normalize_tool_name,
+    extract_from_edit_args,
+    extract_from_write_args,
     failure,
     hook_command,
     hook_signature,
@@ -12,6 +17,31 @@ from gradata.hooks.adapters._base import (
 )
 
 AGENT = "opencode"
+
+OPENCODE_EDIT_TOOLS = EDIT_TOOL_ALIASES
+OPENCODE_WRITE_TOOLS = WRITE_TOOL_ALIASES
+
+
+def detect(payload: dict) -> bool:
+    """OpenCode stdin: ``{"event": "preTool", "tool": "...", "input": {...}}``."""
+    if not isinstance(payload, dict):
+        return False
+    return payload.get("event") in {"preTool", "postTool"}
+
+
+def extract_correction(
+    payload: dict, tool_output: dict | str | None = None
+) -> tuple[str, str] | None:
+    tool_name = _normalize_tool_name(payload.get("tool") or payload.get("tool_name") or "")
+    args = payload.get("input")
+    if not isinstance(args, dict):
+        return None
+
+    if tool_name in OPENCODE_EDIT_TOOLS:
+        return extract_from_edit_args(args)
+    if tool_name in OPENCODE_WRITE_TOOLS:
+        return extract_from_write_args(args, tool_output)
+    return None
 
 
 def install(brain_dir: Path, agent_config_path: Path) -> InstallResult:

--- a/Gradata/src/gradata/hooks/auto_correct.py
+++ b/Gradata/src/gradata/hooks/auto_correct.py
@@ -66,57 +66,33 @@ def _get_brain():
 def _extract_correction(
     payload: dict, tool_output: dict | str | None = None
 ) -> tuple[str, str] | None:
-    """Extract before/after text from a tool call payload.
+    """Dispatch the payload to the right host adapter and extract a correction.
 
-    Handles two stdin shapes:
+    Each adapter under ``gradata.hooks.adapters`` declares which payload
+    shapes belong to its host (``detect()``) and how to read the
+    correction out of one (``extract_correction()``). This dispatcher
+    walks adapters in priority order; the first whose ``detect`` returns
+    True owns the payload.
 
-    1. **Claude Code** — `{"tool_name": "Edit", "input": {"old_string", "new_string"}}`
-       or `{"tool_name": "Write", "input": {"content"}}` with optional
-       `tool_output.old_content` for Write diffs.
+    Returns ``(draft, final)`` or ``None`` if no adapter claims the
+    payload or no correction can be extracted.
 
-    2. **Hermes Agent** (and similar AGENTS.md hosts) —
-       `{"hook_event_name": "post_tool_call", "tool_name": "patch",
-         "tool_input": {"path", "old_string", "new_string"}, ...}`
-       or `{"tool_name": "write_file", "tool_input": {"path", "content"}}`.
-
-    Hermes nests tool args under ``tool_input`` (not ``input``) and uses
-    lowercase tool names (``patch``, ``write_file``, ``mcp_Patch``,
-    ``mcp_Write_file``) rather than ``Edit``/``Write``. Earlier versions
-    of this hook only matched the Claude-Code shape, so every Hermes
-    post_tool_call hook fired but silently captured zero corrections —
-    the canonical "hooks fire but events.jsonl stays idle for days"
-    failure mode. See Gradata/gradata#TBD.
-
-    Returns (draft, final) or None if no meaningful correction.
+    Backwards-compatibility: pre-2026-05-19 this function inlined the
+    Claude Code shape only. The adapter-routed implementation accepts
+    every host's canonical stdin shape. See PR #TBD.
     """
-    tool_name = payload.get("tool_name", "") or ""
-    # Hermes nests args under "tool_input"; Claude Code under "input".
-    args = payload.get("tool_input") or payload.get("input") or {}
-    if not isinstance(args, dict):
-        args = {}
+    from gradata.hooks.adapters._base import iter_adapters_in_priority_order
 
-    # Normalize tool name for matching. Strip mcp_ prefix (e.g. "mcp_Patch" -> "Patch").
-    name_normalized = tool_name
-    if name_normalized.startswith("mcp_"):
-        name_normalized = name_normalized[4:]
+    if not isinstance(payload, dict):
+        return None
 
-    # Edit-class tools: have old_string + new_string at the args top level.
-    EDIT_TOOLS = {"Edit", "edit", "patch", "Patch", "str_replace", "string_replace"}
-    if name_normalized in EDIT_TOOLS:
-        old = args.get("old_string", "") or ""
-        new = args.get("new_string", "") or ""
-        if old and new and old != new:
-            return (old, new)
-
-    # Write-class tools: full-file replacement. Need previous content from tool_output.
-    WRITE_TOOLS = {"Write", "write", "write_file", "Write_file", "create_file"}
-    if name_normalized in WRITE_TOOLS:
-        new_content = args.get("content", "") or ""
-        if isinstance(tool_output, dict) and tool_output.get("old_content"):
-            old_content = tool_output["old_content"]
-            if old_content != new_content and old_content and new_content:
-                return (old_content[:5000], new_content[:5000])
-
+    for _agent_name, adapter in iter_adapters_in_priority_order():
+        try:
+            if adapter.detect(payload):
+                return adapter.extract_correction(payload, tool_output)
+        except Exception:
+            # An adapter must never crash the dispatcher. Fall through.
+            continue
     return None
 
 

--- a/Gradata/tests/test_adapter_extraction_contracts.py
+++ b/Gradata/tests/test_adapter_extraction_contracts.py
@@ -1,0 +1,279 @@
+"""Contract tests for the host-adapter extraction protocol.
+
+Each host adapter must satisfy these invariants:
+
+INVARIANT 1 — Edit-class payloads MUST capture
+    For payloads in the adapter's canonical edit/write shape, the
+    adapter's ``extract_correction()`` returns the expected
+    ``(draft, final)`` tuple, AND the top-level dispatcher routes to it.
+
+INVARIANT 2 — Non-edit payloads MUST safely return None
+    For payloads the host might pipe through stdin that are NOT edits
+    (terminal/bash/search/etc), the dispatcher returns None. The owning
+    adapter MAY claim the payload via ``detect()`` (since it's structurally
+    a payload-from-that-host) but its ``extract_correction()`` MUST return
+    None for non-edit tool names. False positives ("captured an ls command
+    as a correction") would corrupt the brain.
+
+INVARIANT 3 — Cross-host hygiene
+    No adapter falsely claims another host's EDIT-class payload. (For
+    non-edit payloads, false-claim is harmless because extract returns
+    None — see Invariant 2.)
+
+INVARIANT 4 — Dispatcher robustness
+    Garbage input never crashes the dispatcher. A crashing adapter never
+    breaks the dispatcher; subsequent adapters get tried.
+
+This file is the structural guard against the May-2026 regression that
+shipped an extractor matching only one host's edit shape — silent capture
+failure across the other 5 hosts for 43h.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gradata.hooks.adapters import _base
+from gradata.hooks.auto_correct import _extract_correction
+
+# ---- Corpus: per-host EDIT payloads (must capture) ------------------------
+#
+# Each entry: (payload, expected_correction, tool_output)
+# expected_correction is the (draft, final) tuple that MUST come back.
+
+EDIT_PAYLOADS: dict[str, list[tuple[dict, tuple[str, str], dict | None]]] = {
+    "claude-code": [
+        (
+            {"tool_name": "Edit", "input": {"old_string": "Dear Sir", "new_string": "Hey"}},
+            ("Dear Sir", "Hey"),
+            None,
+        ),
+        (
+            {"tool_name": "MultiEdit", "input": {"old_string": "foo", "new_string": "bar"}},
+            ("foo", "bar"),
+            None,
+        ),
+        (
+            {"tool_name": "Write", "input": {"content": "new body"}},
+            ("old body", "new body"),
+            {"old_content": "old body"},
+        ),
+    ],
+    "hermes": [
+        (
+            {
+                "hook_event_name": "post_tool_call",
+                "tool_name": "patch",
+                "tool_input": {"old_string": "foo", "new_string": "bar"},
+                "session_id": "s",
+                "cwd": "/tmp",
+                "extra": {},
+            },
+            ("foo", "bar"),
+            None,
+        ),
+        (
+            {
+                "hook_event_name": "post_tool_call",
+                "tool_name": "mcp_Patch",
+                "tool_input": {"old_string": "a", "new_string": "b"},
+            },
+            ("a", "b"),
+            None,
+        ),
+        (
+            {
+                "hook_event_name": "post_tool_call",
+                "tool_name": "write_file",
+                "tool_input": {"path": "/tmp/x", "content": "new"},
+            },
+            ("old", "new"),
+            {"old_content": "old"},
+        ),
+    ],
+    "codex": [
+        (
+            {"tool": "apply_patch", "input": {"old_string": "x", "new_string": "y"}},
+            ("x", "y"),
+            None,
+        ),
+    ],
+    "gemini": [
+        (
+            {"tool": "Edit", "args": {"old_string": "draft", "new_string": "final"}},
+            ("draft", "final"),
+            None,
+        ),
+    ],
+    "opencode": [
+        (
+            {"event": "preTool", "tool": "edit", "input": {"old_string": "a", "new_string": "b"}},
+            ("a", "b"),
+            None,
+        ),
+    ],
+    # Cursor: no stdin payloads (MCP-only). Empty corpus is correct.
+    "cursor": [],
+}
+
+
+# ---- Corpus: per-host NON-EDIT payloads (dispatcher must return None) -----
+#
+# These represent payloads the host might pipe through the hook
+# subprocess but that don't represent file edits — terminal commands,
+# search calls, etc. The dispatcher MUST NOT extract a correction from
+# them. The owning adapter MAY ``detect()`` them as belonging to its
+# host (that's a structural truth, not a bug); it MUST refuse to
+# extract a correction in ``extract_correction()``.
+
+NON_EDIT_PAYLOADS: dict[str, list[dict]] = {
+    "claude-code": [
+        {"tool_name": "Bash", "input": {"command": "ls"}},
+        {"tool_name": "Read", "input": {"file_path": "/etc/hosts"}},
+    ],
+    "hermes": [
+        {
+            "hook_event_name": "post_tool_call",
+            "tool_name": "terminal",
+            "tool_input": {"command": "ls /tmp"},
+        },
+        {
+            "hook_event_name": "pre_tool_call",
+            "tool_name": "search_files",
+            "tool_input": {"pattern": "TODO"},
+        },
+    ],
+    "codex": [
+        {"tool": "shell", "input": {"command": "echo hi"}},
+    ],
+    "gemini": [
+        {"tool": "Search", "args": {"query": "ignored"}},
+    ],
+    "opencode": [
+        {"event": "preTool", "tool": "shell", "input": {"command": "ls"}},
+    ],
+    "cursor": [],
+}
+
+
+def _edit_params():
+    out = []
+    for host, entries in EDIT_PAYLOADS.items():
+        for i, (payload, expected, tool_output) in enumerate(entries):
+            out.append(pytest.param(host, payload, expected, tool_output, id=f"{host}-edit-{i}"))
+    return out
+
+
+def _non_edit_params():
+    out = []
+    for host, entries in NON_EDIT_PAYLOADS.items():
+        for i, payload in enumerate(entries):
+            out.append(pytest.param(host, payload, id=f"{host}-nonedit-{i}"))
+    return out
+
+
+# ---- INVARIANT 1: edit payloads capture via owning adapter ----------------
+
+
+@pytest.mark.parametrize("host,payload,expected,tool_output", _edit_params())
+def test_owning_adapter_extracts_edit_payload(host, payload, expected, tool_output):
+    """Each adapter's ``extract_correction`` MUST return the expected
+    correction tuple for its host's canonical edit payloads."""
+    adapter = _base.get_adapter(host)
+    assert adapter.extract_correction(payload, tool_output) == expected, (
+        f"{host}.extract_correction() failed on its own edit payload: {payload}"
+    )
+
+
+@pytest.mark.parametrize("host,payload,expected,tool_output", _edit_params())
+def test_owning_adapter_detects_edit_payload(host, payload, expected, tool_output):
+    """detect() must return True for the owning host's edit payloads
+    (otherwise the dispatcher's priority loop can't route them)."""
+    adapter = _base.get_adapter(host)
+    assert adapter.detect(payload) is True, (
+        f"{host}.detect() returned False on its own edit payload: {payload}"
+    )
+
+
+@pytest.mark.parametrize("host,payload,expected,tool_output", _edit_params())
+def test_dispatcher_routes_edit_payload_correctly(host, payload, expected, tool_output):
+    """The top-level dispatcher (``_extract_correction``) MUST return the
+    expected correction for every edit payload in the corpus.
+
+    This is the structural anti-regression test for the May-2026 bug.
+    """
+    assert _extract_correction(payload, tool_output) == expected
+
+
+# ---- INVARIANT 2: non-edit payloads safely return None --------------------
+
+
+@pytest.mark.parametrize("host,payload", _non_edit_params())
+def test_owning_adapter_refuses_non_edit_payload(host, payload):
+    """``extract_correction`` MUST return None for non-edit tool calls
+    even when the payload is structurally from this host. Capturing a
+    terminal/bash/search call as a correction would corrupt the brain."""
+    adapter = _base.get_adapter(host)
+    assert adapter.extract_correction(payload) is None, (
+        f"{host}.extract_correction() falsely captured a non-edit payload: {payload}"
+    )
+
+
+@pytest.mark.parametrize("host,payload", _non_edit_params())
+def test_dispatcher_returns_none_for_non_edit_payload(host, payload):
+    """The dispatcher returns None for every non-edit payload (regardless
+    of which adapter claims it via ``detect()``)."""
+    assert _extract_correction(payload) is None
+
+
+# ---- INVARIANT 3: cross-host hygiene on edit payloads ---------------------
+
+
+@pytest.mark.parametrize("host,payload,expected,tool_output", _edit_params())
+def test_other_adapters_do_not_falsely_claim_edit_payload(host, payload, expected, tool_output):
+    """No adapter EXCEPT the owning one may detect this host's edit
+    payload — that would mis-route the dispatcher and either return the
+    wrong (draft, final) or None on a real correction."""
+    for other_host in _base._DETECT_PRIORITY:
+        if other_host == host:
+            continue
+        other = _base.get_adapter(other_host)
+        assert other.detect(payload) is False, (
+            f"{other_host}.detect() falsely claimed {host}'s edit payload: {payload}"
+        )
+
+
+# ---- INVARIANT 4: robustness ----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "junk",
+    [
+        None,
+        "",
+        [],
+        42,
+        {"random": "field"},
+        {"tool_name": None},
+        {"tool_name": "Edit", "input": "not a dict"},
+        {"hook_event_name": "pre_tool_call", "tool_name": "patch", "tool_input": None},
+    ],
+)
+def test_dispatcher_handles_garbage_safely(junk):
+    """Any non-canonical input must return None, never crash."""
+    assert _extract_correction(junk) is None
+
+
+def test_dispatcher_survives_crashing_adapter(monkeypatch):
+    """If one adapter's ``detect`` raises, the dispatcher must continue
+    to the next adapter rather than propagating."""
+    from gradata.hooks.adapters import hermes as hermes_adapter
+
+    def boom(payload):
+        raise RuntimeError("simulated adapter crash")
+
+    monkeypatch.setattr(hermes_adapter, "detect", boom)
+
+    # Claude-Code shape should still capture via the CC adapter.
+    payload = {"tool_name": "Edit", "input": {"old_string": "x", "new_string": "y"}}
+    assert _extract_correction(payload) == ("x", "y")


### PR DESCRIPTION
## Summary

PR #204 was the band-aid: a single `_extract_correction` in `auto_correct.py` that matched both Claude Code and Hermes payload shapes via a hard-coded tool-name allowlist. This PR is the clean fix: each host adapter under `gradata.hooks.adapters` owns BOTH install-time wiring AND runtime extraction. `auto_correct._extract_correction` becomes a 12-line dispatcher.

## Architecture

Each adapter exposes:
- `AGENT: str` — canonical name
- `install(brain_dir, agent_config_path) -> InstallResult` — existing
- `detect(payload: dict) -> bool` — NEW: does this stdin look like this host?
- `extract_correction(payload, tool_output=None) -> tuple[str, str] | None` — NEW

Dispatcher walks adapters in priority order (`hermes, claude-code, codex, opencode, gemini, cursor`); first to claim via `detect()` routes to its extractor.

## Contract test

`tests/test_adapter_extraction_contracts.py` encodes four invariants over a per-host corpus:

| Invariant | What it pins |
|---|---|
| 1. Edit payloads MUST capture | Owning adapter detects + extracts; dispatcher returns the (draft, final) tuple |
| 2. Non-edit payloads MUST return None | Capturing a `ls`/`shell` command as a correction would corrupt the brain |
| 3. Cross-host hygiene | No adapter falsely claims another host's EDIT payload — verified for every host × every other host |
| 4. Dispatcher robustness | Garbage input never crashes; crashing adapter never blocks the chain |

## Bugs surfaced by the contract test (and fixed here)

- `codex.detect()` was falsely claiming Claude Code `Edit` payloads (both used `input` key). Codex now also requires `tool` field (not `tool_name`), no `event` field (rules out OpenCode), no `args` field (rules out Gemini).

## Test plan

```
pytest tests/test_adapter_extraction_contracts.py \
       tests/test_auto_correct_payload_shapes.py \
       tests/test_hook_adapters.py \
       tests/test_hooks_learning.py
=> 106 passed in 4.99s
```

## Live verification on oliver-admin

```
echo '{"hook_event_name":"post_tool_call","tool_name":"patch",
       "tool_input":{"old_string":"a","new_string":"b"}}' | \
BRAIN_DIR=~/.gradata/brain python3 -m gradata.hooks.auto_correct
=> {"captured": true, ...}
```

## Layering

Edit confined to `gradata.hooks.adapters`; no Layer 0 → 2 import.

## Risk

Low — same wire behavior as #204 (Claude Code shape + Hermes shape both capture, non-edits return None). The responsibility moves to the adapter modules where new hosts can be added without touching `auto_correct.py`.

## Series

#204 (band-aid, Hermes shape support) → this PR (clean fix, adapter-owned extraction with contract test). Recommended merge order: #204 first (smaller, more conservative), then this PR.