### PR TITLE
test: add pending approval drain regression

### DIFF
--- a/Gradata/src/gradata/hooks/session_close.py
+++ b/Gradata/src/gradata/hooks/session_close.py
@@ -90,7 +90,7 @@ def _has_new_triggers(brain_dir: Path, since: str | None, until: str) -> bool:
             row = conn.execute(sql, params).fetchone()
         return row is not None
     except sqlite3.Error as e:
-        _log.debug("trigger check failed: %s", e)
+        _log.debug("trigger check failed: %s", e, exc_info=True)
         return False
 
 
@@ -118,9 +118,9 @@ def _run_graduation(brain_dir: str) -> None:
                     encoding="utf-8",
                 )
             except Exception as e:
-                _log.debug("AGENTS.md auto-export skipped: %s", e)
+                _log.debug("AGENTS.md auto-export skipped: %s", e, exc_info=True)
     except Exception as e:
-        _log.debug("graduation skipped: %s", e)
+        _log.debug("graduation skipped: %s", e, exc_info=True)
 
 
 def _run_tree_consolidation(brain_dir: str) -> None:
@@ -154,7 +154,7 @@ def _run_tree_consolidation(brain_dir: str) -> None:
         if results["climbed"] > 0 or results["contracted"] > 0:
             lessons_path.write_text(format_lessons(lessons), encoding="utf-8")
     except Exception as e:
-        _log.debug("tree consolidation skipped: %s", e)
+        _log.debug("tree consolidation skipped: %s", e, exc_info=True)
 
 
 def _run_pipeline(brain_dir: str, data: dict) -> None:
@@ -179,7 +179,7 @@ def _run_pipeline(brain_dir: str, data: dict) -> None:
                 len(result.hooks_promoted),
             )
     except Exception as e:
-        _log.debug("pipeline skipped: %s", e)
+        _log.debug("pipeline skipped: %s", e, exc_info=True)
 
 
 def _resolve_pending_applications(brain_dir: str, data: dict) -> None:
@@ -281,7 +281,7 @@ def _resolve_pending_applications(brain_dir: str, data: dict) -> None:
             )
             conn.commit()
     except Exception as exc:
-        _log.debug("lesson_applications resolve skipped: %s", exc)
+        _log.debug("lesson_applications resolve skipped: %s", exc, exc_info=True)
 
 
 def _drain_pending_approvals(brain_dir: str, data: dict) -> None:
@@ -353,7 +353,7 @@ def _drain_pending_approvals(brain_dir: str, data: dict) -> None:
                 ctx=ctx,
             )
     except Exception as exc:
-        _log.debug("pending_approvals drain skipped: %s", exc)
+        _log.debug("pending_approvals drain skipped: %s", exc, exc_info=True)
 
 
 def _run_cloud_sync(brain_dir: str, data: dict) -> None:
@@ -383,7 +383,7 @@ def _run_cloud_sync(brain_dir: str, data: dict) -> None:
         session_num = int(data.get("session_number") or 0)
         cloud_sync_tick(brain_dir, session_num)
     except Exception as e:
-        _log.warning("cloud sync tick skipped: %s", e)
+        _log.warning("cloud sync tick skipped: %s", e, exc_info=True)
 
 
 def _flush_retain_queue(brain_dir: str) -> None:
@@ -395,7 +395,7 @@ def _flush_retain_queue(brain_dir: str) -> None:
         if result.get("written"):
             _log.info("RetainOrchestrator: flushed %d events", result["written"])
     except Exception as e:
-        _log.debug("retain flush skipped: %s", e)
+        _log.debug("retain flush skipped: %s", e, exc_info=True)
 
 
 def main(data: dict) -> dict | None:

--- a/Gradata/src/gradata/hooks/session_close.py
+++ b/Gradata/src/gradata/hooks/session_close.py
@@ -284,6 +284,78 @@ def _resolve_pending_applications(brain_dir: str, data: dict) -> None:
         _log.debug("lesson_applications resolve skipped: %s", exc)
 
 
