### PR TITLE
experiment(gra-217): tighten graduation dedup threshold 0.85→0.78

### DIFF
--- a/Gradata/src/gradata/enhancements/self_improvement/_confidence.py
+++ b/Gradata/src/gradata/enhancements/self_improvement/_confidence.py
@@ -136,7 +136,7 @@ MACHINE_SEVERITY_WEIGHTS: dict[str, float] = {
 }
 
 # Graduation gate thresholds
-_GRADUATION_DEDUP_THRESHOLD = 0.85  # Near-duplicate rule detection
+_GRADUATION_DEDUP_THRESHOLD = 0.78  # Near-duplicate rule detection (GRA-217: tightened from 0.85)
 
 # Per-step compound-penalty ceiling.
 # gap-analysis/01-internal-audit.md #1.3: without a cap, a single rewrite


### PR DESCRIPTION
## Summary

Lab experiment GRA-217: `noise_correction_filter_rate`

**Hypothesis:** Tightening `_GRADUATION_DEDUP_THRESHOLD` from 0.85 to 0.78 catches more near-duplicate corrections at graduation time without losing distinct signals — raising the noise correction filter rate.

**Change:** `src/gradata/enhancements/self_improvement/_confidence.py` line 139
- Before: `_GRADUATION_DEDUP_THRESHOLD = 0.85`
- After: `_GRADUATION_DEDUP_THRESHOLD = 0.78`

**Mechanism:** In `_graduation.py`, this threshold gates whether a candidate RULE lesson is blocked as a near-duplicate of an existing rule via semantic vector similarity. Lowering from 0.85 to 0.78 means lessons with ≥0.78 cosine similarity (vs prior ≥0.85) are now filtered — a wider net that should catch more redundant near-duplicates while still allowing genuinely distinct signals through.

**Metric direction:** higher (more noise filtered = better)
**Measurement window:** 7 days
**Lead:** analyst (GRA-217)

Closes: GRA-217