### PR TITLE
feat(cli): add 'gradata forget' subcommand (GRA-1207 / GH #206)

### DIFF
--- a/Gradata/src/gradata/cli.py
+++ b/Gradata/src/gradata/cli.py
@@ -335,8 +335,9 @@ def _cmd_install_agent(args) -> None:
         # ▸ Flag-gated install verification: write + read a test rule
         if verify_install and result.action != "failed":
             try:
-                from gradata import Brain
                 import tempfile
+
+                from gradata import Brain
 
                 verification_marker = f"gradata-install-verify-{name}-{os.urandom(4).hex()}"
                 with tempfile.TemporaryDirectory(prefix="gradata-verify-") as verification_tmp:
@@ -350,13 +351,10 @@ def _cmd_install_agent(args) -> None:
                     )
                     results = verification_brain.search(verification_marker, mode="rules", top_k=3)
                     marker_found = any(
-                        verification_marker in (r.get("text") or "").lower()
-                        for r in results
+                        verification_marker in (r.get("text") or "").lower() for r in results
                     )
                     if not marker_found:
-                        print(
-                            f"  ⚠ verify failed: test rule written but not readable for {name}"
-                        )
+                        print(f"  ⚠ verify failed: test rule written but not readable for {name}")
                         had_failure = True
                     else:
                         print(f"  ✓ verify: {name} install confirmed (write+read)")
@@ -541,6 +539,101 @@ def cmd_diagnose(args):
         print("No lessons yet — need more corrections to start building procedural memory.")
 
     print("\nRun 'gradata health' for a full brain health report.")
+
+
+def cmd_forget(args):
+    """Undo one or more lessons from the brain.
+
+    Selector syntax (passed as positional ``what`` arg):
+      - ``last``           — undo most recent active lesson
+      - ``last N``         — undo last N active lessons (e.g. ``last 3``)
+      - ``all TONE``       — undo every active lesson in a category
+      - ``<description>``  — fuzzy-match a single lesson by description
+
+    By default the command prints matched lessons and asks for confirmation
+    before applying. Pass ``--yes`` to skip the prompt (for scripts).
+
+    The forget is a soft cancel: lessons are flipped to KILLED state, a
+    LESSON_CHANGE event is emitted (so the sync pipeline replays it), and
+    the rule cache is invalidated so the next ``apply_brain_rules()`` call
+    reflects the change. No event is hard-deleted.
+    """
+    brain = _get_brain(args)
+    what = (args.what or "last").strip()
+    skip_confirm = bool(getattr(args, "yes", False))
+
+    # Preview pass — peek at what the matcher would touch so we can show
+    # the user before applying. We re-use brain.forget() with a tiny dance:
+    # the heavy lifting is in Brain.forget; here we just want a confirm step.
+    try:
+        from gradata._types import LessonState
+        from gradata.enhancements.self_improvement import parse_lessons
+    except ImportError:
+        print("Error: enhancements module not available — cannot forget lessons")
+        sys.exit(1)
+
+    lessons_path = brain._find_lessons_path()
+    if not lessons_path or not lessons_path.is_file():
+        print("No lessons file found — nothing to forget.")
+        sys.exit(0)
+
+    lessons = parse_lessons(lessons_path.read_text(encoding="utf-8"))
+    active = [
+        (i, l)
+        for i, l in enumerate(lessons)
+        if l.state in (LessonState.INSTINCT, LessonState.PATTERN, LessonState.RULE)
+    ]
+    if not active:
+        print("No active lessons — nothing to forget.")
+        sys.exit(0)
+
+    wl = what.lower()
+    preview: list = []
+    if wl == "last" or wl.startswith("last "):
+        parts = wl.split()
+        n = int(parts[1]) if len(parts) == 2 and parts[1].isdigit() else 1
+        preview = [l for _, l in active[-n:]]
+    elif wl.startswith("all "):
+        cat = what[4:].strip()
+        preview = [l for _, l in active if l.category.upper() == cat.upper()]
+    else:
+        # Fuzzy single-target — let rollback's matcher decide
+        matches = [l for _, l in active if what.lower() in (l.description or "").lower()]
+        if not matches:
+            print(f"No active lessons match: {what!r}")
+            sys.exit(1)
+        preview = matches[:1]
+
+    if not preview:
+        print(f"No matches for: {what!r}")
+        sys.exit(1)
+
+    print(f"Will forget {len(preview)} lesson{'s' if len(preview) != 1 else ''}:")
+    for l in preview:
+        desc = (l.description or "")[:80]
+        print(f"  [{l.category:10}] {l.state.value:8} conf={l.confidence:.2f}  {desc}")
+
+    if not skip_confirm:
+        try:
+            ans = input("\nProceed? [y/N] ").strip().lower()
+        except EOFError:
+            ans = ""
+        if ans not in ("y", "yes"):
+            print("Cancelled — no lessons forgotten.")
+            sys.exit(0)
+
+    # Delegate the actual work to Brain.forget — same semantics as the
+    # public Python API.
+    result = brain.forget(what)
+    if isinstance(result, dict) and result.get("error"):
+        print(f"Error: {result['error']}")
+        sys.exit(1)
+
+    items = result if isinstance(result, list) else [result]
+    rolled_back = [r for r in items if r.get("rolled_back")]
+    print(f"\nForgotten: {len(rolled_back)} lesson{'s' if len(rolled_back) != 1 else ''}.")
+    if rolled_back:
+        print("(LESSON_CHANGE events emitted — sync pipeline will replay.)")
 
 
 def cmd_correct(args):
