### PR TITLE
fix(install): add PostToolUse/Stop/PreCompact/UserPromptSubmit hooks to Claude Code adapter

### DIFF
--- a/Gradata/src/gradata/hooks/adapters/_base.py
+++ b/Gradata/src/gradata/hooks/adapters/_base.py
@@ -136,6 +136,34 @@ def hook_command(brain_dir: Path) -> str:
     )
 
 
+def auto_correct_command(brain_dir: Path) -> str:
+    return (
+        f"BRAIN_DIR={shlex.quote(str(brain_dir))} "
+        f"{shlex.quote(sys.executable)} -m gradata.hooks.auto_correct"
+    )
+
+
+def session_close_command(brain_dir: Path) -> str:
+    return (
+        f"BRAIN_DIR={shlex.quote(str(brain_dir))} "
+        f"{shlex.quote(sys.executable)} -m gradata.hooks.session_close"
+    )
+
+
+def pre_compact_command(brain_dir: Path) -> str:
+    return (
+        f"BRAIN_DIR={shlex.quote(str(brain_dir))} "
+        f"{shlex.quote(sys.executable)} -m gradata.hooks.pre_compact"
+    )
+
+
+def context_inject_command(brain_dir: Path) -> str:
+    return (
+        f"BRAIN_DIR={shlex.quote(str(brain_dir))} "
+        f"{shlex.quote(sys.executable)} -m gradata.hooks.context_inject"
+    )
+
+
 def mcp_command(brain_dir: Path) -> list[str]:
     return [sys.executable, "-m", "gradata.mcp_server", "--brain-dir", str(brain_dir)]
 

--- a/Gradata/src/gradata/hooks/adapters/claude_code.py
+++ b/Gradata/src/gradata/hooks/adapters/claude_code.py
@@ -7,11 +7,15 @@ from gradata.hooks.adapters._base import (
     WRITE_TOOL_ALIASES,
     InstallResult,
     _normalize_tool_name,
+    auto_correct_command,
+    context_inject_command,
     extract_from_edit_args,
     extract_from_write_args,
     failure,
     hook_command,
     hook_signature,
+    pre_compact_command,
+    session_close_command,
     read_json,
     write_json,
 )
@@ -58,24 +62,84 @@ def install(brain_dir: Path, agent_config_path: Path) -> InstallResult:
         data = read_json(agent_config_path)
         hooks = data.setdefault("hooks", {})
         pre_tool = hooks.setdefault("PreToolUse", [])
-        if any(sig in str(item) for item in pre_tool):
+        post_tool = hooks.setdefault("PostToolUse", [])
+        stop = hooks.setdefault("Stop", [])
+        pre_compact = hooks.setdefault("PreCompact", [])
+        user_prompt = hooks.setdefault("UserPromptSubmit", [])
+        has_pre_tool = any(sig in str(item) for item in pre_tool)
+        has_post_tool = any(sig in str(item) for item in post_tool)
+        has_stop = any(sig in str(item) for item in stop)
+        has_pre_compact = any(sig in str(item) for item in pre_compact)
+        has_user_prompt = any(sig in str(item) for item in user_prompt)
+        if has_pre_tool and has_post_tool and has_stop and has_pre_compact and has_user_prompt:
             return InstallResult(
                 AGENT, agent_config_path, "already_present", "hook already present"
             )
-        pre_tool.append(
-            {
-                "matcher": "*",
-                "hooks": [
-                    {
-                        "type": "command",
-                        "command": hook_command(brain_dir),
-                        "id": sig,
-                    }
-                ],
-            }
-        )
+        if not has_pre_tool:
+            pre_tool.append(
+                {
+                    "matcher": "*",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": hook_command(brain_dir),
+                            "id": sig,
+                        }
+                    ],
+                }
+            )
+        if not has_post_tool:
+            post_tool.append(
+                {
+                    "matcher": "Edit|Write",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": auto_correct_command(brain_dir),
+                            "id": sig,
+                        }
+                    ],
+                }
+            )
+        if not has_stop:
+            stop.append(
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": session_close_command(brain_dir),
+                            "id": sig,
+                        }
+                    ],
+                }
+            )
+        if not has_pre_compact:
+            pre_compact.append(
+                {
+                    "matcher": "manual|auto",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": pre_compact_command(brain_dir),
+                            "id": sig,
+                        }
+                    ],
+                }
+            )
+        if not has_user_prompt:
+            user_prompt.append(
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": context_inject_command(brain_dir),
+                            "id": sig,
+                        }
+                    ],
+                }
+            )
         write_json(agent_config_path, data)
-        return InstallResult(AGENT, agent_config_path, "added", "installed PreToolUse hook")
+        return InstallResult(AGENT, agent_config_path, "added", "installed Claude Code hooks")
     except Exception as exc:
         return failure(AGENT, agent_config_path, exc)
 
@@ -98,27 +162,32 @@ def uninstall(brain_dir: Path, agent_config_path: Path) -> InstallResult:
         hooks = data.get("hooks")
         if not isinstance(hooks, dict):
             return InstallResult(AGENT, agent_config_path, "already_present", "no hooks block")
-        pre_tool = hooks.get("PreToolUse")
-        if not isinstance(pre_tool, list):
-            return InstallResult(AGENT, agent_config_path, "already_present", "no PreToolUse")
-
         removed = 0
