### PR TITLE
docs: add SDK/CLI quickstart smoke path

### DIFF
--- a/Gradata/README.md
+++ b/Gradata/README.md
@@ -103,7 +103,7 @@ Install Gradata, create a brain, then attach it to the agent you use every day:
 pip install gradata
 gradata init ./my-brain
 gradata install --agent claude-code --brain ./my-brain
-gradata audit
+gradata --brain-dir ./my-brain audit
 ```
 
 Supported agent targets:
@@ -122,6 +122,13 @@ Once installed, Gradata recalls relevant behavioral rules before tool use. You c
 
 ```bash
 gradata recall "drafting cold email to PE-backed ecommerce CMO" --max-tokens 2000
+```
+
+To verify the onboarding path without cloud credentials or mutating your real
+agent config, run the offline smoke script from a source checkout:
+
+```bash
+PYTHONPATH=src python examples/offline_quickstart_smoke.py
 ```
 
 ## Bring your own API key

--- a/Gradata/docs/getting-started/install.md
+++ b/Gradata/docs/getting-started/install.md
@@ -93,12 +93,31 @@ Environment variables:
 
 ---
 
+## Attach an agent
+
+After creating a brain, wire it into the agent you use every day:
+
+```bash
+gradata install --agent claude-code --brain ./my-brain
+```
+
+Supported targets are `claude-code`, `codex`, `gemini`, `cursor`, `hermes`,
+`opencode`, and `all`.
+
 ## Verify
 
 ```bash
 gradata --help
-gradata doctor            # environment health check
-gradata stats             # show brain stats
+gradata --brain-dir ./my-brain doctor --no-cloud  # environment health check
+gradata --brain-dir ./my-brain stats              # show brain stats
+gradata --brain-dir ./my-brain audit              # data-flow audit
+```
+
+For a non-mutating offline smoke test that exercises init, agent-install dry
+run, correction, recall, stats, and audit:
+
+```bash
+PYTHONPATH=src python examples/offline_quickstart_smoke.py
 ```
 
 From Python:

--- a/Gradata/examples/README.md
+++ b/Gradata/examples/README.md
@@ -25,8 +25,8 @@ python examples/with_openai.py
 
 ## with_claude_code.py
 
-Manual walkthrough of what the Claude Code plugin does automatically —
-same `Brain.correct()` / `Brain.apply_brain_rules()` API the hooks call.
+Manual walkthrough of what the Claude Code hooks do automatically —
+same `Brain.correct()` / `Brain.apply_brain_rules()` API the agent integration calls.
 
 ```bash
 pip install gradata
@@ -34,4 +34,4 @@ python examples/with_claude_code.py
 ```
 
 For the zero-code install, run `gradata install --agent claude-code` — see the
-top-level [README](../README.md#install-for-claude-code) for details.
+top-level [README](../README.md#quickstart) for details.

--- a/Gradata/examples/offline_quickstart_smoke.py
+++ b/Gradata/examples/offline_quickstart_smoke.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Offline smoke test for the public Gradata quickstart.
+
+This script exercises the install/onboarding path without network access or
+external credentials. Run it from a source checkout with `PYTHONPATH=src`, or
+after installing the package with `pip install gradata`.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def run(args: list[str], *, env: dict[str, str]) -> str:
+    cmd = [sys.executable, "-m", "gradata.cli", *args]
+    print("$ " + " ".join(cmd))
+    proc = subprocess.run(
+        cmd,
+        check=False,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    print(proc.stdout.strip())
+    if proc.returncode != 0:
+        raise SystemExit(proc.returncode)
+    return proc.stdout
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="gradata-quickstart-") as tmp:
+        root = Path(tmp)
+        brain = root / "my-brain"
+        home = root / "home"
+        home.mkdir()
+
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        env["GRADATA_BRAIN_DIR"] = str(brain)
+        env.setdefault("GRADATA_LOG", "WARNING")
+
+        run(["--help"], env=env)
+        run(["init", str(brain), "--domain", "Smoke", "--name", "Quickstart Smoke", "--no-interactive"], env=env)
+        run(["--brain-dir", str(brain), "install", "--agent", "claude-code", "--brain", str(brain), "--dry-run"], env=env)
+        run([
+            "--brain-dir",
+            str(brain),
+            "correct",
+            "--draft",
+            "We are pleased to inform you of our new product offering.",
+            "--final",
+            "Hey, check out what we just shipped.",
+        ], env=env)
+        run(["--brain-dir", str(brain), "recall", "draft a launch email", "--max-tokens", "400"], env=env)
+        run(["--brain-dir", str(brain), "stats"], env=env)
+        run(["--brain-dir", str(brain), "audit"], env=env)
+
+        if not (brain / "system.db").exists():
+            raise SystemExit(f"missing expected brain database: {brain / 'system.db'}")
+
+    print("✓ offline quickstart smoke passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- adds `examples/offline_quickstart_smoke.py` to verify the public SDK/CLI quickstart without network credentials or real agent-config mutation
- fixes README quickstart to pass `--brain-dir ./my-brain` to audit
- updates install docs with the agent attach step and docs-ready smoke command
- replaces active “Claude Code plugin” wording in examples with SDK/CLI hook/integration language

## Verification
- `PYTHONPATH=src python3 examples/offline_quickstart_smoke.py` → passed, including init, `install --agent claude-code --dry-run`, correction, recall, stats, audit
- `python3 -m py_compile examples/offline_quickstart_smoke.py`
- `PYTHONPATH=src python3 -m pytest -q tests/test_cli.py tests/test_cli_install_agent.py` → 29 passed, 2 warnings

Paperclip: GRA-1781
