### PR TITLE
fix: include rule identity in graduation events

### DIFF
--- a/Gradata/src/gradata/enhancements/self_improvement/_graduation.py
+++ b/Gradata/src/gradata/enhancements/self_improvement/_graduation.py
@@ -8,6 +8,7 @@ All constants are imported from _confidence to avoid duplication.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 
 from gradata._types import (
@@ -65,9 +66,22 @@ def _emit_rule_graduated(
     back to the module-level ``gradata._events.emit`` which uses globals
     rewired by tests/conftest.
     """
+    category = getattr(lesson, "category", "") or ""
+    description = getattr(lesson, "description", "") or ""
+    source_correction_ids = list(getattr(lesson, "correction_event_ids", []) or [])
+    source_correction_id = source_correction_ids[0] if source_correction_ids else None
+    rule_id_seed = f"{category}:{description}"
+    rule_id = hashlib.sha256(rule_id_seed.encode("utf-8")).hexdigest()[:16]
     payload = {
-        "category": getattr(lesson, "category", "") or "",
-        "description": getattr(lesson, "description", "") or "",
+        # Provenance fields required by downstream rule-file materializers.
+        "rule_id": rule_id,
+        "pattern": description,
+        "source_correction_id": source_correction_id,
+        "source_correction_ids": source_correction_ids,
+        "lesson_description": description,
+        # Existing fields retained for backwards compatibility.
+        "category": category,
+        "description": description,
         "old_state": getattr(old_state, "name", str(old_state)),
         "new_state": getattr(new_state, "name", str(new_state)),
         "confidence": float(getattr(lesson, "confidence", 0.0)),

--- a/Gradata/tests/test_graduation_notification.py
+++ b/Gradata/tests/test_graduation_notification.py
@@ -2,7 +2,54 @@
 
 from __future__ import annotations
 
+from gradata._types import Lesson, LessonState
 from gradata.brain import Brain
+from gradata.enhancements.self_improvement._graduation import _emit_rule_graduated
+
+
+def test_rule_graduated_event_includes_rule_identity_payload():
+    """RULE_GRADUATED carries provenance needed by rule-file materializers."""
+
+    class FakeBrain:
+        def __init__(self):
+            self.calls = []
+
+        def emit(self, event_type, source, data, tags):
+            self.calls.append((event_type, source, data, tags))
+
+    brain = FakeBrain()
+    lesson = Lesson(
+        date="2026-06-03",
+        state=LessonState.RULE,
+        confidence=0.95,
+        category="PROCESS",
+        description="Always verify work before reporting done",
+        fire_count=5,
+        correction_event_ids=["evt_correction_123"],
+    )
+
+    _emit_rule_graduated(
+        lesson,
+        LessonState.PATTERN,
+        LessonState.RULE,
+        "pattern_to_rule",
+        brain=brain,
+    )
+
+    assert len(brain.calls) == 1
+    event_type, source, payload, tags = brain.calls[0]
+    assert event_type == "RULE_GRADUATED"
+    assert source == "graduate"
+    assert tags == []
+    assert payload["rule_id"]
+    assert payload["pattern"] == "Always verify work before reporting done"
+    assert payload["lesson_description"] == "Always verify work before reporting done"
+    assert payload["source_correction_id"] == "evt_correction_123"
+    assert payload["source_correction_ids"] == ["evt_correction_123"]
+    assert payload["category"] == "PROCESS"
+    assert payload["description"] == "Always verify work before reporting done"
+    assert payload["old_state"] == "PATTERN"
+    assert payload["new_state"] == "RULE"
 
 
 def test_graduation_event_emitted_on_pattern_promotion(tmp_path):

--- a/Gradata/tests/test_graduation_notification.py
+++ b/Gradata/tests/test_graduation_notification.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+
 from gradata._types import Lesson, LessonState
 from gradata.brain import Brain
 from gradata.enhancements.self_improvement._graduation import _emit_rule_graduated
@@ -36,12 +38,16 @@ def test_rule_graduated_event_includes_rule_identity_payload():
         brain=brain,
     )
 
+    expected_rule_id = hashlib.sha256(
+        b"PROCESS:Always verify work before reporting done"
+    ).hexdigest()[:16]
+
     assert len(brain.calls) == 1
     event_type, source, payload, tags = brain.calls[0]
     assert event_type == "RULE_GRADUATED"
     assert source == "graduate"
     assert tags == []
-    assert payload["rule_id"]
+    assert payload["rule_id"] == expected_rule_id
     assert payload["pattern"] == "Always verify work before reporting done"
     assert payload["lesson_description"] == "Always verify work before reporting done"
     assert payload["source_correction_id"] == "evt_correction_123"
@@ -50,6 +56,9 @@ def test_rule_graduated_event_includes_rule_identity_payload():
     assert payload["description"] == "Always verify work before reporting done"
     assert payload["old_state"] == "PATTERN"
     assert payload["new_state"] == "RULE"
+    assert payload["confidence"] == 0.95
+    assert payload["fire_count"] == 5
+    assert payload["reason"] == "pattern_to_rule"
 
 
 def test_graduation_event_emitted_on_pattern_promotion(tmp_path):


### PR DESCRIPTION
Fixes GRA-2050.

Changes:
- Adds rule identity/provenance fields to RULE_GRADUATED event payloads:
  - rule_id
  - pattern
  - source_correction_id
  - source_correction_ids
  - lesson_description
- Preserves existing category/description/state/confidence/fire_count fields.
- Adds a regression test for the required payload shape.

Verification:
- python3 -m pytest tests/test_graduation_notification.py tests/test_brain_events.py::TestBrainEmit::test_data_payload_stored -q
  - 6 passed in 8.52s
- python3 -m pytest tests/test_graduation_notification.py tests/test_brain_events.py tests/test_brain_pipeline.py tests/test_pattern_graduation_integration.py -q
  - 92 passed, 2 warnings in 37.46s