@@ -1573,6 +1666,24 @@ def main():
     p_correct.add_argument("--category", type=str, help="Correction category override")
     p_correct.add_argument("--session", type=int, help="Session number")
 
+    # forget — undo lessons by selector
+    p_forget = sub.add_parser("forget", help="Undo one or more lessons from the brain")
+    p_forget.add_argument(
+        "what",
+        nargs="?",
+        default="last",
+        help=(
+            "Selector: 'last', 'last N', 'all CATEGORY', or fuzzy description "
+            "substring. Default: 'last'."
+        ),
+    )
+    p_forget.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Skip interactive confirmation (for scripts)",
+    )
+
     # tune — optimize a prompt against correction history
     p_tune = sub.add_parser("tune", help="Tune a prompt with Agent-Lightning APO")
     p_tune.add_argument("prompt_file", help="Prompt template file")
@@ -1764,6 +1875,7 @@ def main():
         "report": cmd_report,
         "watch": cmd_watch,
         "correct": cmd_correct,
+        "forget": cmd_forget,
         "tune": cmd_tune,
         "review": cmd_review,
         "diagnose": cmd_diagnose,

--- a/Gradata/tests/test_forget_command.py
+++ b/Gradata/tests/test_forget_command.py
@@ -1,0 +1,123 @@
+"""Tests for `gradata forget` — soft-delete lessons by selector."""
+
+from __future__ import annotations
+
+import contextlib
+from types import SimpleNamespace
+
+import pytest
+
+try:
+    from gradata.cli import cmd_forget
+except ImportError:
+    pytest.skip("gradata SDK not importable", allow_module_level=True)
+
+
+@pytest.fixture
+def seeded_brain(tmp_path):
+    """Return a Brain with 3 active lessons across 2 categories."""
+    from gradata import Brain
+
+    brain_dir = tmp_path / "brain"
+    brain = Brain.init(str(brain_dir), domain="Test")
+
+    # Seed via the public correct() API so the events table matches reality.
+    # Each correction generates a lesson via the auto-graduation pipeline;
+    # we explicitly select category to ensure both buckets exist.
+    brain.correct(
+        draft="Dear Sir or Madam",
+        final="Hey there",
+        category="TONE",
+    )
+    brain.correct(
+        draft="The following is a list:",
+        final="Here:",
+        category="TONE",
+    )
+    brain.correct(
+        draft="def foo():",
+        final="def foo() -> None:",
+        category="STYLE",
+    )
+    return brain, brain_dir
+
+
+def _run_forget(brain_dir, what, yes=True, capsys=None):
+    """Invoke cmd_forget and return captured stdout."""
+    args = SimpleNamespace(brain_dir=str(brain_dir), what=what, yes=yes)
+    with contextlib.suppress(SystemExit):
+        cmd_forget(args)
+    return capsys.readouterr().out if capsys else ""
+
+
+def test_forget_last_drops_one_lesson(seeded_brain, capsys):
+    brain, brain_dir = seeded_brain
+    before = len([l for l in _active_lessons(brain)])
+    out = _run_forget(brain_dir, "last", yes=True, capsys=capsys)
+    after = len([l for l in _active_lessons(brain)])
+    assert "Will forget 1 lesson" in out
+    assert "Forgotten: 1 lesson" in out
+    assert after == before - 1
+
+
+def test_forget_last_n_drops_n_lessons(seeded_brain, capsys):
+    brain, brain_dir = seeded_brain
+    before = len([l for l in _active_lessons(brain)])
+    out = _run_forget(brain_dir, "last 2", yes=True, capsys=capsys)
+    after = len([l for l in _active_lessons(brain)])
+    assert "Will forget 2 lessons" in out
+    assert after == before - 2
+
+
+def test_forget_all_category_drops_matching(seeded_brain, capsys):
+    brain, brain_dir = seeded_brain
+    tone_before = len([l for l in _active_lessons(brain) if l.category.upper() == "TONE"])
+    assert tone_before >= 1
+    out = _run_forget(brain_dir, "all TONE", yes=True, capsys=capsys)
+    tone_after = len([l for l in _active_lessons(brain) if l.category.upper() == "TONE"])
+    assert tone_after == 0
+    assert "Will forget" in out
+
+
+def test_forget_fuzzy_description(seeded_brain, capsys):
+    brain, brain_dir = seeded_brain
+    # Find an actual lesson description substring to match on
+    active = _active_lessons(brain)
+    assert active, "test prerequisite: at least one lesson seeded"
+    # Take the first word of the first lesson's description as the fuzzy key.
+    # This is robust to whatever the auto-graduation pipeline produced.
+    descs = [(l.description or "") for l in active]
+    candidate = next((d for d in descs if len(d) > 3), "")
+    assert candidate, f"no usable descriptions found: {descs}"
+    needle = candidate.split()[0]
+    out = _run_forget(brain_dir, needle, yes=True, capsys=capsys)
+    assert "Will forget" in out
+
+
+def test_forget_no_matches_returns_clean_error(seeded_brain, capsys):
+    brain, brain_dir = seeded_brain
+    out = _run_forget(brain_dir, "nonexistent-phrase-zzz", yes=True, capsys=capsys)
+    assert "No active lessons match" in out or "No matches" in out
+
+
+def test_forget_unknown_category_says_no_matches(seeded_brain, capsys):
+    brain, brain_dir = seeded_brain
+    out = _run_forget(brain_dir, "all NONEXISTENT", yes=True, capsys=capsys)
+    assert "No matches" in out or "No active lessons in" in out
+
+
+# ---- helpers --------------------------------------------------------------
+
+
+def _active_lessons(brain):
+    from gradata._types import LessonState
+    from gradata.enhancements.self_improvement import parse_lessons
+
+    p = brain._find_lessons_path()
+    if not p or not p.is_file():
+        return []
+    return [
+        l
+        for l in parse_lessons(p.read_text(encoding="utf-8"))
+        if l.state in (LessonState.INSTINCT, LessonState.PATTERN, LessonState.RULE)
+    ]