+def _drain_pending_approvals(brain_dir: str, data: dict) -> None:
+    """Make unresolved pending_approvals visible to the session-end processor.
+
+    GRA-2060 found approval-gated corrections sitting in ``pending_approvals``
+    with no hook/processor path consuming the table. Human-review rows should
+    remain open, but they must not remain silent: each unresolved row gets an
+    idempotent ``PENDING_APPROVAL`` event so downstream surfaces can list or
+    alert on it.
+    """
+    try:
+        import json as _json
+
+        from gradata._events import emit
+        from gradata._paths import BrainContext
+
+        db = Path(brain_dir) / "system.db"
+        if not db.is_file():
+            return
+        session_num = int(data.get("session_number") or 0) or None
+        with sqlite3.connect(db) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                "SELECT id, lesson_category, lesson_description, severity, "
+                "correction_event_id, agent_type, created_at "
+                "FROM pending_approvals WHERE resolution IS NULL"
+            ).fetchall()
+            if not rows:
+                return
+
+            existing_payloads = conn.execute(
+                "SELECT data_json FROM events WHERE type = 'PENDING_APPROVAL'"
+            ).fetchall()
+            already_emitted: set[int] = set()
+            for (raw_payload,) in existing_payloads:
+                try:
+                    payload = (
+                        _json.loads(raw_payload) if isinstance(raw_payload, str) else raw_payload
+                    )
+                except (TypeError, _json.JSONDecodeError):
+                    continue
+                if isinstance(payload, dict):
+                    approval_id = payload.get("approval_id")
+                    if isinstance(approval_id, int):
+                        already_emitted.add(approval_id)
+
+        ctx = BrainContext.from_brain_dir(brain_dir)
+        for row in rows:
+            approval_id = int(row["id"])
+            if approval_id in already_emitted:
+                continue
+            emit(
+                "PENDING_APPROVAL",
+                "session_close.pending_approvals",
+                {
+                    "approval_id": approval_id,
+                    "status": "awaiting_human_review",
+                    "source_issue": "GRA-2060",
+                    "lesson_category": row["lesson_category"],
+                    "lesson_description": row["lesson_description"],
+                    "severity": row["severity"],
+                    "correction_event_id": row["correction_event_id"],
+                    "agent_type": row["agent_type"],
+                    "created_at": row["created_at"],
+                },
+                ["review", "pending_approval", "source_issue:GRA-2060"],
+                session=session_num,
+                ctx=ctx,
+            )
+    except Exception as exc:
+        _log.debug("pending_approvals drain skipped: %s", exc)
+
+
 def _run_cloud_sync(brain_dir: str, data: dict) -> None:
     """Push session telemetry + corrections to Gradata Cloud.
 
@@ -346,6 +418,7 @@ def main(data: dict) -> dict | None:
     _run_pipeline(brain_dir_str, data)
     _run_tree_consolidation(brain_dir_str)
     _resolve_pending_applications(brain_dir_str, data)
+    _drain_pending_approvals(brain_dir_str, data)
     _run_cloud_sync(brain_dir_str, data)
 
     _write_stamp(brain_dir, upper_bound)

--- a/Gradata/tests/test_pending_approvals_drain.py
+++ b/Gradata/tests/test_pending_approvals_drain.py
@@ -1,0 +1,75 @@
+"""Regression tests for GRA-2094 / GRA-2060 pending approval drain visibility."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sqlite3
+from pathlib import Path
+
+
+def test_session_close_drain_emits_review_event_for_public_correction_path(
+    tmp_path: Path, monkeypatch
+):
+    """GRA-2060: pending_approvals must not remain a silent dead-end forever.
+
+    The fixture captures a pending approval through the public Brain.correct()
+    path, runs the same session_close sweep used by hooks, then asserts the
+    processor creates an explicit terminal/visible state event for the pending
+    row. This prevents regressions where rows sit in pending_approvals with no
+    consumer reading them.
+    """
+    monkeypatch.delenv("BRAIN_DIR", raising=False)
+    monkeypatch.delenv("GRADATA_BRAIN", raising=False)
+    monkeypatch.delenv("GRADATA_BRAIN_DIR", raising=False)
+    monkeypatch.delenv("GRADATA_API_KEY", raising=False)
+
+    brain_dir = tmp_path / "gra-2094-brain"
+    monkeypatch.setenv("BRAIN_DIR", str(brain_dir))
+
+    import gradata._paths as paths
+    from gradata.brain import Brain
+    from gradata.hooks import session_close
+
+    importlib.reload(paths)
+
+    brain = Brain.init(brain_dir, name="GRA-2094", domain="Testing", interactive=False)
+    event = brain.correct(
+        "Use em dashes in every outbound email.",
+        "Do not use em dashes in outbound email.",
+        category="DRAFTING",
+        context={"source": "public-hook-fixture", "issue": "GRA-2060"},
+        session=2060,
+        approval_required=True,
+    )
+    assert event.get("approval_required") is True
+
+    with sqlite3.connect(brain_dir / "system.db") as conn:
+        pending_before = conn.execute(
+            "SELECT id, resolution FROM pending_approvals WHERE resolution IS NULL"
+        ).fetchall()
+    assert len(pending_before) == 1
+
+    session_close.main({"session_number": 2060})
+
+    with sqlite3.connect(brain_dir / "system.db") as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            "SELECT type, data_json FROM events WHERE type = 'PENDING_APPROVAL'"
+        ).fetchall()
+
+    assert rows, "session_close must drain/mark pending_approvals rows explicitly"
+    payloads = [json.loads(row["data_json"]) for row in rows]
+    assert any(
+        payload.get("source_issue") == "GRA-2060"
+        and payload.get("status") == "awaiting_human_review"
+        and payload.get("approval_id") == pending_before[0][0]
+        for payload in payloads
+    )
+
+    with sqlite3.connect(brain_dir / "system.db") as conn:
+        still_pending = conn.execute(
+            "SELECT id FROM pending_approvals WHERE id = ? AND resolution IS NULL",
+            (pending_before[0][0],),
+        ).fetchone()
+    assert still_pending is not None, "reviewable approvals stay open for human approval"


