### PR TITLE
test: cover Stop session graduation sweep

### DIFF
--- a/Gradata/src/gradata/hooks/session_close.py
+++ b/Gradata/src/gradata/hooks/session_close.py
@@ -157,6 +157,17 @@ def _run_tree_consolidation(brain_dir: str) -> None:
         _log.debug("tree consolidation skipped: %s", e, exc_info=True)
 
 
+def _export_agents_rules(brain_dir: str, lessons_path: Path) -> None:
+    """Refresh AGENTS.md from the current RULE-tier lessons."""
+    from gradata.enhancements.rule_export import DEFAULT_PATHS, export_rules
+
+    agents_path = Path(brain_dir) / DEFAULT_PATHS["agents"]
+    agents_path.write_text(
+        export_rules(Path(brain_dir), target="agents", lessons_path=lessons_path),
+        encoding="utf-8",
+    )
+
+
 def _run_pipeline(brain_dir: str, data: dict) -> None:
     try:
         from gradata.enhancements.rule_pipeline import run_rule_pipeline
@@ -171,10 +182,21 @@ def _run_pipeline(brain_dir: str, data: dict) -> None:
             db_path=db_path,
             current_session=current_session,
         )
-        if result.graduated or result.meta_rules_created or result.hooks_promoted:
+        if result.graduated or result.patterns_lifted:
+            try:
+                _export_agents_rules(brain_dir, lessons_path)
+            except Exception as e:
+                _log.debug("AGENTS.md pipeline export skipped: %s", e, exc_info=True)
+        if (
+            result.graduated
+            or result.meta_rules_created
+            or result.hooks_promoted
+            or result.patterns_lifted
+        ):
             _log.info(
-                "Pipeline: %d graduated, %d meta-rules, %d hooks",
+                "Pipeline: %d graduated, %d lifted patterns, %d meta-rules, %d hooks",
                 len(result.graduated),
+                result.patterns_lifted,
                 len(result.meta_rules_created),
                 len(result.hooks_promoted),
             )

--- a/Gradata/tests/test_session_close_write_through_gate.py
+++ b/Gradata/tests/test_session_close_write_through_gate.py
@@ -7,9 +7,12 @@ to avoid double-writes. Only runs when GRADATA_DISABLE_WRITE_THROUGH=1.
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 from unittest.mock import patch
 
+from gradata.enhancements.self_improvement import parse_lessons
+from gradata.enhancements.meta_rules_storage import upsert_correction_patterns_batch
 from gradata.hooks import session_close
 
 
@@ -64,3 +67,74 @@ def test_run_graduation_exports_agents_md_for_new_rule(tmp_path: Path, monkeypat
     session_close._run_graduation(str(tmp_path))
     assert (tmp_path / "AGENTS.md").read_text(encoding="utf-8") == agents_text
     assert agents_text.count("Always verify work before reporting done") == 1
+
+
+def test_stop_session_sweep_graduates_synthetic_fixture_to_agents_md(
+    tmp_path: Path,
+    monkeypatch,
+):
+    """Full Stop hook smoke: trigger-gated sweep promotes fixture lessons.
+
+    The fixture starts with three INSTINCT entries plus a repeated correction
+    pattern. A synthetic trigger row makes the session-close waterfall run; the
+    resulting lessons.md keeps the live INSTINCT/PATTERN trail while AGENTS.md
+    receives the lifted RULE-tier output.
+    """
+    monkeypatch.setenv("GRADATA_BETA_LB_GATE", "0")
+    monkeypatch.delenv("GRADATA_API_KEY", raising=False)
+    monkeypatch.setattr(session_close, "resolve_brain_dir", lambda: str(tmp_path))
+
+    lessons_path = tmp_path / "lessons.md"
+    lessons_path.write_text(
+        "# Lessons\n\n"
+        "[2026-06-03] [INSTINCT:0.61] PROCESS: Verify artifacts before reporting completion\n"
+        "  Root cause: User correction\n"
+        "  Fire count: 2 | Sessions since fire: 0 | Misfires: 0\n"
+        "[2026-06-03] [INSTINCT:0.62] TESTING: Run focused tests before status updates\n"
+        "  Root cause: User correction\n"
+        "  Fire count: 2 | Sessions since fire: 0 | Misfires: 0\n"
+        "[2026-06-03] [INSTINCT:0.40] COMMUNICATION: Mention blockers explicitly\n"
+        "  Root cause: User correction\n"
+        "  Fire count: 0 | Sessions since fire: 0 | Misfires: 0\n",
+        encoding="utf-8",
+    )
+    before = parse_lessons(lessons_path.read_text(encoding="utf-8"))
+    assert sum(1 for lesson in before if lesson.state.name == "INSTINCT") == 3
+
+    db_path = tmp_path / "system.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE events ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "type TEXT, ts TEXT, session INTEGER, data_json TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO events(type, ts, session, data_json) VALUES (?, ?, ?, ?)",
+            ("CORRECTION", "2026-06-03T12:00:00+00:00", 7, "{}"),
+        )
+        conn.commit()
+
+    upsert_correction_patterns_batch(
+        db_path,
+        [
+            (
+                "verify-evidence-pattern",
+                "PROCESS",
+                "Always include exact verification evidence in completion comments",
+                session_id,
+                "minor",
+            )
+            for session_id in range(1, 6)
+        ],
+    )
+
+    session_close.main({"session_number": 7})
+
+    after_text = lessons_path.read_text(encoding="utf-8")
+    agents_text = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+    assert "[PATTERN:0.61] PROCESS: Verify artifacts before reporting completion" in after_text
+    assert "[PATTERN:0.62] TESTING: Run focused tests before status updates" in after_text
+    assert "[INSTINCT:0.40] COMMUNICATION: Mention blockers explicitly" in after_text
+    assert "[RULE:0.92] PROCESS: Always include exact verification evidence" in after_text
+    assert "- Always include exact verification evidence in completion comments" in agents_text
+    assert (tmp_path / session_close.STAMP_FILE).is_file()


### PR DESCRIPTION
## Summary
- Add a full Stop/session-close synthetic fixture for GRA-1102 with three INSTINCT lessons before the sweep.
- Seed repeated correction patterns, run the trigger-gated session-close waterfall, and assert lessons.md + AGENTS.md graduation output.
- Refresh AGENTS.md after session-close pipeline lifts RULE-tier correction patterns, not only direct _run_graduation promotions.

## Paperclip
Issue: GRA-1102
Issue UUID: d100fb3c-a477-449c-84d5-84de5a044879

## Verification
- `python3 -m pytest tests/test_session_close_write_through_gate.py -q` → 5 passed
- `python3 -m pytest tests/test_session_close_write_through_gate.py tests/test_rule_pipeline.py tests/test_rule_export.py -q` → 53 passed
