### PR TITLE
test: isolate quickstart smoke brain env

### DIFF
--- a/Gradata/docs/getting-started/install.md
+++ b/Gradata/docs/getting-started/install.md
@@ -114,7 +114,9 @@ gradata --brain-dir ./my-brain audit              # data-flow audit
 ```
 
 For a non-mutating offline smoke test that exercises init, agent-install dry
-run, correction, recall, stats, and audit:
+run, correction, recall, stats, and audit. The script creates a temporary HOME
+and ignores inherited live-brain variables such as `BRAIN_DIR`/`GRADATA_BRAIN`
+so it can be run safely from an agent shell:
 
 ```bash
 PYTHONPATH=src python examples/offline_quickstart_smoke.py

--- a/Gradata/examples/offline_quickstart_smoke.py
+++ b/Gradata/examples/offline_quickstart_smoke.py
@@ -43,6 +43,10 @@ def main() -> int:
         env["HOME"] = str(home)
         env["GRADATA_BRAIN_DIR"] = str(brain)
         env.setdefault("GRADATA_LOG", "WARNING")
+        # Make this smoke deterministic when run by developers/agents that already
+        # export a live Gradata brain path in their shell.
+        env.pop("BRAIN_DIR", None)
+        env.pop("GRADATA_BRAIN", None)
 
         run(["--help"], env=env)
         run(["init", str(brain), "--domain", "Smoke", "--name", "Quickstart Smoke", "--no-interactive"], env=env)
@@ -57,9 +61,11 @@ def main() -> int:
             "Hey, check out what we just shipped.",
         ], env=env)
         run(["--brain-dir", str(brain), "recall", "draft a launch email", "--max-tokens", "400"], env=env)
-        run(["--brain-dir", str(brain), "stats"], env=env)
+        stats = run(["--brain-dir", str(brain), "stats"], env=env)
         run(["--brain-dir", str(brain), "audit"], env=env)
 
+        if f"Brain: {brain}" not in stats:
+            raise SystemExit(f"stats used the wrong brain directory:\n{stats}")
         if not (brain / "system.db").exists():
             raise SystemExit(f"missing expected brain database: {brain / 'system.db'}")
 


### PR DESCRIPTION
## Summary

- harden `examples/offline_quickstart_smoke.py` against inherited live Gradata brain env (`BRAIN_DIR`, `GRADATA_BRAIN`)
- assert `stats` is using the temporary smoke brain, so Show HN onboarding smoke catches env contamination
- document that the offline smoke creates a temporary HOME and ignores inherited live-brain variables

## Verification

```bash
BRAIN_DIR=/home/olive/.gradata/brain GRADATA_BRAIN=/home/olive/.gradata/brain PYTHONPATH=Gradata/src python3 Gradata/examples/offline_quickstart_smoke.py
# ...
# Brain: /tmp/gradata-quickstart-ck89cjie/my-brain
# ✓ offline quickstart smoke passed
```

```bash
python3 -m py_compile Gradata/examples/offline_quickstart_smoke.py
git diff --check
```

Prior GRA-1781 docs/smoke artifact already merged in PR #236; this follow-up fixes the environment contamination found while verifying it.