### PR DESCRIPTION
## Summary
- Adds a GRA-2094/GRA-2060 regression test that captures a pending approval through `Brain.correct(... approval_required=True)` with isolated temp brain state and live Gradata env vars unset.
- Adds session_close pending approval drain visibility: unresolved `pending_approvals` rows emit idempotent `PENDING_APPROVAL` events with `awaiting_human_review`, so they no longer silently dead-end.

## Verification
- RED: `env -u BRAIN_DIR -u GRADATA_BRAIN -u GRADATA_BRAIN_DIR -u GRADATA_API_KEY /home/olive/.local/bin/uv run pytest tests/test_pending_approvals_drain.py::test_session_close_drain_emits_review_event_for_public_correction_path -q` failed before implementation with `AssertionError: session_close must drain/mark pending_approvals rows explicitly`.
- GREEN: same focused test passed.
- Related tests: `env -u BRAIN_DIR -u GRADATA_BRAIN -u GRADATA_BRAIN_DIR -u GRADATA_API_KEY /home/olive/.local/bin/uv run pytest tests/test_pending_approvals_drain.py tests/test_session_close_write_through_gate.py tests/test_workers.py -q` → `18 passed in 2.97s`.
- Lint/check: `/home/olive/.local/bin/uvx ruff check src/gradata/hooks/session_close.py tests/test_pending_approvals_drain.py` → `All checks passed!`; `git diff --check` passed.
