### PR TITLE
fix: materialize graduated rule files

### DIFF
--- a/Gradata/src/gradata/enhancements/rule_file_materializer.py
+++ b/Gradata/src/gradata/enhancements/rule_file_materializer.py
@@ -1,0 +1,129 @@
+"""Materialize graduated RULE events into brain/rules/*.json files.
+
+RULE_GRADUATED events are the transition log; these JSON files are the durable
+per-rule artifacts consumed by lightweight injectors/exporters. The writer is
+best-effort and idempotent: repeat emissions for the same rule_id overwrite the
+same file atomically.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from gradata._atomic import atomic_write_json
+
+_log = logging.getLogger(__name__)
+
+
+def rule_id_for(category: str, pattern: str) -> str:
+    """Return the stable rule id used by RULE_GRADUATED payloads."""
+    return hashlib.sha256(f"{category}:{pattern}".encode("utf-8")).hexdigest()[:16]
+
+
+def _coerce_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _record_from_payload(payload: dict, *, session: int | None = None) -> dict | None:
+    """Build the canonical rules/<rule_id>.json record from an event payload."""
+    if (payload.get("new_state") or "") != "RULE":
+        return None
+
+    category = str(payload.get("category") or "GENERAL")
+    pattern = str(payload.get("pattern") or payload.get("description") or "").strip()
+    if not pattern:
+        return None
+
+    rule_id = str(payload.get("rule_id") or rule_id_for(category, pattern))
+    source_ids = payload.get("source_correction_ids") or []
+    if not isinstance(source_ids, list):
+        source_ids = [source_ids]
+    source_id = payload.get("source_correction_id") or (source_ids[0] if source_ids else None)
+
+    graduation = {
+        "old_state": payload.get("old_state"),
+        "new_state": payload.get("new_state"),
+        "reason": payload.get("reason"),
+        "confidence": _coerce_float(payload.get("confidence")),
+        "fire_count": _coerce_int(payload.get("fire_count")),
+        "graduated_at": datetime.now(UTC).isoformat(),
+    }
+    if session is not None:
+        graduation["session"] = session
+
+    return {
+        "schema_version": 1,
+        "rule_id": rule_id,
+        "pattern": pattern,
+        "category": category,
+        "source": payload.get("source") or "graduate",
+        "source_correction_id": source_id,
+        "source_correction_ids": source_ids,
+        "lesson_description": payload.get("lesson_description") or pattern,
+        "confidence": graduation["confidence"],
+        "fire_count": graduation["fire_count"],
+        "graduation": graduation,
+    }
+
+
+def write_rule_file(payload: dict, brain_dir: str | Path, *, session: int | None = None) -> Path | None:
+    """Write brain/rules/<rule_id>.json for PATTERN->RULE graduations.
+
+    Returns the written path, or None if the payload is not a RULE graduation or
+    cannot be materialized. Never raises; callers should treat this as a
+    best-effort side effect of the graduation event.
+    """
+    try:
+        record = _record_from_payload(payload, session=session)
+        if record is None:
+            return None
+        path = Path(brain_dir) / "rules" / f"{record['rule_id']}.json"
+        atomic_write_json(path, record, indent=2)
+        return path
+    except Exception as exc:  # pragma: no cover - defensive best-effort guard
+        _log.debug("rule file materialization failed: %s", exc)
+        return None
+
+
+def write_rule_file_for_lesson(
+    lesson: Any,
+    brain_dir: str | Path,
+    *,
+    old_state: Any,
+    reason: str,
+    session: int | None = None,
+) -> Path | None:
+    """Materialize a just-graduated Lesson without requiring an event payload."""
+    category = getattr(lesson, "category", "") or ""
+    pattern = getattr(lesson, "description", "") or ""
+    source_ids = list(getattr(lesson, "correction_event_ids", []) or [])
+    payload = {
+        "rule_id": rule_id_for(category, pattern),
+        "pattern": pattern,
+        "source_correction_id": source_ids[0] if source_ids else None,
+        "source_correction_ids": source_ids,
+        "lesson_description": pattern,
+        "category": category,
+        "description": pattern,
+        "old_state": getattr(old_state, "name", str(old_state)),
+        "new_state": getattr(getattr(lesson, "state", None), "name", str(getattr(lesson, "state", ""))),
+        "confidence": getattr(lesson, "confidence", 0.0),
+        "fire_count": getattr(lesson, "fire_count", 0),
+        "reason": reason,
+        "source": "graduate",
+    }
+    return write_rule_file(payload, brain_dir, session=session)

--- a/Gradata/src/gradata/enhancements/rule_pipeline.py
+++ b/Gradata/src/gradata/enhancements/rule_pipeline.py
@@ -436,11 +436,27 @@ def run_rule_pipeline(
     pre_states = {id(l): l.state for l in all_lessons}
     _graduate(all_lessons)
     for lesson in all_lessons:
-        if pre_states.get(id(lesson)) != lesson.state and lesson.state in (
+        old_state = pre_states.get(id(lesson))
+        if old_state != lesson.state and lesson.state in (
             LessonState.PATTERN,
             LessonState.RULE,
         ):
             result.graduated.append(f"{lesson.category}:{lesson.description[:30]}")
+            if lesson.state == LessonState.RULE:
+                try:
+                    from gradata.enhancements.rule_file_materializer import (
+                        write_rule_file_for_lesson,
+                    )
+
+                    write_rule_file_for_lesson(
+                        lesson,
+                        lessons_path.parent,
+                        old_state=old_state,
+                        reason="pattern_to_rule",
+                        session=current_session,
+                    )
+                except Exception as exc:
+                    _log.debug("Phase 2: rule file materialization failed: %s", exc)
 
     # Synthesize meta-rules from graduated rules
     try:

--- a/Gradata/src/gradata/enhancements/self_improvement/_graduation.py
+++ b/Gradata/src/gradata/enhancements/self_improvement/_graduation.py
@@ -91,6 +91,11 @@ def _emit_rule_graduated(
     if brain is not None and hasattr(brain, "emit"):
         try:
             brain.emit("RULE_GRADUATED", "graduate", payload, [])
+            brain_dir = getattr(brain, "dir", None)
+            if brain_dir is not None:
+                from gradata.enhancements.rule_file_materializer import write_rule_file
+
+                write_rule_file(payload, brain_dir)
         except Exception as exc:
             # Do NOT fall through to the module-level emit here. ``brain.emit``
             # may have partially persisted (event written but bus publish

--- a/Gradata/tests/test_rule_file_materialization.py
+++ b/Gradata/tests/test_rule_file_materialization.py
@@ -1,0 +1,87 @@
+"""Regression tests for RULE_GRADUATED -> brain/rules/*.json materialization."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from gradata._types import Lesson, LessonState
+from gradata.enhancements.rule_pipeline import run_rule_pipeline
+from gradata.enhancements.self_improvement import format_lessons, graduate
+from tests.conftest import init_brain
+
+
+def _rule_id(category: str, description: str) -> str:
+    return hashlib.sha256(f"{category}:{description}".encode("utf-8")).hexdigest()[:16]
+
+
+def _pattern_to_rule_lesson() -> Lesson:
+    return Lesson(
+        date="2026-06-02",
+        state=LessonState.PATTERN,
+        confidence=0.95,
+        category="ACCURACY",
+        description="Always verify citations before submitting",
+        fire_count=8,
+        correction_event_ids=["evt_correction_1", "evt_correction_2"],
+    )
+
+
+def test_direct_pattern_to_rule_graduation_writes_rule_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("GRADATA_BETA_LB_GATE", "0")
+    brain = init_brain(tmp_path)
+    lesson = _pattern_to_rule_lesson()
+
+    graduate([lesson], brain=brain)
+
+    rid = _rule_id("ACCURACY", "Always verify citations before submitting")
+    rule_path = Path(brain.dir) / "rules" / f"{rid}.json"
+    assert rule_path.is_file()
+    data = json.loads(rule_path.read_text(encoding="utf-8"))
+    assert data["rule_id"] == rid
+    assert data["pattern"] == "Always verify citations before submitting"
+    assert data["category"] == "ACCURACY"
+    assert data["source"] == "graduate"
+    assert data["source_correction_id"] == "evt_correction_1"
+    assert data["source_correction_ids"] == ["evt_correction_1", "evt_correction_2"]
+    assert data["graduation"]["old_state"] == "PATTERN"
+    assert data["graduation"]["new_state"] == "RULE"
+    assert data["graduation"]["reason"] == "pattern_to_rule"
+
+
+def test_pipeline_pattern_to_rule_graduation_writes_rule_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("GRADATA_BETA_LB_GATE", "0")
+    lesson = _pattern_to_rule_lesson()
+    lessons_path = tmp_path / "lessons.md"
+    db_path = tmp_path / "system.db"
+    lessons_path.write_text(format_lessons([lesson]), encoding="utf-8")
+
+    result = run_rule_pipeline(lessons_path, db_path, current_session=99999)
+
+    assert result.graduated == ["ACCURACY:Always verify citations before"]
+    rid = _rule_id("ACCURACY", "Always verify citations before submitting")
+    rule_path = tmp_path / "rules" / f"{rid}.json"
+    assert rule_path.is_file()
+    data = json.loads(rule_path.read_text(encoding="utf-8"))
+    assert data["rule_id"] == rid
+    assert data["pattern"] == "Always verify citations before submitting"
+    assert data["graduation"]["session"] == 99999
+
+
+def test_instinct_to_pattern_does_not_write_rule_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("GRADATA_BETA_LB_GATE", "0")
+    brain = init_brain(tmp_path)
+    lesson = Lesson(
+        date="2026-06-02",
+        state=LessonState.INSTINCT,
+        confidence=0.75,
+        category="TONE",
+        description="Prefer short sentences in emails",
+        fire_count=5,
+    )
+
+    graduate([lesson], brain=brain)
+
+    rules_dir = Path(brain.dir) / "rules"
+    assert not rules_dir.exists() or list(rules_dir.glob("*.json")) == []


### PR DESCRIPTION
## Summary
- Add `rule_file_materializer` to write durable `brain/rules/<rule_id>.json` artifacts for PATTERN->RULE graduations.
- Wire both direct `graduate(..., brain=brain)` and session-close `run_rule_pipeline(...)` paths.
- Add regression coverage proving RULE graduations write files and INSTINCT->PATTERN does not.

## Tests
- `python3 -m py_compile src/gradata/enhancements/rule_file_materializer.py tests/test_rule_file_materialization.py`
- `git diff --check`
- `python3 -m pytest tests/test_rule_file_materialization.py tests/test_rule_graduated_events.py tests/test_rule_pipeline.py -q` (37 passed)

Paperclip: GRA-2048