### PR DESCRIPTION
## Summary

Adds `gradata forget <selector>` — undo lessons from the brain via CLI without writing Python.

Wraps the existing `Brain.forget()` public API. Preview-before-apply UX with interactive confirmation; `--yes` skips for scripts.

## Selector syntax

```
gradata forget                  # most recent active lesson
gradata forget last 3           # last 3 active lessons
gradata forget all TONE         # every active lesson in a category
gradata forget 'casual tone'    # fuzzy description substring match
gradata forget last --yes       # skip confirmation
```

## Soft-delete semantics

- Lessons flipped to `KILLED` state (not hard-deleted)
- LESSON_CHANGE event emitted with `action='rolled_back'` and `kill_reason='manual_forget'`
- Rule cache invalidated; next `apply_brain_rules()` reflects the change
- Sync pipeline replays the events to cloud automatically

## Test plan

```
pytest tests/test_forget_command.py
=> 6 passed in 3.29s
```

6 cases: last (single), last N, all CATEGORY, fuzzy description, no-match clean error, unknown-category clean error. Tests seed via the public `Brain.correct()` API so the events table matches production exactly.

## Epic context

GRA-1198 (kill the plugin) / GH #206. Replaces plugin `/gradata:forget` slash command. Companion to PR #208 (`gradata status`).

## Layering

`cmd_forget` delegates to `Brain.forget()` (Layer 2 public API). Layer 0 imports (LessonState, parse_lessons) used for preview only, not state mutation. No Layer 0 → 2 imports.

## Risk

Low. Pure additive CLI wrapper. Underlying `Brain.forget()` already has production usage.