### PR TITLE
feat(telemetry): add CLI activation funnel events

### DIFF
--- a/Gradata/src/gradata/_telemetry.py
+++ b/Gradata/src/gradata/_telemetry.py
@@ -65,7 +65,11 @@ logger = logging.getLogger("gradata.telemetry")
 
 # ── Constants ─────────────────────────────────────────────────────────
 DEFAULT_ENDPOINT: Final[str] = "https://api.gradata.ai/telemetry/event"
+DEFAULT_POSTHOG_ENDPOINT: Final[str] = "https://us.i.posthog.com/capture/"
 ENV_ENDPOINT: Final[str] = "GRADATA_TELEMETRY_ENDPOINT"
+ENV_POSTHOG_HOST: Final[str] = "GRADATA_POSTHOG_HOST"
+ENV_POSTHOG_API_KEY: Final[str] = "GRADATA_POSTHOG_API_KEY"
+ENV_POSTHOG_PROJECT_API_KEY: Final[str] = "POSTHOG_PROJECT_API_KEY"
 ENV_KILL_SWITCH: Final[str] = "GRADATA_TELEMETRY"
 _CONFIG_FILENAME: Final[str] = "config.toml"
 
@@ -94,11 +98,26 @@ ACTIVATION_EVENTS: Final[tuple[str, ...]] = (
     "first_hook_installed",
 )
 
+# PostHog activation-funnel events requested by GRA-2031. Kept separate from
+# the legacy anonymous activation tuple so older tests and payload contracts do
+# not accidentally widen.
+CLI_TELEMETRY_EVENTS: Final[tuple[str, ...]] = (
+    "cli_install",
+    "first_rule_graduated",
+    "rule_injected",
+)
+
 ActivationEvent = Literal[
     "brain_initialized",
     "first_correction_captured",
     "first_graduation",
     "first_hook_installed",
+]
+
+CliTelemetryEvent = Literal[
+    "cli_install",
+    "first_rule_graduated",
+    "rule_injected",
 ]
 
 
@@ -239,6 +258,24 @@ def _endpoint() -> str:
     return os.environ.get(ENV_ENDPOINT, "").strip() or DEFAULT_ENDPOINT
 
 
+def _posthog_api_key() -> str | None:
+    return (
+        os.environ.get(ENV_POSTHOG_API_KEY, "").strip()
+        or os.environ.get(ENV_POSTHOG_PROJECT_API_KEY, "").strip()
+        or None
+    )
+
+
+def _posthog_endpoint() -> str:
+    explicit = os.environ.get(ENV_ENDPOINT, "").strip()
+    if explicit:
+        return explicit
+    host = os.environ.get(ENV_POSTHOG_HOST, "").strip().rstrip("/")
+    if host:
+        return f"{host}/capture/"
+    return DEFAULT_POSTHOG_ENDPOINT
+
+
 def _sdk_version() -> str:
     try:
         from gradata import __version__
@@ -249,7 +286,7 @@ def _sdk_version() -> str:
 
 
 def _build_payload(event: str) -> dict[str, str]:
-    """Exact wire format. No extra fields, ever."""
+    """Exact legacy wire format. No extra fields, ever."""
     return {
         "event": event,
         "user_id": anonymous_user_id(),
@@ -258,11 +295,97 @@ def _build_payload(event: str) -> dict[str, str]:
     }
 
 