-        kept: list = []
-        for entry in pre_tool:
-            entry_str = str(entry)
-            if sig in entry_str:
-                # Either the entry's `hooks[].id` carries our sig, or the
-                # whole entry was ours. Drop it.
-                removed += 1
+        for lifecycle in (
+            "PreToolUse",
+            "PostToolUse",
+            "Stop",
+            "PreCompact",
+            "UserPromptSubmit",
+        ):
+            entries = hooks.get(lifecycle)
+            if not isinstance(entries, list):
                 continue
-            kept.append(entry)
+            kept: list = []
+            for entry in entries:
+                entry_str = str(entry)
+                if sig in entry_str:
+                    # Either the entry's `hooks[].id` carries our sig, or the
+                    # whole entry was ours. Drop it.
+                    removed += 1
+                    continue
+                kept.append(entry)
+            if kept:
+                hooks[lifecycle] = kept
+            else:
+                hooks.pop(lifecycle, None)
         if removed == 0:
             return InstallResult(AGENT, agent_config_path, "already_present", "hook not present")
-
-        if kept:
-            hooks["PreToolUse"] = kept
-        else:
-            hooks.pop("PreToolUse", None)
         if not hooks:
             data.pop("hooks", None)
         write_json(agent_config_path, data)

--- a/Gradata/tests/test_hook_adapters.py
+++ b/Gradata/tests/test_hook_adapters.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import tomllib
 from pathlib import Path
@@ -43,13 +44,36 @@ def test_codex_adapter_writes_valid_toml_with_quoted_brain_path(tmp_path: Path) 
 
     assert result.action == "added"
     parsed = tomllib.loads(config_path.read_text(encoding="utf-8"))
-    hook = parsed["hooks"]["pre_tool"][0]
+    hooks = parsed["hooks"]
+    hook = hooks["pre_tool"][0]
+    assert set(hooks) >= {"pre_tool", "post_tool", "session_end"}
     assert hook["id"].startswith("gradata:codex:")
     # Round-trip: the brain dir must appear in the hook id (which is
     # build-from-brain-dir before any shell-escaping).
     # Adapter normalizes to POSIX path for cross-platform stable signature,
     # so compare against as_posix() not raw str() (Windows uses backslashes).
     assert brain_dir.as_posix() in hook["id"]
+    assert "gradata.hooks.inject_brain_rules" in hooks["pre_tool"][0]["command"]
+    assert "gradata.hooks.auto_correct" in hooks["post_tool"][0]["command"]
+    assert "gradata.hooks.session_close" in hooks["session_end"][0]["command"]
+
+
+def test_opencode_adapter_writes_pre_post_and_session_hooks(tmp_path: Path) -> None:
+    brain_dir = tmp_path / "brain"
+    brain_dir.mkdir()
+    config_path = tmp_path / ".config" / "opencode" / "config.json"
+
+    adapter = get_adapter("opencode")
+    first = adapter.install(brain_dir, config_path)
+    second = adapter.install(brain_dir, config_path)
+
+    assert first.action == "added"
+    assert second.action == "already_present"
+    hooks = json.loads(config_path.read_text(encoding="utf-8"))["hooks"]
+    assert set(hooks) >= {"preTool", "postTool", "sessionEnd"}
+    assert "gradata.hooks.inject_brain_rules" in hooks["preTool"][0]["command"]
+    assert "gradata.hooks.auto_correct" in hooks["postTool"][0]["command"]
+    assert "gradata.hooks.session_close" in hooks["sessionEnd"][0]["command"]
 
 
 def test_adapter_install_does_not_touch_real_user_config(tmp_path: Path) -> None:
@@ -63,3 +87,26 @@ def test_adapter_install_does_not_touch_real_user_config(tmp_path: Path) -> None
     assert result.action == "added"
     after = real_config.read_text(encoding="utf-8") if real_config.exists() else None
     assert after == before
+
+
+def test_claude_code_install_writes_pre_compact_entry(tmp_path: Path) -> None:
+    brain_dir = tmp_path / "brain"
+    brain_dir.mkdir()
+    config_path = tmp_path / ".claude" / "settings.json"
+
+    adapter = get_adapter("claude-code")
+    first = adapter.install(brain_dir, config_path)
+    second = adapter.install(brain_dir, config_path)
+
+    assert first.action == "added"
+    assert second.action == "already_present"
+    settings = json.loads(config_path.read_text(encoding="utf-8"))
+    pre_compact = settings["hooks"]["PreCompact"]
+    commands = [
+        hook.get("command", "")
+        for entry in pre_compact
+        for hook in entry.get("hooks", [])
+    ]
+    assert len(pre_compact) == 1
+    assert any("BRAIN_DIR=" in command for command in commands)
+    assert any("gradata.hooks.pre_compact" in command for command in commands)


### PR DESCRIPTION
Closes GRA-1233

## Problem
`gradata install --agent claude-code` only installed PreToolUse hooks. PostToolUse auto_correct was missing — no correction capture on install.

## Fix
- Added `auto_correct_command`, `session_close_command`, `pre_compact_command`, `context_inject_command` to `_base.py`
- Updated `claude_code.py install()` to write all 5 lifecycle hooks with per-lifecycle idempotency
- Updated `uninstall()` to clean all 5 instead of just PreToolUse

## Test
`test_hook_adapters.py` — 10/10 pass, including `test_claude_code_install_writes_pre_compact_entry`