### PR TITLE
fix: auto-export AGENTS.md after graduation

### DIFF
--- a/Gradata/src/gradata/_core.py
+++ b/Gradata/src/gradata/_core.py
@@ -1014,6 +1014,23 @@ def brain_end_session(
         if all_lessons:  # guard against wiping lessons file when all lessons are killed
             write_lessons_safe(lessons_path, format_lessons(all_lessons))
 
+        # Product contract: post-graduation export is ON by default.  Any
+        # newly graduated RULE should be visible to agent runtimes without a
+        # manual `gradata export` step.  The exporter rewrites AGENTS.md from
+        # canonical RULE-tier lessons, so rerunning end_session is idempotent
+        # and cannot append duplicate entries.
+        agents_exported = False
+        if transitions:
+            try:
+                from gradata.enhancements.rule_export import DEFAULT_PATHS, export_rules
+
+                agents_text = export_rules(brain.dir, target="agents", lessons_path=lessons_path)
+                agents_path = brain.dir / DEFAULT_PATHS["agents"]
+                agents_path.write_text(agents_text, encoding="utf-8")
+                agents_exported = True
+            except Exception as e:
+                _log.debug("AGENTS.md auto-export failed: %s", e)
+
         # Archive graduated RULE lessons
         new_rules = [
             l
@@ -1126,6 +1143,7 @@ def brain_end_session(
             "kills": kills,
             "new_rules": [l.description[:60] for l in new_rules] if new_rules else [],
             "graduated_rules": graduated_rules,
+            "agents_exported": agents_exported,
             "meta_rules_discovered": meta_rules_discovered,
         }
 

--- a/Gradata/src/gradata/hooks/session_close.py
+++ b/Gradata/src/gradata/hooks/session_close.py
@@ -105,8 +105,20 @@ def _run_graduation(brain_dir: str) -> None:
         lessons = parse_lessons(text)
         if not lessons:
             return
-        active, _ = graduate(lessons)
-        lessons_path.write_text(format_lessons(active), encoding="utf-8")
+        active, graduated = graduate(lessons)
+        all_lessons = active + graduated
+        lessons_path.write_text(format_lessons(all_lessons), encoding="utf-8")
+        if graduated:
+            try:
+                from gradata.enhancements.rule_export import DEFAULT_PATHS, export_rules
+
+                agents_path = Path(brain_dir) / DEFAULT_PATHS["agents"]
+                agents_path.write_text(
+                    export_rules(Path(brain_dir), target="agents", lessons_path=lessons_path),
+                    encoding="utf-8",
+                )
+            except Exception as e:
+                _log.debug("AGENTS.md auto-export skipped: %s", e)
     except Exception as e:
         _log.debug("graduation skipped: %s", e)
 

--- a/Gradata/tests/test_graduation_notification.py
+++ b/Gradata/tests/test_graduation_notification.py
@@ -153,3 +153,33 @@ def test_rule_graduation_message(tmp_path):
     if rule_events:
         assert "permanent" in rule_events[0]["message"].lower()
         assert "confidence" in rule_events[0]["message"].lower()
+
+
+def test_rule_graduation_auto_exports_agents_md(tmp_path, monkeypatch):
+    """Synthetic PATTERN -> RULE graduation writes AGENTS.md by default, idempotently."""
+    monkeypatch.setenv("GRADATA_BETA_LB_GATE", "0")
+    (tmp_path / "lessons.md").write_text(
+        "# Lessons\n\n"
+        "[2026-06-03] [PATTERN:0.95] PROCESS: Always verify work before reporting done\n"
+        "  Root cause: User correction\n"
+        "  Fire count: 5 | Sessions since fire: 0 | Misfires: 0\n",
+        encoding="utf-8",
+    )
+    brain = Brain(str(tmp_path))
+
+    result = brain.end_session(session_corrections=[], skip_meta_rules=True)
+
+    agents_path = tmp_path / "AGENTS.md"
+    assert result["promotions"] == 1
+    assert result["agents_exported"] is True
+    assert agents_path.exists()
+    agents_text = agents_path.read_text(encoding="utf-8")
+    assert "# AGENTS.md" in agents_text
+    assert "## PROCESS" in agents_text
+    assert "- Always verify work before reporting done" in agents_text
+
+    # Re-running end_session rewrites from canonical RULE lessons rather than appending.
+    second = brain.end_session(session_corrections=[], skip_meta_rules=True)
+    assert second["promotions"] == 0
+    assert agents_path.read_text(encoding="utf-8") == agents_text
+    assert agents_text.count("Always verify work before reporting done") == 1

--- a/Gradata/tests/test_session_close_write_through_gate.py
+++ b/Gradata/tests/test_session_close_write_through_gate.py
@@ -7,6 +7,7 @@ to avoid double-writes. Only runs when GRADATA_DISABLE_WRITE_THROUGH=1.
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import patch
 
 from gradata.hooks import session_close
@@ -40,3 +41,26 @@ def test_run_cloud_sync_skipped_when_no_api_key(monkeypatch):
     with patch("gradata._core.cloud_sync_tick") as mock_tick:
         session_close._run_cloud_sync("/tmp/fake-brain", {"session_number": 1})
     mock_tick.assert_not_called()
+
+
+def test_run_graduation_exports_agents_md_for_new_rule(tmp_path: Path, monkeypatch):
+    """Session-close graduation smoke: synthetic RULE promotion populates AGENTS.md."""
+    monkeypatch.setenv("GRADATA_BETA_LB_GATE", "0")
+    (tmp_path / "lessons.md").write_text(
+        "# Lessons\n\n"
+        "[2026-06-03] [PATTERN:0.95] PROCESS: Always verify work before reporting done\n"
+        "  Root cause: User correction\n"
+        "  Fire count: 5 | Sessions since fire: 0 | Misfires: 0\n",
+        encoding="utf-8",
+    )
+
+    session_close._run_graduation(str(tmp_path))
+
+    lessons_text = (tmp_path / "lessons.md").read_text(encoding="utf-8")
+    agents_text = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+    assert "[RULE:0.95] PROCESS: Always verify work before reporting done" in lessons_text
+    assert "- Always verify work before reporting done" in agents_text
+
+    session_close._run_graduation(str(tmp_path))
+    assert (tmp_path / "AGENTS.md").read_text(encoding="utf-8") == agents_text
+    assert agents_text.count("Always verify work before reporting done") == 1


### PR DESCRIPTION
## Summary
- Decision: AGENTS.md auto-export is ON by default after graduation; no manual `gradata export` step required.
- Wire `brain_end_session` to rewrite `AGENTS.md` from canonical RULE-tier lessons after successful graduation persistence.
- Wire the session-close hook graduation path to preserve graduated RULE lessons and export `AGENTS.md` too.
- Add unit/hook smoke coverage proving synthetic graduation populates `AGENTS.md` idempotently.

## Verification
- `python3 -m pytest tests/test_graduation_notification.py::test_rule_graduation_auto_exports_agents_md tests/test_session_close_write_through_gate.py::test_run_graduation_exports_agents_md_for_new_rule tests/test_rule_export.py -q`
  - `23 passed in 3.24s`
- `/home/olive/.local/bin/uvx ruff check src/gradata/_core.py src/gradata/hooks/session_close.py tests/test_graduation_notification.py tests/test_session_close_write_through_gate.py`
  - `All checks passed!`
- `git diff --check`
  - clean

Closes GRA-27
