### PR TITLE
feat: cache Brain recall results

### DIFF
--- a/Gradata/src/gradata/brain.py
+++ b/Gradata/src/gradata/brain.py
@@ -36,8 +36,12 @@ per process, or use process-level locks for multi-worker deployments.
 from __future__ import annotations
 
 import dataclasses
+import hashlib
+import json
 import logging
 import sys
+import time
+from collections import OrderedDict
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -90,6 +94,7 @@ class Brain(BrainInspectionMixin):
         brain_dir: str | Path | None = None,
         working_dir: str | Path | None = None,
         encryption_key: str | None = None,
+        cache_ttl: float = 30.0,
     ):
         from gradata._paths import resolve_brain_dir
 
@@ -123,6 +128,9 @@ class Brain(BrainInspectionMixin):
         from gradata.rules.cache import RuleCache
 
         self._rule_cache = RuleCache()
+        self._recall_cache_ttl = max(0.0, float(cache_ttl))
+        self._recall_cache: OrderedDict[tuple[str, str], tuple[float, str]] = OrderedDict()
+        self._recall_cache_size = 256
 
         # Capability probe cached once: apply_brain_rules() is a hot path
         # and we don't want find_spec() in every call.
@@ -508,7 +516,7 @@ class Brain(BrainInspectionMixin):
         also skipped when ``dry_run=True``, ``approval_required=True``, or
         when the brain is in renter mode.
         """
-        self._rule_cache.invalidate()  # Correction invalidates cached rules
+        self.invalidate_cache()  # Correction invalidates cached rules
         from gradata._core import brain_correct
 
         result = brain_correct(
@@ -640,7 +648,7 @@ class Brain(BrainInspectionMixin):
 
         # Deterministic event_id: stable across retries.
         digest = hashlib.sha1(
-            f"{draft}\x00{final}".encode("utf-8"),
+            f"{draft}\x00{final}".encode(),
             usedforsecurity=False,
         ).hexdigest()[:16]
         ts_ms = int(_time.time() * 1000)
@@ -1095,6 +1103,78 @@ class Brain(BrainInspectionMixin):
 
     # ── Rules ──────────────────────────────────────────────────────────
 
+    def invalidate_cache(self) -> None:
+        """Clear in-process recall/rule caches for this Brain instance."""
+        self._recall_cache.clear()
+        self._rule_cache.invalidate()
+
+    def _recall_cache_key(
+        self,
+        task: str,
+        scope: object,
+        *,
+        ranker: str,
+        max_rules: int,
+        max_recall_tokens: int,
+    ) -> tuple[str, str]:
+        task_hash = hashlib.sha256(task.encode("utf-8")).hexdigest()
+        scope_payload = {
+            "task_type": getattr(scope, "task_type", ""),
+            "domain": getattr(scope, "domain", ""),
+            "audience": getattr(scope, "audience", ""),
+            "ranker": ranker,
+            "max_rules": max_rules,
+            "max_recall_tokens": max_recall_tokens,
+        }
+        scope_hash = hashlib.sha256(
+            json.dumps(scope_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        return task_hash, scope_hash
+
+    def _get_recall_cache(self, key: tuple[str, str]) -> str | None:
+        if self._recall_cache_ttl <= 0:
+            return None
+        cached = self._recall_cache.get(key)
+        if cached is None:
+            return None
+        expires_at, result = cached
+        if expires_at <= time.monotonic():
+            self._recall_cache.pop(key, None)
+            return None
+        self._recall_cache.move_to_end(key)
+        return result
+
+    def _put_recall_cache(self, key: tuple[str, str], result: str) -> None:
+        if self._recall_cache_ttl <= 0:
+            return
+        self._recall_cache[key] = (time.monotonic() + self._recall_cache_ttl, result)
+        self._recall_cache.move_to_end(key)
+        while len(self._recall_cache) > self._recall_cache_size:
+            self._recall_cache.popitem(last=False)
+
+    def recall(
+        self,
+        task: str,
+        context: dict | None = None,
+        agent_type: str | None = None,
+        max_rules: int | None = None,
+        max_recall_tokens: int | None = None,
+        ranker: str | None = None,
+    ) -> str:
+        """Recall applicable brain rules for a task.
+
+        Thin public alias for apply_brain_rules(), backed by the same 30s
+        in-process LRU cache keyed by task hash and derived scope.
+        """
+        return self.apply_brain_rules(
+            task,
+            context=context,
+            agent_type=agent_type,
+            max_rules=max_rules,
+            max_recall_tokens=max_recall_tokens,
+            ranker=ranker,
+        )
+
     def apply_brain_rules(
         self,
         task: str,
@@ -1140,15 +1220,14 @@ class Brain(BrainInspectionMixin):
             return ""
         scope = build_scope(ctx)
 
-        # Check rule cache first (Pattern 2: skip re-ranking if scope unchanged)
-        from gradata.rules.cache import RuleCache
-
-        cache_key = RuleCache.make_key(
-            f"{scope.task_type}:{ranker}:{max_recall_tokens}:{max_rules}",
-            scope.domain,
-            scope.audience,
+        cache_key = self._recall_cache_key(
+            task,
+            scope,
+            ranker=ranker,
+            max_rules=max_rules,
+            max_recall_tokens=max_recall_tokens,
         )
-        cached = self._rule_cache.get(cache_key)
+        cached = self._get_recall_cache(cache_key)
         if cached is not None:
             return cached
 
@@ -1241,7 +1320,7 @@ class Brain(BrainInspectionMixin):
                     else:
                         result = "<brain-rules>"
                     result = f"{result}\n</brain-rules>"
-        self._rule_cache.put(cache_key, result)
+        self._put_recall_cache(cache_key, result)
         return result
 
     def scoped_rules(

--- a/Gradata/tests/test_brain_recall_cache.py
+++ b/Gradata/tests/test_brain_recall_cache.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from gradata import Brain
+from gradata._types import Lesson, LessonState
+from gradata.enhancements.self_improvement import format_lessons
+
+
+def _seed_rule(brain: Brain) -> None:
+    lessons = [
+        Lesson(
+            date="2026-01-01",
+            state=LessonState.RULE,
+            confidence=0.95,
+            category="PROCESS",
+            description="Verify cache-sensitive tasks before responding",
+        )
+    ]
+    (brain.dir / "lessons.md").write_text(format_lessons(lessons), encoding="utf-8")
+
+
+def _count_rule_applications(monkeypatch) -> Callable[[], int]:
+    calls = 0
+
+    def fake_apply_rules_with_tree(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        from gradata.rules.rule_engine import apply_rules
+
+        return apply_rules(args[0], args[1], max_rules=kwargs["max_rules"], bus=None)
+
+    monkeypatch.setattr(
+        "gradata.rules.rule_engine.apply_rules_with_tree", fake_apply_rules_with_tree
+    )
+    return lambda: calls
+
+
+def test_recall_cache_reuses_same_task_without_recomputing(
+    fresh_brain: Brain, monkeypatch
+) -> None:
+    _seed_rule(fresh_brain)
+    calls = _count_rule_applications(monkeypatch)
+
+    first = fresh_brain.recall("write a launch checklist")
+    second = fresh_brain.recall("write a launch checklist")
+
+    assert first == second
+    assert calls() == 1
+
+
+def test_recall_cache_key_includes_task_hash(fresh_brain: Brain, monkeypatch) -> None:
+    _seed_rule(fresh_brain)
+    calls = _count_rule_applications(monkeypatch)
+
+    fresh_brain.recall("write a launch checklist")
+    fresh_brain.recall("write a sales email")
+
+    assert calls() == 2
+
+
+def test_recall_cache_key_includes_scope_and_options(
+    fresh_brain: Brain, monkeypatch
+) -> None:
+    _seed_rule(fresh_brain)
+    calls = _count_rule_applications(monkeypatch)
+
+    fresh_brain.recall("write copy", context={"domain": "marketing"}, max_rules=1)
+    fresh_brain.recall("write copy", context={"domain": "support"}, max_rules=1)
+    fresh_brain.recall("write copy", context={"domain": "support"}, max_rules=2)
+    fresh_brain.recall("write copy", context={"domain": "support"}, max_rules=2)
+
+    assert calls() == 3
+
+
+def test_invalidate_cache_forces_next_recall_miss(fresh_brain: Brain, monkeypatch) -> None:
+    _seed_rule(fresh_brain)
+    calls = _count_rule_applications(monkeypatch)
+
+    fresh_brain.recall("write a launch checklist")
+    fresh_brain.invalidate_cache()
+    fresh_brain.recall("write a launch checklist")
+
+    assert calls() == 2
+
+
+def test_cache_ttl_zero_disables_recall_cache(fresh_brain: Brain, monkeypatch) -> None:
+    brain = Brain(fresh_brain.dir, cache_ttl=0)
+    _seed_rule(brain)
+    calls = _count_rule_applications(monkeypatch)
+
+    brain.recall("write a launch checklist")
+    brain.recall("write a launch checklist")
+
+    assert calls() == 2
+
+
+def test_cache_expires_after_configured_ttl(fresh_brain: Brain, monkeypatch) -> None:
+    brain = Brain(fresh_brain.dir, cache_ttl=5)
+    _seed_rule(brain)
+    calls = _count_rule_applications(monkeypatch)
+    now = 100.0
+    monkeypatch.setattr("gradata.brain.time.monotonic", lambda: now)
+
+    brain.recall("write a launch checklist")
+    brain.recall("write a launch checklist")
+    now = 106.0
+    brain.recall("write a launch checklist")
+
+    assert calls() == 2
+
+
+def test_recall_cache_evicts_least_recently_used_entry(
+    fresh_brain: Brain, monkeypatch
+) -> None:
+    _seed_rule(fresh_brain)
+    fresh_brain._recall_cache_size = 2
+    calls = _count_rule_applications(monkeypatch)
+
+    fresh_brain.recall("task one")
+    fresh_brain.recall("task two")
+    fresh_brain.recall("task one")
+    fresh_brain.recall("task three")
+    fresh_brain.recall("task two")
+
+    assert calls() == 4


### PR DESCRIPTION
## Summary
- Add Brain(cache_ttl=...) with a 30s default in-process recall cache.
- Cache recall/apply_brain_rules outputs in an LRU capped at 256 entries, keyed by task hash plus scope/options.
- Add explicit Brain.invalidate_cache() and invalidate recall/rule caches on correct().
- Cover cache hits, task/scope/options misses, manual invalidation, TTL expiry, cache disable, and LRU eviction.

## Verification
- `git diff --check`
- `/home/olive/.local/bin/uvx ruff check Gradata/src/gradata/brain.py Gradata/tests/test_brain_recall_cache.py`
- `python3 -m pytest Gradata/tests/test_brain_recall_cache.py Gradata/tests/test_brain_config_recall.py Gradata/tests/test_mcp_recall_token_budget.py -q`

Paperclip: GRA-987