-def _post(payload: dict[str, str], timeout: float = 3.0) -> bool:
+def _safe_brain_id(brain_dir: str | Path | None = None) -> str | None:
+    if brain_dir is None:
+        return None
+    try:
+        from gradata._tenant import tenant_for
+
+        return tenant_for(Path(brain_dir))
+    except Exception:
+        return hashlib.sha256(str(brain_dir).encode("utf-8")).hexdigest()[:32]
+
+
+def _install_started_at() -> str:
+    key = "telemetry.install_started_at"
+    cfg = _read_config()
+    existing = cfg.get(key, "").strip()
+    if existing:
+        return existing
+    ts = datetime.now(UTC).isoformat()
+    with _config_lock():
+        cfg = _read_config()
+        existing = cfg.get(key, "").strip()
+        if existing:
+            return existing
+        _write_config_key(key, ts)
+    return ts
+
+
+def _hours_since_install() -> float | None:
+    raw = _read_config().get("telemetry.install_started_at", "").strip()
+    if not raw:
+        return None
+    try:
+        installed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        return max(0.0, (datetime.now(UTC) - installed).total_seconds() / 3600.0)
+    except ValueError:
+        return None
+
+
+def _cohort() -> str | None:
+    value = os.environ.get("GRADATA_COHORT", "").strip()
+    return value or None
+
+
+def _experiment_id() -> str | None:
+    value = os.environ.get("GRADATA_EXPERIMENT_ID", "").strip()
+    return value or None
+
+
+def _build_cli_payload(
+    event: str,
+    *,
+    brain_dir: str | Path | None = None,
+    agent_type: str | None = None,
+    rule_id: str | None = None,
+    injection_count_this_session: int | None = None,
+) -> dict:
+    """PostHog-compatible activation-funnel payload for CLI/SDK events."""
+    if event not in CLI_TELEMETRY_EVENTS:
+        raise ValueError(f"Unknown CLI telemetry event: {event!r}")
+    user_id = anonymous_user_id()
+    props: dict[str, object] = {
+        "distinct_id": user_id,
+        "user_id": user_id,
+        "brain_id": _safe_brain_id(brain_dir),
+        "agent_type": agent_type or "unknown",
+        "cli_version": _sdk_version(),
+        "experiment_id": _experiment_id(),
+        "cohort": _cohort(),
+    }
+    if rule_id is not None:
+        props["rule_id"] = str(rule_id)
+    if event == "cli_install":
+        props["install_started_at"] = _install_started_at()
+    if event == "first_rule_graduated":
+        props["hours_since_install"] = _hours_since_install()
+    if event == "rule_injected":
+        props["injection_count_this_session"] = int(injection_count_this_session or 0)
+    return {
+        "api_key": _posthog_api_key(),
+        "event": event,
+        "distinct_id": user_id,
+        "properties": props,
+        "timestamp": datetime.now(UTC).isoformat(),
+    }
+
+
+def _post(payload: dict, timeout: float = 3.0, endpoint: str | None = None) -> bool:
     """Best-effort POST. Never raises. Returns True on 2xx."""
     body = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(
-        _endpoint(),
+        endpoint or _endpoint(),
         data=body,
         headers={"Content-Type": "application/json"},
         method="POST",
@@ -293,6 +416,71 @@ def send_event(event: str, *, blocking: bool = False) -> None:
 
     thread = threading.Thread(target=_post, args=(payload,), daemon=True)
     thread.start()
+
+
+def send_cli_event(
+    event: str,
+    *,
+    brain_dir: str | Path | None = None,
+    agent_type: str | None = None,
+    rule_id: str | None = None,
+    injection_count_this_session: int | None = None,
+    blocking: bool = False,
+) -> None:
+    """Fire a GRA-2031 CLI/SDK funnel event.
+
+    Best-effort and opt-in: no exception or network failure may surface to the
+    user or block hook hot paths.
+    """
+    if event not in CLI_TELEMETRY_EVENTS:
+        raise ValueError(f"Unknown CLI telemetry event: {event!r}")
+    if not is_enabled():
+        return
+    if not _posthog_api_key():
+        logger.debug("CLI telemetry skipped: no PostHog project API key configured")
+        return
+    try:
+        payload = _build_cli_payload(
+            event,
+            brain_dir=brain_dir,
+            agent_type=agent_type,
+            rule_id=rule_id,
+            injection_count_this_session=injection_count_this_session,
+        )
+    except Exception as exc:
+        logger.debug("CLI telemetry payload build failed: %s", exc)
+        return
+
+    endpoint = _posthog_endpoint()
+    if blocking:
+        _post(payload, endpoint=endpoint)
+        return
+
+    thread = threading.Thread(target=_post, args=(payload,), kwargs={"endpoint": endpoint}, daemon=True)
+    thread.start()
+
+
+def send_cli_once(
+    event: str,
+    *,
+    brain_dir: str | Path | None = None,
+    agent_type: str | None = None,
+    rule_id: str | None = None,
+    blocking: bool = False,
+) -> bool:
+    """Fire a CLI telemetry event at most once per user config."""
+    if event not in CLI_TELEMETRY_EVENTS:
+        raise ValueError(f"Unknown CLI telemetry event: {event!r}")
+    if not is_enabled():
+        return False
+    with _config_lock():
+        cfg = _read_config()
+        key = f"telemetry.fired_{event}"
+        if cfg.get(key) == "true":
+            return False
+        _write_config_key(key, "true")
+    send_cli_event(event, brain_dir=brain_dir, agent_type=agent_type, rule_id=rule_id, blocking=blocking)
+    return True
 
 
 # ── First-fire guard (activation events fire once per machine) ────────

--- a/Gradata/src/gradata/brain.py
+++ b/Gradata/src/gradata/brain.py
@@ -121,6 +121,7 @@ class Brain(BrainInspectionMixin):
         self._fired_rules: list[
             Lesson
         ] = []  # Rules injected this session (for misfire attribution)
+        self._telemetry_rule_injection_count = 0
         self._convergence_cache: dict | None = None
         self._convergence_session: int | None = None
 
@@ -1307,6 +1308,19 @@ class Brain(BrainInspectionMixin):
                     )
                 except Exception as e:
                     logger.debug("rule_injected emit failed: %s", e)
