### PR TITLE
fix(tests): isolate cloud-sync HOME so dev ~/.gradata/key doesn't leak (closes #216)

### DIFF
--- a/Gradata/tests/test_cloud_sync.py
+++ b/Gradata/tests/test_cloud_sync.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from gradata.cloud.sync import (
     CloudClient,
     CloudConfig,
@@ -98,6 +100,30 @@ class TestCloudConfig:
 
 
 class TestCloudClient:
+    @pytest.fixture(autouse=True)
+    def isolate_credential_resolution(self, monkeypatch, tmp_path):
+        """Prevent dev's real ~/.gradata/key from leaking into these tests.
+
+        CloudClient.enabled falls through to _resolved_credential() which
+        reads ~/.gradata/key. Without isolation, any dev who has actually
+        used Gradata locally would see test_client_disabled_* tests fail.
+        See GitHub issue #216.
+
+        The keyfile module captures ``Path.home() / ".gradata" / "key"`` at
+        import time, so just setting $HOME isn't enough — we redirect the
+        module-level KEYFILE_PATH/KEYFILE_DIR directly.
+        """
+        from gradata.cloud import _credentials
+
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.delenv("GRADATA_API_KEY", raising=False)
+        monkeypatch.setattr(_credentials, "KEYFILE_DIR", fake_home / ".gradata")
+        monkeypatch.setattr(
+            _credentials, "KEYFILE_PATH", fake_home / ".gradata" / "key"
+        )
+
     def test_client_disabled_by_default(self, tmp_path: Path):
         client = CloudClient(tmp_path)
         assert client.enabled is False


### PR DESCRIPTION
## Summary

Closes #216.

`CloudClient.enabled` falls through to `_resolved_credential()`, which reads `~/.gradata/key`. The `TestCloudClient` fixtures didn't isolate `HOME`, so on any dev machine that had run `gradata cloud enable`, the real keyfile leaked into the test and two 'should-be-disabled' assertions failed:

- `TestCloudClient::test_client_disabled_by_default`
- `TestCloudClient::test_client_disabled_without_token`

This PR adds an autouse fixture on `TestCloudClient` that:

1. Points `HOME` at a per-test tmp dir
2. Drops `GRADATA_API_KEY` from the env
3. Redirects the module-level `KEYFILE_DIR` / `KEYFILE_PATH` in `gradata.cloud._credentials` (those are captured at import time via `Path.home()`, so `HOME` alone isn't sufficient)

## Test plan

- `pytest tests/test_cloud_sync.py` on a dev box with a populated `~/.gradata/key` → **21 passed** (was 19 passed / 2 failed).
- Tests that need `enabled=True` still pass because they set an explicit `CloudConfig.token`, which short-circuits the keyfile lookup before `_resolved_credential()` is consulted.
- No CI regression risk: CI doesn't have `~/.gradata/key`, so it already passed; behavior unchanged there.

## Layering check

No layering impact — test-only change. No new imports into `src/gradata/`.

## Risk

None. Test-isolation fix only. No production code touched.