### PR TITLE
fix: install post-tool hooks for Codex and OpenCode

### DIFF
--- a/Gradata/src/gradata/hooks/adapters/codex.py
+++ b/Gradata/src/gradata/hooks/adapters/codex.py
@@ -9,7 +9,6 @@ from gradata.hooks.adapters._base import (
     WRITE_TOOL_ALIASES,
     InstallResult,
     _normalize_tool_name,
-    contains_signature,
     extract_from_edit_args,
     extract_from_write_args,
     failure,
@@ -18,6 +17,11 @@ from gradata.hooks.adapters._base import (
 )
 
 AGENT = "codex"
+HOOKS: tuple[tuple[str, str], ...] = (
+    ("pre_tool", "inject_brain_rules"),
+    ("post_tool", "auto_correct"),
+    ("session_end", "session_close"),
+)
 
 # Codex's edit/write tool surface (OpenAI Codex CLI documented tool names).
 CODEX_EDIT_TOOLS = EDIT_TOOL_ALIASES | frozenset({"apply_patch", "str_replace_editor"})
@@ -73,30 +77,82 @@ def _toml_string(value: str) -> str:
 def install(brain_dir: Path, agent_config_path: Path) -> InstallResult:
     try:
         sig = hook_signature(AGENT, brain_dir)
-        if contains_signature(agent_config_path, sig):
-            return InstallResult(
-                AGENT, agent_config_path, "already_present", "hook already present"
-            )
         existing = (
             agent_config_path.read_text(encoding="utf-8") if agent_config_path.exists() else ""
         )
-        block = (
-            "\n[[hooks.pre_tool]]\n"
-            f"id = {_toml_string(sig)}\n"
-            f"command = {_toml_string(hook_command(brain_dir))}\n"
-        )
-        atomic_write_text(agent_config_path, existing.rstrip() + block)
-        return InstallResult(AGENT, agent_config_path, "added", "installed pre_tool hook")
+        if _has_exact_installed_hook_set(existing, sig):
+            return InstallResult(
+                AGENT, agent_config_path, "already_present", "hook already present"
+            )
+        cleaned = _remove_gradata_hook_tables(existing)
+        blocks = []
+        for event, module in HOOKS:
+            blocks.append(
+                f"[[hooks.{event}]]\n"
+                f"id = {_toml_string(f'{sig}:{event}:{module}')}\n"
+                f"command = {_toml_string(hook_command(brain_dir, module))}\n"
+            )
+        atomic_write_text(agent_config_path, cleaned.rstrip() + "\n" + "\n".join(blocks))
+        return InstallResult(AGENT, agent_config_path, "added", "installed Codex hooks")
     except Exception as exc:
         return failure(AGENT, agent_config_path, exc)
 
 
-def uninstall(brain_dir: Path, agent_config_path: Path) -> InstallResult:
-    """Reverse install: drop the [[hooks.pre_tool]] block carrying our signature.
+def _is_gradata_module_table(table: list[str], module: str | None = None) -> bool:
+    text = "".join(table)
+    if "gradata.hooks." not in text and f"gradata:{AGENT}:" not in text:
+        return False
+    if module is None:
+        return True
+    return f"gradata.hooks.{module}" in text or f":{module}" in text
 
-    Operates on the raw TOML text — walks line-by-line, identifies the
-    [[hooks.pre_tool]] table that contains our signature, and removes that
-    table + its keys. Preserves all other tables verbatim.
+
+def _split_toml_tables(text: str) -> list[list[str]]:
+    tables: list[list[str]] = []
+    current: list[str] = []
+    for line in text.splitlines(keepends=True):
+        stripped = line.lstrip()
+        if stripped.startswith("[[") or stripped.startswith("["):
+            if current:
+                tables.append(current)
+            current = [line]
+        else:
+            current.append(line)
+    if current:
+        tables.append(current)
+    return tables
+
+
+def _remove_gradata_hook_tables(text: str) -> str:
+    kept: list[str] = []
+    for table in _split_toml_tables(text):
+        header = table[0].lstrip() if table else ""
+        if header.startswith("[[hooks.") and _is_gradata_module_table(table):
+            continue
+        kept.extend(table)
+    return "".join(kept).rstrip() + ("\n" if kept else "")
+
+
+def _has_exact_installed_hook_set(text: str, sig: str) -> bool:
+    for event, module in HOOKS:
+        expected_header = f"[[hooks.{event}]]"
+        expected_id = f"{sig}:{event}:{module}"
+        matches = [
+            table
+            for table in _split_toml_tables(text)
+            if table and table[0].strip() == expected_header and _is_gradata_module_table(table, module)
+        ]
+        if len(matches) != 1 or expected_id not in "".join(matches[0]):
+            return False
+    return True
+
+
+def uninstall(brain_dir: Path, agent_config_path: Path) -> InstallResult:
+    """Reverse install: drop Codex hook blocks carrying our signature.
+
+    Operates on the raw TOML text — walks line-by-line, identifies hook
+    tables that contain our signature, and removes those tables + keys.
+    Preserves all other tables verbatim.
     """
     try:
         if not agent_config_path.is_file():
@@ -131,7 +187,7 @@ def uninstall(brain_dir: Path, agent_config_path: Path) -> InstallResult:
                 # Flush the previous table
                 flush(current_table, current_is_hook)
                 current_table = [line]
-                current_is_hook = stripped.startswith("[[hooks.pre_tool]]")
+                current_is_hook = stripped.startswith("[[hooks.")
             else:
                 if current_table:
                     current_table.append(line)
@@ -148,7 +204,7 @@ def uninstall(brain_dir: Path, agent_config_path: Path) -> InstallResult:
         new_text = "".join(out_lines).rstrip() + "\n"
         atomic_write_text(agent_config_path, new_text)
         return InstallResult(
-            AGENT, agent_config_path, "removed", f"removed {removed} [[hooks.pre_tool]] block"
+            AGENT, agent_config_path, "removed", f"removed {removed} Codex hook block"
         )
     except Exception as exc:
         return failure(AGENT, agent_config_path, exc)

--- a/Gradata/src/gradata/hooks/adapters/opencode.py
+++ b/Gradata/src/gradata/hooks/adapters/opencode.py
@@ -17,6 +17,11 @@ from gradata.hooks.adapters._base import (
 )
 
 AGENT = "opencode"
+HOOKS: tuple[tuple[str, str], ...] = (
+    ("preTool", "inject_brain_rules"),
+    ("postTool", "auto_correct"),
+    ("sessionEnd", "session_close"),
+)
 
 OPENCODE_EDIT_TOOLS = EDIT_TOOL_ALIASES
 OPENCODE_WRITE_TOOLS = WRITE_TOOL_ALIASES
@@ -49,26 +54,84 @@ def install(brain_dir: Path, agent_config_path: Path) -> InstallResult:
         sig = hook_signature(AGENT, brain_dir)
         data = read_json(agent_config_path)
         hooks = data.setdefault("hooks", {})
-        pre_tool = hooks.setdefault("preTool", [])
-        if any(sig in str(item) for item in pre_tool):
+        if _has_exact_installed_hook_set(hooks, sig):
             return InstallResult(
                 AGENT, agent_config_path, "already_present", "hook already present"
             )
-        pre_tool.append({"id": sig, "command": hook_command(brain_dir)})
+        for event, module in HOOKS:
+            _remove_existing_module_hook(hooks, event, module)
+            hooks.setdefault(event, []).append(
+                {"id": f"{sig}:{event}:{module}", "command": hook_command(brain_dir, module)}
+            )
         write_json(agent_config_path, data)
-        return InstallResult(AGENT, agent_config_path, "added", "installed preTool hook")
+        return InstallResult(AGENT, agent_config_path, "added", "installed OpenCode hooks")
     except Exception as exc:
         return failure(AGENT, agent_config_path, exc)
 
 
-def uninstall(brain_dir: Path, agent_config_path: Path) -> InstallResult:
-    """Reverse install: drop signature-matching entries from hooks.preTool."""
-    from gradata.hooks.adapters._base import uninstall_from_list_in_dict
-
-    return uninstall_from_list_in_dict(
-        agent=AGENT,
-        brain_dir=brain_dir,
-        agent_config_path=agent_config_path,
-        outer_key="hooks",
-        inner_key="preTool",
+def _is_gradata_module_hook(item: object, event: str, module: str) -> bool:
+    text = str(item)
+    return f"gradata.hooks.{module}" in text or (
+        f"gradata:{AGENT}:" in text and f":{event}:{module}" in text
     )
+
+
+def _has_exact_installed_hook_set(hooks: dict, sig: str) -> bool:
+    for event, module in HOOKS:
+        entries = hooks.get(event)
+        if not isinstance(entries, list):
+            return False
+        module_entries = [entry for entry in entries if _is_gradata_module_hook(entry, event, module)]
+        if len(module_entries) != 1:
+            return False
+        if f"{sig}:{event}:{module}" not in str(module_entries[0]):
+            return False
+    return True
+
+
+def _remove_existing_module_hook(hooks: dict, event: str, module: str) -> None:
+    entries = hooks.get(event)
+    if not isinstance(entries, list):
+        return
+    kept = [entry for entry in entries if not _is_gradata_module_hook(entry, event, module)]
+    if kept:
+        hooks[event] = kept
+    else:
+        hooks.pop(event, None)
+
+
+def uninstall(brain_dir: Path, agent_config_path: Path) -> InstallResult:
+    """Reverse install: drop signature-matching entries from all OpenCode hooks."""
+    try:
+        if not agent_config_path.is_file():
+            return InstallResult(
+                AGENT, agent_config_path, "already_present", "config file does not exist"
+            )
+        sig = hook_signature(AGENT, brain_dir)
+        data = read_json(agent_config_path)
+        hooks = data.get("hooks")
+        if not isinstance(hooks, dict):
+            return InstallResult(AGENT, agent_config_path, "already_present", "no hooks block")
+        removed = 0
+        for event in list(hooks):
+            entries = hooks.get(event)
+            if not isinstance(entries, list):
+                continue
+            kept = []
+            for entry in entries:
+                if sig in str(entry):
+                    removed += 1
+                    continue
+                kept.append(entry)
+            if kept:
+                hooks[event] = kept
+            else:
+                hooks.pop(event, None)
+        if removed == 0:
+            return InstallResult(AGENT, agent_config_path, "already_present", "hook not present")
+        if not hooks:
+            data.pop("hooks", None)
+        write_json(agent_config_path, data)
+        return InstallResult(AGENT, agent_config_path, "removed", f"removed {removed} hook entry")
+    except Exception as exc:
+        return failure(AGENT, agent_config_path, exc)

--- a/Gradata/tests/test_hook_adapters.py
+++ b/Gradata/tests/test_hook_adapters.py
@@ -56,6 +56,53 @@ def test_codex_adapter_writes_valid_toml_with_quoted_brain_path(tmp_path: Path) 
     assert brain_dir.as_posix() in hook["id"]
 
 
+def test_codex_adapter_installs_pre_post_and_session_hooks(tmp_path: Path) -> None:
+    brain_dir = tmp_path / "brain"
+    brain_dir.mkdir()
+    config_path = adapter_config_path("codex", home=tmp_path / "home")
+
+    result = get_adapter("codex").install(brain_dir, config_path)
+
+    assert result.action == "added"
+    parsed = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    assert set(parsed["hooks"]) >= {"pre_tool", "post_tool", "session_end"}
+    assert "gradata.hooks.inject_brain_rules" in parsed["hooks"]["pre_tool"][0]["command"]
+    assert "gradata.hooks.auto_correct" in parsed["hooks"]["post_tool"][0]["command"]
+    assert "gradata.hooks.session_close" in parsed["hooks"]["session_end"][0]["command"]
+
+
+def test_hermes_adapter_installs_pre_post_and_session_hooks(tmp_path: Path) -> None:
+    brain_dir = tmp_path / "brain"
+    brain_dir.mkdir()
+    config_path = adapter_config_path("hermes", home=tmp_path / "home")
+
+    result = get_adapter("hermes").install(brain_dir, config_path)
+
+    assert result.action == "added"
+    text = config_path.read_text(encoding="utf-8")
+    assert "pre_tool_call:" in text
+    assert "post_tool_call:" in text
+    assert "on_session_end:" in text
+    assert "gradata.hooks.inject_brain_rules" in text
+    assert "gradata.hooks.auto_correct" in text
+    assert "gradata.hooks.session_close" in text
+
+
+def test_opencode_adapter_installs_pre_post_and_session_hooks(tmp_path: Path) -> None:
+    brain_dir = tmp_path / "brain"
+    brain_dir.mkdir()
+    config_path = adapter_config_path("opencode", home=tmp_path / "home")
+
+    result = get_adapter("opencode").install(brain_dir, config_path)
+
+    assert result.action == "added"
+    parsed = json.loads(config_path.read_text(encoding="utf-8"))
+    assert set(parsed["hooks"]) >= {"preTool", "postTool", "sessionEnd"}
+    assert "gradata.hooks.inject_brain_rules" in parsed["hooks"]["preTool"][0]["command"]
+    assert "gradata.hooks.auto_correct" in parsed["hooks"]["postTool"][0]["command"]
+    assert "gradata.hooks.session_close" in parsed["hooks"]["sessionEnd"][0]["command"]
+
+
 @pytest.mark.parametrize("agent", AGENTS)
 def test_adapter_install_does_not_touch_real_user_config(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, agent: str


### PR DESCRIPTION
## Summary
- add Codex post_tool and session_end hook installation alongside pre_tool
- add OpenCode postTool and sessionEnd hook installation alongside preTool
- add adapter tests covering pre/post/session hook installation for Codex, Hermes, and OpenCode

## Verification
- `python3 -m pytest tests/test_hook_adapters.py` → 21 passed
- isolated HOME CLI smoke: `python3 -m gradata.cli install --agent codex|hermes|opencode --brain <tmp>` → wrote post/session hook configs and assertions passed
- `python3 -m pytest tests/test_hook_adapters.py tests/test_adapter_extraction_contracts.py tests/test_uninstall_command.py` → 92 passed
- `/home/olive/.local/bin/uvx ruff check src/gradata/hooks/adapters/codex.py src/gradata/hooks/adapters/opencode.py tests/test_hook_adapters.py` → All checks passed
- `git diff --check` → clean

Paperclip: GRA-55