+                try:
+                    from gradata import _telemetry
+
+                    self._telemetry_rule_injection_count += 1
+                    _telemetry.send_cli_event(
+                        "rule_injected",
+                        brain_dir=self.dir,
+                        agent_type="sdk",
+                        rule_id=applied_rule.rule_id,
+                        injection_count_this_session=self._telemetry_rule_injection_count,
+                    )
+                except Exception as e:
+                    logger.debug("rule_injected telemetry failed: %s", e)
 
         result = format_rules_for_prompt(applied)
         if max_recall_tokens > 0 and result:

--- a/Gradata/src/gradata/cli.py
+++ b/Gradata/src/gradata/cli.py
@@ -81,6 +81,10 @@ def cmd_init(args):
         _telemetry.send_once("brain_initialized")
     except Exception as exc:
         _log.debug("telemetry send_once(brain_initialized) failed: %s", exc)
+    try:
+        _telemetry.send_cli_event("cli_install", brain_dir=args.path, agent_type="cli")
+    except Exception as exc:
+        _log.debug("telemetry send_cli_event(cli_install) failed: %s", exc)
 
 
 def cmd_search(args):
@@ -496,6 +500,12 @@ def _cmd_install_agent(args) -> None:
             except Exception as exc:
                 # Manifest write is best-effort; don't fail install on it.
                 print(f"  ⚠ install manifest write failed: {exc}")
+            try:
+                from gradata import _telemetry
+
+                _telemetry.send_cli_event("cli_install", brain_dir=brain_dir, agent_type=name)
+            except Exception as exc:
+                _log.debug("telemetry send_cli_event(cli_install) failed: %s", exc)
 
         # ▸ Flag-gated install verification: write + read a test rule
         if verify_install and result.action != "failed":

