### PR TITLE
chore(plugin): retire .claude-plugin/ references (GRA-1249 / GH #206)

### DIFF
--- a/Gradata/.dockerignore
+++ b/Gradata/.dockerignore
@@ -2,7 +2,6 @@
 .git
 .github
 .claude
-.claude-plugin
 .tmp
 .venv
 venv

--- a/Gradata/CHANGELOG.md
+++ b/Gradata/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Breaking
+
+- **Plugin marketplace install path retired.** The `.claude-plugin/` directory
+  and `/plugin install gradata` flow are gone; use
+  `gradata install --agent claude-code` instead. See PR #211 for the README
+  guide. (GRA-1249, epic GRA-1198)
+
 ### Changed
 
 - Renamed the deterministic anchor-preserving prompt injection module to

--- a/Gradata/examples/README.md
+++ b/Gradata/examples/README.md
@@ -33,4 +33,5 @@ pip install gradata
 python examples/with_claude_code.py
 ```
 
-For the zero-code install, see [.claude-plugin/README.md](../.claude-plugin/README.md).
+For the zero-code install, run `gradata install --agent claude-code` — see the
+top-level [README](../README.md#install-for-claude-code) for details.

--- a/Gradata/examples/with_claude_code.py
+++ b/Gradata/examples/with_claude_code.py
@@ -1,9 +1,8 @@
 """Using Gradata alongside Claude Code.
 
-With the Claude Code plugin installed (`/plugin install gradata`),
-corrections on `Edit` / `Write` tool calls are captured automatically and
-graduated rules are injected into every session. No code is needed in the
-hot path.
+With `gradata install --agent claude-code` run once, corrections on `Edit` /
+`Write` tool calls are captured automatically and graduated rules are
+injected into every session. No code is needed in the hot path.
 
 This example is the manual equivalent: the same `Brain` API the hooks use,
 run directly so you can inspect what gets stored and what would be injected.
@@ -11,7 +10,8 @@ run directly so you can inspect what gets stored and what would be injected.
 Run:
     python examples/with_claude_code.py
 
-See also: .claude-plugin/README.md for the zero-code install flow.
+See also: the README's "Install for Claude Code" section for the zero-code
+install flow.
 """
 
 from pathlib import Path


### PR DESCRIPTION
## Summary

Final cleanup of the kill-the-plugin epic (GRA-1198 / GH #206). The `.claude-plugin/` directory itself was already removed in a prior cleanup (CHANGELOG: 'Remove orphaned gradata-plugin/ subdir (#54)'). What remained were stale string references in docs and examples now that the SDK ships all subcommands directly via PRs #208/#209/#210/#211 + #213.

## Changes

- `.dockerignore`: removed dead `.claude-plugin` exclude line
- `examples/with_claude_code.py`: replaced `/plugin install gradata` language with the canonical `gradata install --agent claude-code`
- `examples/README.md`: fixed broken link to `.claude-plugin/README.md`
- `CHANGELOG.md`: BREAKING entry under Unreleased

## Breaking change

Anyone who installed via the `/plugin marketplace add Gradata/gradata` flow before 2026-05-20 must migrate:

```bash
pipx install gradata
gradata install --agent claude-code --brain ~/.gradata/brain
```

This is communicated via:
- CHANGELOG.md `### Breaking` entry (this PR)
- README.md single-install-path section (PR #211, merged)
- Issue archive notice on Gradata/gradata-plugin (planned in GRA-1250)

## Verification

```
pip install /home/olive/work/gradata-sdk/Gradata   # in fresh venv
gradata install --agent claude-code --brain /tmp/test-brain --help
# both succeed
```

```
pytest tests/ -x -q   →  816 passed, 7 skipped, 1 pre-existing failure
# pre-existing failure: tests/test_byo_key_provider.py needs httpx (dev env, not this PR)
```

```
ruff check examples/with_claude_code.py pyproject.toml   →  All checks passed
grep -r 'claude-plugin\|gradata-plugin' src/ docs/   →  only intentional CHANGELOG hits
```

## Epic context

GRA-1198 (kill the plugin) / GH #206. This is the last reference scrub. Companion PR for archiving the standalone Gradata/gradata-plugin repo: GRA-1250.

## Authoring note

Started by a delegate_task subagent (hit max_iterations on PR-open); parent agent verified the diff was clean (extracted via git stash since 3 subagents ran in parallel on the same workdir), tested, committed, pushed, opened PR.