### PR TITLE
docs: single install path — pipx + gradata install (GRA-1212 / GH #206)

### DIFF
--- a/Gradata/README.md
+++ b/Gradata/README.md
@@ -177,24 +177,27 @@ brain.prove()      # Paired t-test on correction rate
 
 ---
 
-## Install (pick one)
-
-### Claude Code (recommended)
-
-```
-/plugin marketplace add Gradata/gradata
-/plugin install gradata
-```
-
-Prereq: `pipx install gradata`. See [`.claude-plugin/README.md`](./.claude-plugin/README.md).
-
-### Python SDK
+## Install
 
 ```bash
 pipx install gradata
-gradata init ./my-brain
-gradata install --agent claude-code --brain ./my-brain
+gradata install --agent claude-code --brain ~/.gradata/brain
 ```
+
+Replace `--agent claude-code` with your host: `codex`, `gemini`, `hermes`, `opencode`, or `cursor`. One command, one path — the Python CLI is the single install surface for every host.
+
+After install, your AI agent has 6 SDK subcommands:
+
+```bash
+gradata status     # one-page brain/daemon/cloud summary
+gradata correct    # log a draft -> final correction
+gradata forget     # undo lessons by selector
+gradata prove      # statistical evidence the brain is improving (CI signal)
+gradata recall     # pull rules into the current prompt
+gradata doctor     # check environment + brain health
+```
+
+See `gradata --help` for the full list (init, install, embed, sync, watch, tune, health, report, hooks, rule, skill, seed, cloud, project, mine, audit, manifest, stats, validate, demo, context).
 
 ### JS / TypeScript
 
@@ -359,7 +362,7 @@ graph TB
 - `examples/` — SDK usage examples
 - `packages/npm/` — `@gradata/cli` JS client
 - `gradata-install/` — npm wrapper for one-command IDE setup
-- `.claude-plugin/` + `hooks/` — Claude Code plugin manifest
+- `hooks/` — runtime hook adapters loaded by `gradata install`
 - `brain/` — research scripts (benchmarks, simulations)
 
 ---


### PR DESCRIPTION
## Summary

Replaces the two-path Claude Code marketplace OR Python SDK pipx branching with a single canonical install: `pipx install gradata && gradata install --agent <host>`.

## Why

The `/plugin marketplace add` path was a duplicate surface that did the same thing `gradata install --agent claude-code` already does (apply hooks + slash commands). Two paths created onboarding friction ('which one?') for zero functional gain. Council voted Option A 'kill the plugin' on 2026-05-01.

## Companion PRs that made this safe

Three subcommands shipped today replace what the plugin's slash commands did:

- PR #208 (merged) — `gradata status` replaces `/gradata:status`
- PR #209 (merged) — `gradata forget` replaces `/gradata:forget`
- PR #210 (in-CI) — `gradata prove` replaces `/gradata:prove`

`/gradata:promote` is deferred (no SDK scope-machinery exists — separate feature spike).

## Changes

- Removed the 'pick one' framing
- Removed `/plugin marketplace add` + `/plugin install` instructions
- Surfaced the 6 first-class SDK subcommands the agent gets after install: status, correct, forget, prove, recall, doctor
- Updated repo-layout list to remove `.claude-plugin/` (manifest stays in tree until separate retirement PR — README description matches reality AS OF THIS COMMIT)

## Verification

Render the README on GitHub — install section shows one canonical path. No 'pick one' framing remains. Plugin marketplace install command is gone.

## Epic context

GRA-1198 (kill the plugin) / GH #206. Caps the epic from the docs side. Plugin directory retirement (`.claude-plugin/` removal) is a follow-up PR.