--- a/Gradata/src/gradata/enhancements/self_improvement/_graduation.py
+++ b/Gradata/src/gradata/enhancements/self_improvement/_graduation.py
@@ -150,6 +150,17 @@ def _emit_rule_graduated(
             brain.emit("RULE_GRADUATED", "graduate", payload, [])
             brain_dir = getattr(brain, "dir", None)
             if brain_dir is not None:
+                try:
+                    from gradata import _telemetry
+
+                    _telemetry.send_cli_once(
+                        "first_rule_graduated",
+                        brain_dir=brain_dir,
+                        agent_type="sdk",
+                        rule_id=rule_id,
+                    )
+                except Exception as exc:
+                    _log.debug("telemetry send_cli_once(first_rule_graduated) failed: %s", exc)
                 from gradata.enhancements.rule_file_materializer import write_rule_file
 
                 write_rule_file(payload, brain_dir)

--- a/Gradata/src/gradata/hooks/inject_brain_rules.py
+++ b/Gradata/src/gradata/hooks/inject_brain_rules.py
@@ -43,6 +43,34 @@ except ImportError:
     INJECTABLE_META_SOURCES = frozenset()  # type: ignore[assignment]
 
 _log = logging.getLogger(__name__)
+_INJECTION_COUNT_THIS_SESSION = 0
+
+
+def _emit_rule_injected_telemetry(
+    *,
+    brain_dir: str | Path,
+    agent_type: str,
+    rule_ids: list[str],
+) -> None:
+    """Best-effort GRA-2031 rule_injected events, one per injected rule."""
+    global _INJECTION_COUNT_THIS_SESSION
+    if not rule_ids:
+        return
+    try:
+        from gradata import _telemetry
+
+        for rid in rule_ids:
+            _INJECTION_COUNT_THIS_SESSION += 1
+            _telemetry.send_cli_event(
+                "rule_injected",
+                brain_dir=brain_dir,
+                agent_type=agent_type,
+                rule_id=rid,
+                injection_count_this_session=_INJECTION_COUNT_THIS_SESSION,
+            )
+    except Exception as exc:
+        _log.debug("telemetry send_cli_event(rule_injected) failed: %s", exc)
+
 
 # One-shot flag so the qmd-bash-missing warning only fires once per process.
 _QMD_BASH_WARNED = False
@@ -844,6 +872,11 @@ def main(data: dict) -> dict | None:
     # to specific rules (Meta-Harness A). Silent failure: missing manifest
     # just disables per-rule attribution, never blocks session start.
     if injection_manifest:
+        _emit_rule_injected_telemetry(
+            brain_dir=brain_dir,
+            agent_type=_agent_type(data),
+            rule_ids=[str(entry.get("full_id") or "") for entry in injection_manifest.values()],
+        )
         try:
             import json as _json
 

--- a/Gradata/src/gradata/hooks/jit_inject.py
+++ b/Gradata/src/gradata/hooks/jit_inject.py
@@ -21,6 +21,7 @@ see in practice (~100s of graduated rules max).
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -30,7 +31,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from gradata.hooks._base import extract_message, resolve_brain_dir, run_hook
-from gradata.hooks._injection_guard import is_suspicious, sanitize as sanitize_draft
+from gradata.hooks._injection_guard import is_suspicious
+from gradata.hooks._injection_guard import sanitize as sanitize_draft
 from gradata.hooks._profiles import Profile
 
 if TYPE_CHECKING:
@@ -59,6 +61,34 @@ except ImportError:  # pragma: no cover - import gate
     _BM25_AVAILABLE = False
 
 _log = logging.getLogger(__name__)
+_INJECTION_COUNT_THIS_SESSION = 0
+
+
+def _rule_id_for_lesson(lesson) -> str:
+    category = getattr(lesson, "category", "") or ""
+    description = getattr(lesson, "description", "") or ""
+    return hashlib.sha256(f"{category}:{description}".encode()).hexdigest()[:16]
+
+
+def _emit_rule_injected_telemetry(brain_dir: str | Path, agent_type: str, rule_ids: list[str]) -> None:
+    global _INJECTION_COUNT_THIS_SESSION
+    if not rule_ids:
+        return
+    try:
+        from gradata import _telemetry
+
+        for rid in rule_ids:
+            _INJECTION_COUNT_THIS_SESSION += 1
+            _telemetry.send_cli_event(
+                "rule_injected",
+                brain_dir=brain_dir,
+                agent_type=agent_type,
+                rule_id=rid,
+                injection_count_this_session=_INJECTION_COUNT_THIS_SESSION,
+            )
+    except Exception as exc:
+        _log.debug("telemetry send_cli_event(rule_injected) failed: %s", exc)
+
 
 HOOK_META = {
     "event": "UserPromptSubmit",
@@ -398,6 +428,11 @@ def main(data: dict) -> dict | None:
         lines.append(f"{prefix} {r.description}")
     if not lines:
         return None
+    _emit_rule_injected_telemetry(
+        brain_dir,
+        str(data.get("agent_type") or data.get("agent") or data.get("client") or "unknown"),
+        [_rule_id_for_lesson(r) for r, _sim in ranked[: len(lines)]],
+    )
     rules_block = "\n".join(lines)
     if len(rules_block) > max_prompt_chars:
         rules_block = rules_block[:max_prompt_chars].rstrip()

--- a/Gradata/tests/test_telemetry.py
+++ b/Gradata/tests/test_telemetry.py
@@ -21,6 +21,9 @@ def _isolate_config(tmp_path, monkeypatch):
     # Clear kill-switch env
     monkeypatch.delenv(_telemetry.ENV_KILL_SWITCH, raising=False)
     monkeypatch.delenv(_telemetry.ENV_ENDPOINT, raising=False)
+    monkeypatch.delenv(_telemetry.ENV_POSTHOG_HOST, raising=False)
+    monkeypatch.delenv(_telemetry.ENV_POSTHOG_API_KEY, raising=False)
+    monkeypatch.delenv(_telemetry.ENV_POSTHOG_PROJECT_API_KEY, raising=False)
     yield
 
 
@@ -117,6 +120,7 @@ class TestPayload:
         assert json.loads(json.dumps(payload)) == payload
 
 
+
 # ── send_event ───────────────────────────────────────────────────────
 class TestSendEvent:
     def test_rejects_unknown_event(self):
@@ -206,3 +210,81 @@ class TestEndpoint:
     def test_override(self, monkeypatch):
         monkeypatch.setenv(_telemetry.ENV_ENDPOINT, "https://test.local/event")
         assert _telemetry._endpoint() == "https://test.local/event"
+        assert _telemetry._posthog_endpoint() == "https://test.local/event"
+
+    def test_posthog_default_and_host_override(self, monkeypatch):
+        assert _telemetry._posthog_endpoint() == _telemetry.DEFAULT_POSTHOG_ENDPOINT
+        monkeypatch.setenv(_telemetry.ENV_POSTHOG_HOST, "https://eu.i.posthog.com/")
+        assert _telemetry._posthog_endpoint() == "https://eu.i.posthog.com/capture/"
+
+    def test_posthog_api_key_env_aliases(self, monkeypatch):
+        monkeypatch.setenv(_telemetry.ENV_POSTHOG_PROJECT_API_KEY, "phc_project")
+        assert _telemetry._posthog_api_key() == "phc_project"
+        monkeypatch.setenv(_telemetry.ENV_POSTHOG_API_KEY, "phc_gradata")
+        assert _telemetry._posthog_api_key() == "phc_gradata"
+
+
+# ── CLI/PostHog funnel telemetry (GRA-2031) ─────────────────────────
+class TestCliTelemetry:
+    def test_cli_payload_schema_includes_identity_and_experiment_fields(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(_telemetry.ENV_POSTHOG_API_KEY, "phc_test")
+        monkeypatch.setenv("GRADATA_EXPERIMENT_ID", "exp-1")
+        monkeypatch.setenv("GRADATA_COHORT", "beta")
+        payload = _telemetry._build_cli_payload(
+            "rule_injected",
+            brain_dir=tmp_path,
+            agent_type="codex",
+            rule_id="rule-1",
+            injection_count_this_session=3,
+        )
+        assert payload["event"] == "rule_injected"
+        assert payload["api_key"] == "phc_test"
+        assert payload["distinct_id"] == payload["properties"]["distinct_id"]
+        props = payload["properties"]
+        assert props["user_id"] == payload["distinct_id"]
+        assert props["brain_id"]
+        assert props["agent_type"] == "codex"
+        assert props["cli_version"]
+        assert props["rule_id"] == "rule-1"
+        assert props["injection_count_this_session"] == 3
+        assert props["experiment_id"] == "exp-1"
+        assert props["cohort"] == "beta"
+
+    def test_cli_payload_experiment_and_cohort_default_to_null(self, tmp_path):
+        payload = _telemetry._build_cli_payload("cli_install", brain_dir=tmp_path)
+        props = payload["properties"]
+        assert props["experiment_id"] is None
+        assert props["cohort"] is None
+        assert props["agent_type"] == "unknown"
+        assert props["install_started_at"]
+
+    def test_send_cli_event_is_opt_in_and_best_effort(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(_telemetry.ENV_POSTHOG_API_KEY, "phc_test")
+        with patch.object(_telemetry, "_post") as post:
+            _telemetry.send_cli_event("cli_install", brain_dir=tmp_path, agent_type="cli", blocking=True)
+            post.assert_not_called()
+        _telemetry.set_enabled(True)
+        with patch.object(_telemetry, "_post", return_value=True) as post:
+            _telemetry.send_cli_event("cli_install", brain_dir=tmp_path, agent_type="cli", blocking=True)
+            post.assert_called_once()
+            assert post.call_args[0][0]["event"] == "cli_install"
+            assert post.call_args.kwargs["endpoint"] == _telemetry.DEFAULT_POSTHOG_ENDPOINT
+
+    def test_send_cli_event_noops_without_posthog_key(self, tmp_path):
+        _telemetry.set_enabled(True)
+        with patch.object(_telemetry, "_post") as post:
+            _telemetry.send_cli_event("cli_install", brain_dir=tmp_path, agent_type="cli", blocking=True)
+            post.assert_not_called()
+
+    def test_send_cli_once_dedupes_first_rule(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(_telemetry.ENV_POSTHOG_API_KEY, "phc_test")
+        _telemetry.set_enabled(True)
+        with patch.object(_telemetry, "_post", return_value=True) as post:
+            assert _telemetry.send_cli_once(
+                "first_rule_graduated", brain_dir=tmp_path, agent_type="sdk", rule_id="r1", blocking=True
+            ) is True
+            assert _telemetry.send_cli_once(
+                "first_rule_graduated", brain_dir=tmp_path, agent_type="sdk", rule_id="r2", blocking=True
+            ) is False
+            assert post.call_count == 1
+            assert post.call_args[0][0]["properties"]["rule_id"] == "r1"


### PR DESCRIPTION
## Summary
- add PostHog capture payloads for cli_install, first_rule_graduated, and rule_injected
- include distinct_id/user_id, brain_id, agent_type, cli_version, nullable experiment_id/cohort, rule metadata, and install timing
- wire events into CLI init/install, rule graduation, SDK recall, and hook injection paths with opt-in + graceful fire-and-forget behavior

## Verification
- python3 -m pytest tests/test_telemetry.py -q
- env -u BRAIN_DIR -u GRADATA_BRAIN python3 -m pytest tests/test_cli.py tests/test_cli_install_agent.py tests/test_jit_inject.py tests/test_rule_graduated_events.py tests/test_import_integrity.py -q
- ruff check changed source/test files

Paperclip: 2d5e11b2-5e31-4b69-a4b4-4106f0e2feda / GRA-2031